### PR TITLE
docs: add governance and release artifact guides

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Default ownership
+* @X-PG13
+
+# Project governance and automation
+/.github/ @X-PG13
+/CODE_OF_CONDUCT.md @X-PG13
+/CONTRIBUTING.md @X-PG13
+/SECURITY.md @X-PG13
+/SUPPORT.md @X-PG13
+
+# Core application
+/src/ainews/ @X-PG13
+/tests/ @X-PG13
+
+# Docs and demo assets
+/docs/ @X-PG13
+/README.md @X-PG13
+/README.zh-CN.md @X-PG13
+
+# Release and deployment material
+/compose.yaml @X-PG13
+/Dockerfile @X-PG13
+/Makefile @X-PG13
+/pyproject.toml @X-PG13

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,11 @@
 - What changed
 - Why it changed
 
+## Review Focus
+
+- Primary area touched
+- Main risk or rollback concern
+
 ## Validation
 
 - [ ] `python -m unittest discover -s tests -v`
@@ -14,3 +19,4 @@
 - [ ] Documentation updated when behavior or configuration changed
 - [ ] Tests added or updated for behavior changes
 - [ ] No secrets or private endpoints were committed
+- [ ] `CODEOWNERS` and `docs/pr-review-policy.md` were checked for ownership and review scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ make check
 - Do not remove existing sources without documenting the reason.
 - Use the pull request template and summarize validation clearly.
 - Prefer existing labels such as `good first issue`, `help wanted`, `source`, `extractor`, and `publisher`.
+- Follow `docs/pr-review-policy.md` for review scope and single-maintainer rules.
+- Check `CODEOWNERS` before moving code across ownership boundaries.
 
 ## Issues And Security
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ make smoke
 - [Database Migrations](docs/database-migrations.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Monitoring](docs/monitoring.md)
+- [PR Review Policy](docs/pr-review-policy.md)
+- [Release Artifacts](docs/release-artifacts.md)
 - [Use Cases](docs/use-cases.md)
 - [Contributor Playbook](docs/contributor-playbook.md)
 - [Release Checklist](docs/release-checklist.md)
@@ -208,7 +210,7 @@ python -m pip install -e ".[dev]"
 This repository already includes the expected open-source project baseline:
 
 - Community docs: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`
-- Collaboration templates: GitHub issue templates and pull request template
+- Collaboration templates: GitHub issue templates, pull request template, `CODEOWNERS`, and review policy
 - Quality gates: `ruff`, unit tests, coverage, package build validation, `pre-commit`
 - Automation: CI, tag-based release workflow, CodeQL, Dependabot
 - Packaging and runtime: non-root Docker runtime, `HEALTHCHECK`, `compose.yaml`, `.dockerignore`, `.editorconfig`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,8 @@ make smoke
 - [数据库迁移](docs/database-migrations.md)
 - [故障排查](docs/troubleshooting.zh-CN.md)
 - [监控接入](docs/monitoring.zh-CN.md)
+- [PR 审核约定](docs/pr-review-policy.zh-CN.md)
+- [Release 产物校验](docs/release-artifacts.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)
 - [贡献者手册](docs/contributor-playbook.md)
 - [发版清单](docs/release-checklist.zh-CN.md)
@@ -208,7 +210,7 @@ python -m pip install -e ".[dev]"
 当前仓库已经补齐以下开源工程基线：
 
 - 社区文档：`CONTRIBUTING.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`
-- 协作模板：GitHub issue templates 和 pull request template
+- 协作模板：GitHub issue templates、pull request template、`CODEOWNERS` 和审核约定
 - 质量门禁：`ruff` lint、单元测试、coverage、包构建校验、`pre-commit`
 - 自动化：CI、tag release workflow、CodeQL、Dependabot
 - 打包与运行：非 root Docker 运行、`HEALTHCHECK`、`compose.yaml`、`.dockerignore`、`.editorconfig`

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -67,6 +67,14 @@ Open the dashboard at `http://127.0.0.1:8000/`.
 - Use `--force-republish` only when you intentionally want another outbound publish attempt
 - Configure your own LLM, Telegram, Feishu, or WeChat credentials in `.env`
 - Review generated content before external publishing
