### PR TITLE
ci: add release artifact smoke checks

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -1,0 +1,115 @@
+name: Release Artifact Smoke
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to validate, for example v1.1.0
+        required: true
+        type: string
+
+concurrency:
+  group: release-artifact-smoke-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  install-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact:
+          - wheel
+          - sdist
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      AINEWS_HOME: ${{ github.workspace }}/.ainews-release-smoke
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Download release assets
+        run: |
+          mkdir -p dist
+          gh release download "${RELEASE_TAG}" \
+            --dir dist \
+            --pattern "*.whl" \
+            --pattern "*.tar.gz" \
+            --pattern "sha256sums.txt"
+          ls -la dist
+
+      - name: Verify release checksums
+        run: |
+          cd dist
+          sha256sum -c sha256sums.txt
+
+      - name: Install artifact
+        run: |
+          case "${{ matrix.artifact }}" in
+            wheel)
+              ARTIFACT_PATH="$(find dist -maxdepth 1 -type f -name '*.whl' | head -n 1)"
+              ;;
+            sdist)
+              ARTIFACT_PATH="$(find dist -maxdepth 1 -type f -name '*.tar.gz' | head -n 1)"
+              ;;
+          esac
+          test -n "${ARTIFACT_PATH}"
+          python -m pip install --upgrade pip
+          python -m pip install "${ARTIFACT_PATH}"
+
+      - name: Run CLI smoke checks
+        run: |
+          mkdir -p "${AINEWS_HOME}"
+          python -m ainews --help
+          python -m ainews stats
+
+      - name: Start API and verify health
+        run: |
+          python -m uvicorn ainews.api:create_app --factory --host 127.0.0.1 --port 8001 >/tmp/ainews-release-smoke.log 2>&1 &
+          echo $! >/tmp/ainews-release-smoke.pid
+          for attempt in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8001/health >/tmp/ainews-release-health.json; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/ainews-release-smoke.log
+          exit 1
+
+      - name: Validate health payload
+        run: |
+          python - <<'PY'
+          import json
+
+          with open("/tmp/ainews-release-health.json", "r", encoding="utf-8") as handle:
+              payload = json.load(handle)
+
+          assert payload["ready"] is True
+          assert payload["checks"]["database"] == "ok"
+          assert payload["checks"]["sources"] == "ok"
+          assert "version" in payload
+          PY
+
+      - name: Stop API
+        if: always()
+        run: |
+          if [ -f /tmp/ainews-release-smoke.pid ]; then
+            kill "$(cat /tmp/ainews-release-smoke.pid)" >/dev/null 2>&1 || true
+          fi
+          if [ -f /tmp/ainews-release-smoke.log ]; then
+            tail -n 200 /tmp/ainews-release-smoke.log
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v6
@@ -62,7 +64,7 @@ jobs:
           path: dist/*
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: dist/*
 
@@ -77,8 +79,11 @@ jobs:
           fi
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: /tmp/release-notes.md
-          files: |
-            dist/*
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release upload "${TAG}" dist/* --clobber
+            gh release edit "${TAG}" --title "${TAG}" --notes-file /tmp/release-notes.md
+          else
+            gh release create "${TAG}" dist/* --title "${TAG}" --notes-file /tmp/release-notes.md
+          fi

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ This repository already includes the expected open-source project baseline:
 - Collaboration templates: GitHub issue templates, pull request template, `CODEOWNERS`, and review policy
 - Quality gates: `ruff`, unit tests, coverage, package build validation, `pre-commit`
 - Automation: CI, tag-based release workflow, CodeQL, Dependabot
+- Release verification: published artifact checksum and install smoke workflow
 - Packaging and runtime: non-root Docker runtime, `HEALTHCHECK`, `compose.yaml`, `.dockerignore`, `.editorconfig`
 - Supply chain: release checksums, CycloneDX SBOM, build provenance, PyPI trusted publishing workflow
 - Observability: Prometheus-compatible `/metrics`, source runtime history, housekeeping workflow, and ready-to-run monitoring profile

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,6 +213,7 @@ python -m pip install -e ".[dev]"
 - 协作模板：GitHub issue templates、pull request template、`CODEOWNERS` 和审核约定
 - 质量门禁：`ruff` lint、单元测试、coverage、包构建校验、`pre-commit`
 - 自动化：CI、tag release workflow、CodeQL、Dependabot
+- 发版校验：release artifact checksum 和安装 smoke workflow
 - 打包与运行：非 root Docker 运行、`HEALTHCHECK`、`compose.yaml`、`.dockerignore`、`.editorconfig`
 - 供应链：release checksums、CycloneDX SBOM、build provenance、PyPI trusted publishing workflow
 - 可观测性：Prometheus `/metrics`、来源运行态历史、housekeeping 工作流、可直接运行的 monitoring profile

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -10,6 +10,12 @@ Every tagged GitHub release publishes a release bundle with:
 - CycloneDX SBOM JSON
 - provenance attestation
 
+The repository also includes a GitHub Actions validation workflow:
+
+- `.github/workflows/release-artifact-smoke.yml`
+
+It downloads the published release assets, verifies checksums, installs the wheel and source archive in clean jobs, and runs minimal CLI and `/health` smoke checks.
+
 ## Download And Verify
 
 From a release page, download the wheel, source archive, and `sha256sums.txt`.
@@ -44,6 +50,8 @@ python -m pip install ainews_open-X.Y.Z.tar.gz
 python -m ainews --help
 python -m ainews stats
 ```
+
+For the GitHub-hosted equivalent, re-run the `Release Artifact Smoke` workflow against any published tag.
 
 ## SBOM And Provenance
 

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -10,6 +10,12 @@
 - CycloneDX SBOM JSON
 - provenance attestation
 
+仓库还提供了一个自动验收 workflow：
+
+- `.github/workflows/release-artifact-smoke.yml`
+
+它会下载已经发布的 release 资产，校验 checksum，在干净环境里分别安装 wheel 和 source archive，并执行最小 CLI 与 `/health` 烟雾测试。
+
 ## 下载并校验
 
 从 Release 页面下载 wheel、source archive 和 `sha256sums.txt`。
@@ -44,6 +50,8 @@ python -m pip install ainews_open-X.Y.Z.tar.gz
 python -m ainews --help
 python -m ainews stats
 ```
+
+如果你想跑 GitHub 托管环境里的同等校验，直接对已发布 tag 重新执行 `Release Artifact Smoke` workflow。
 
 ## SBOM 和 Provenance
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -33,6 +33,7 @@ Confirm:
 
 - GitHub Actions `CI` is green
 - GitHub Actions `CodeQL` is green
+- GitHub Actions `Release Artifact Smoke` is green for the last published tag
 - `release.yml` is present and current
 - `pypi-publish.yml` is present if PyPI publication is intended
 - required repository secrets are configured
@@ -65,6 +66,7 @@ python -m ainews --help
 ## After Release
 
 1. Verify the release page and demo page are still reachable.
-2. Confirm the package metadata on GitHub and PyPI looks correct.
-3. Confirm `Latest` points to the intended tag.
-4. Announce the release using `docs/releases/` copy if applicable.
+2. Confirm `Release Artifact Smoke` passed for the published tag.
+3. Confirm the package metadata on GitHub and PyPI looks correct.
+4. Confirm `Latest` points to the intended tag.
+5. Announce the release using `docs/releases/` copy if applicable.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -33,6 +33,7 @@ make smoke
 
 - GitHub Actions `CI` 为绿色
 - GitHub Actions `CodeQL` 为绿色
+- 上一个已发布 tag 的 GitHub Actions `Release Artifact Smoke` 为绿色
 - `release.yml` 存在且是当前版本
 - 如果需要发 PyPI，`pypi-publish.yml` 已配置
 - 仓库 secrets 已补齐
@@ -65,6 +66,7 @@ python -m ainews --help
 ## 发版后
 
 1. 检查 Release 页面和 demo 页面仍可访问。
-2. 检查 GitHub / PyPI 上的包元信息是否正确。
-3. 检查 `Latest` 是否指向预期 tag。
-4. 如需对外公告，可直接复用 `docs/releases/` 里的文案。
+2. 检查已发布 tag 的 `Release Artifact Smoke` 是否通过。
+3. 检查 GitHub / PyPI 上的包元信息是否正确。
+4. 检查 `Latest` 是否指向预期 tag。
+5. 如需对外公告，可直接复用 `docs/releases/` 里的文案。


### PR DESCRIPTION
## Summary
- add a release artifact smoke workflow that downloads published wheel and sdist assets, verifies checksums, and runs CLI plus /health smoke checks
- replace the release publish step with gh CLI and bump provenance attestation to v3 to remove Node 20 deprecation warnings from the release workflow
- update release docs and checklists to include artifact verification guidance

## Validation
- [x] git diff --check
- [x] workflow YAML parsed locally
- [ ] CI / CodeQL via GitHub Actions
- [ ] Release Artifact Smoke against v1.1.0 after merge to main
