### PR TITLE
ci: fix release artifact checksum verification

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -53,9 +53,7 @@ jobs:
           ls -la dist
 
       - name: Verify release checksums
-        run: |
-          cd dist
-          sha256sum -c sha256sums.txt
+        run: sha256sum -c dist/sha256sums.txt
 
       - name: Install artifact
         run: |


### PR DESCRIPTION
## Summary
- fix the release artifact smoke workflow to verify checksums against the release bundle paths recorded in sha256sums.txt

## Validation
- [x] git diff --check
- [x] workflow YAML parsed locally
- [ ] CI / CodeQL via GitHub Actions
- [ ] Release Artifact Smoke against v1.1.0 after merge to main