+
+### Artifact Verification
+
+```bash
+shasum -a 256 -c sha256sums.txt
+python -m pip install ainews_open-X.Y.Z-py3-none-any.whl
+python -m ainews --help
+```
 ```
 
 ## Repository About

--- a/docs/pr-review-policy.md
+++ b/docs/pr-review-policy.md
@@ -1,0 +1,39 @@
+# PR Review Policy
+
+[English](./pr-review-policy.md) · [简体中文](./pr-review-policy.zh-CN.md)
+
+This repository uses `CODEOWNERS` and branch protection to keep changes reviewable without overcomplicating a single-maintainer workflow.
+
+## Review Baseline
+
+- Open a pull request for any change that touches behavior, contracts, workflows, deployment, or governance files.
+- Keep `main` green before merging. The current merge gate is the protected-branch check set on GitHub.
+- Use the PR template and fill in validation clearly.
+- Resolve review conversations before merging.
+
+## What Reviewers Should Check
+
+- Scope: the PR solves one bounded problem and does not bundle unrelated refactors.
+- Behavior: any user-visible or operator-visible change is called out in the summary.
+- Safety: no secrets, private endpoints, or internal paths are exposed.
+- Contracts: config, CLI, API, export payloads, and schema changes are documented when affected.
+- Validation: tests and manual checks match the type of change.
+
+## Review Expectations By Change Type
+
+- Source registry changes: include source rationale and keep source ids stable.
+- Extraction logic changes: include or update HTML fixtures and regression tests.
+- API or dashboard changes: update both API tests and operator-facing docs.
+- Release or workflow changes: update release docs or checklist when the operator flow changes.
+
+## CODEOWNERS Usage
+
+- `CODEOWNERS` assigns default ownership for core code, docs, workflows, and release assets.
+- GitHub will suggest the listed owner when a pull request touches those paths.
+- In the current single-maintainer setup, `CODEOWNERS` is used for ownership clarity and review routing, not for mandatory code-owner approval, to avoid deadlocking releases.
+
+## Single-Maintainer Rule
+
+- Until there is another maintainer, the repository keeps required status checks and conversation resolution enabled on `main`.
+- Review count is intentionally not forced to `1` yet, because a solo maintainer cannot self-satisfy a mandatory review gate under strict branch protection.
+- If another maintainer joins, enable code-owner review and at least one approving review in branch protection.

--- a/docs/pr-review-policy.zh-CN.md
+++ b/docs/pr-review-policy.zh-CN.md
@@ -1,0 +1,39 @@
+# PR 审核约定
+
+[English](./pr-review-policy.md) · [简体中文](./pr-review-policy.zh-CN.md)
+
+这个仓库用 `CODEOWNERS` 和分支保护来保持协作清晰，同时避免把单维护者工作流锁死。
+
+## 审核基线
+
+- 只要改动涉及行为、契约、workflow、部署或治理文件，就走 PR。
+- 合并前保持 `main` 所要求的检查全绿，以 GitHub 保护分支规则为准。
+- 使用 PR 模板，把验证方式写清楚。
+- 合并前解决 review conversation。
+
+## 审核重点
+
+- 范围：一个 PR 只解决一个边界清晰的问题，不夹带无关重构。
+- 行为：任何用户侧或运维侧变化都要在摘要里说清楚。
+- 安全：不能暴露密钥、私有地址或内部路径。
+- 契约：涉及配置、CLI、API、导出结构、数据库 schema 时，要同步更新文档。
+- 验证：测试和手工验证要和改动类型匹配。
+
+## 按改动类型的额外要求
+
+- 新闻源 registry 改动：说明来源理由，并保持 source id 稳定。
+- 正文抽取逻辑改动：补或更新 HTML fixture 和回归测试。
+- API 或控制台改动：同时补 API 测试和面向运维的文档。
+- Release 或 workflow 改动：操作流程变更时，更新发版文档或 checklist。
+
+## CODEOWNERS 用法
+
+- `CODEOWNERS` 为核心代码、文档、workflow 和 release 资产定义默认 owner。
+- PR 涉及这些路径时，GitHub 会自动建议对应 owner。
+- 当前是单维护者模式，所以 `CODEOWNERS` 先用于明确责任和 review 路由，不强制开启 mandatory code-owner approval，避免把发版流程锁死。
+
+## 单维护者规则
+
+- 在有第二位维护者加入之前，仓库保持 `main` 的 required status checks 和 conversation resolution。
+- 当前不强制 `1` 个审批，是因为严格保护下单维护者无法自己满足 mandatory review gate。
+- 未来如果有第二位维护者，再把 branch protection 升级成 code-owner review 和至少一个 approval。

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -1,0 +1,52 @@
+# Release Artifacts
+
+[English](./release-artifacts.md) · [简体中文](./release-artifacts.zh-CN.md)
+
+Every tagged GitHub release publishes a release bundle with:
+
+- source distribution (`.tar.gz`)
+- wheel (`.whl`)
+- `sha256sums.txt`
+- CycloneDX SBOM JSON
+- provenance attestation
+
+## Download And Verify
+
+From a release page, download the wheel, source archive, and `sha256sums.txt`.
+
+### Linux
+
+```bash
+sha256sum -c sha256sums.txt
+```
+
+### macOS
+
+```bash
+shasum -a 256 -c sha256sums.txt
+```
+
+## Install From The Wheel
+
+```bash
+python -m pip install ainews_open-X.Y.Z-py3-none-any.whl
+```
+
+## Install From The Source Archive
+
+```bash
+python -m pip install ainews_open-X.Y.Z.tar.gz
+```
+
+## Quick Post-Install Check
+
+```bash
+python -m ainews --help
+python -m ainews stats
+```
+
+## SBOM And Provenance
+
+- The SBOM file is published as `vX.Y.Z-sbom.json`.
+- Provenance is attached through GitHub artifact attestations in the release workflow.
+- Use these assets when you need a lightweight supply-chain review or internal package intake evidence.

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -1,0 +1,52 @@
+# Release 产物校验
+
+[English](./release-artifacts.md) · [简体中文](./release-artifacts.zh-CN.md)
+
+每个带 tag 的 GitHub Release 都会发布一组 release bundle，包含：
+
+- source distribution（`.tar.gz`）
+- wheel（`.whl`）
+- `sha256sums.txt`
+- CycloneDX SBOM JSON
+- provenance attestation
+
+## 下载并校验
+
+从 Release 页面下载 wheel、source archive 和 `sha256sums.txt`。
+
+### Linux
+
+```bash
+sha256sum -c sha256sums.txt
+```
+
+### macOS
+
+```bash
+shasum -a 256 -c sha256sums.txt
+```
+
+## 从 Wheel 安装
+
+```bash
+python -m pip install ainews_open-X.Y.Z-py3-none-any.whl
+```
+
+## 从 Source Archive 安装
+
+```bash
+python -m pip install ainews_open-X.Y.Z.tar.gz
+```
+
+## 安装后快速检查
+
+```bash
+python -m ainews --help
+python -m ainews stats
+```
+
+## SBOM 和 Provenance
+
+- SBOM 文件会作为 `vX.Y.Z-sbom.json` 发布
+- provenance 通过 GitHub release workflow 的 artifact attestations 生成
+- 如果你要做内部制品准入或轻量供应链审计，可以直接使用这些文件

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,16 +8,17 @@ Use this checklist before cutting a new public release.
 
 1. Read `CHANGELOG.md` and add the new release notes file under `docs/releases/`.
 2. Confirm `README.md` and `README.zh-CN.md` still point to valid docs and demo assets.
-3. Run:
+3. Confirm `docs/release-artifacts.md` still matches the current release bundle shape.
+4. Run:
 
 ```bash
 make check
 make smoke
 ```
 
-4. Confirm `docker compose config -q` passes with `.env.example`.
-5. Confirm open code scanning alerts are `0`.
-6. Confirm the demo page still renders and sample assets exist under `docs/demo/`.
+5. Confirm `docker compose config -q` passes with the current compose profile.
+6. Confirm open code scanning alerts are `0`.
+7. Confirm the demo page still renders and sample assets exist under `docs/demo/`.
 
 ## Versioning
 
@@ -52,6 +53,14 @@ git push origin vX.Y.Z
 - SBOM artifact
 - provenance attestation
 - final release notes
+- artifact install and checksum verification guidance
+
+3. Verify the release artifact instructions still work:
+
+```bash
+python -m pip install ainews_open-X.Y.Z-py3-none-any.whl
+python -m ainews --help
+```
 
 ## After Release
 

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -8,16 +8,17 @@
 
 1. 阅读 `CHANGELOG.md`，并在 `docs/releases/` 下补本次版本说明。
 2. 确认 `README.md` 和 `README.zh-CN.md` 里的文档、demo 链接都有效。
-3. 运行：
+3. 确认 `docs/release-artifacts.zh-CN.md` 仍然和当前 release bundle 结构一致。
+4. 运行：
 
 ```bash
 make check
 make smoke
 ```
 
-4. 用 `.env.example` 验证 `docker compose config -q` 能通过。
-5. 确认 open code scanning alerts 为 `0`。
-6. 确认 demo 页面和 `docs/demo/` 下的样例文件都还在。
+5. 用当前 compose profile 验证 `docker compose config -q` 能通过。
+6. 确认 open code scanning alerts 为 `0`。
+7. 确认 demo 页面和 `docs/demo/` 下的样例文件都还在。
 
 ## 版本更新
 
@@ -52,6 +53,14 @@ git push origin vX.Y.Z
 - SBOM
 - provenance attestation
 - 最终版 release notes
+- release artifact 的安装与校验说明
+
+3. 额外验证一次 release artifact 安装说明可用：
+
+```bash
+python -m pip install ainews_open-X.Y.Z-py3-none-any.whl
+python -m ainews --help
+```
 
 ## 发版后
 

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -49,3 +49,23 @@ Open:
 - The PyPI publish workflow runs when the GitHub Release is published and trusted publishing is configured
 - Repeat publication for the same stored digest and target remains idempotent by default
 - Review generated content before sending it to external channels
+
+### Release artifacts
+
+Each release publishes:
+
+- wheel
+- source archive
+- `sha256sums.txt`
+- SBOM JSON
+- provenance attestation
+
+Verify and install from the release bundle:
+
+```bash
+shasum -a 256 -c sha256sums.txt
+python -m pip install ainews_open-1.1.0-py3-none-any.whl
+python -m ainews --help
+```
+
+Reusable verification guidance lives in `docs/release-artifacts.md`.


### PR DESCRIPTION
## Summary
- add CODEOWNERS and a PR review policy for governance clarity
- document release artifact verification and install checks in both English and Chinese
- wire the new governance and release docs into README, contributing guidance, PR template, and release notes

## Validation
- [x] git diff --check
- [x] documentation links and templates updated
- [ ] CI / CodeQL / smoke via GitHub Actions
