### PR TITLE
release: prepare v1.1.1

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event_name == 'workflow_dispatch' || vars.AINEWS_ENABLE_PYPI_PUBLISH == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.1.1] - 2026-04-08
+
+### Added
+
+- A dedicated `Release Artifact Smoke` workflow that downloads published release assets, verifies checksums, installs both wheel and source archive, and runs minimal CLI plus `/health` smoke checks
+
+### Changed
+
+- Package version is now `1.1.1`
+- Release documentation now treats `Release Artifact Smoke` as a mandatory pass gate before a release is considered complete
+- PyPI publication is now opt-in by default through `AINEWS_ENABLE_PYPI_PUBLISH=true`, while manual workflow dispatch remains available
+
+### Fixed
+
+- Corrected release artifact checksum verification so the smoke workflow validates the published bundle paths exactly as recorded in `sha256sums.txt`
+
 ## [1.1.0] - 2026-04-08
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.1.0`
+`v1.1.1`
 
 ### Suggested Title
 
-`AI News Open v1.1.0 · Operations And Monitoring Update`
+`AI News Open v1.1.1 · Release Hardening Patch`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.1.0
+## AI News Open v1.1.1
 
-AI News Open `v1.1.0` expands the stable workflow with source runtime controls, alerting, Google News resolution, and direct Prometheus/Grafana monitoring assets.
+AI News Open `v1.1.1` hardens the release process itself with published-artifact smoke checks and stricter release-completion rules.
 
 ### What it does
 
@@ -40,10 +40,10 @@ AI News Open `v1.1.0` expands the stable workflow with source runtime controls, 
 
 ### Highlights in this release
 
-- Source cooldown, maintenance mode, acknowledgement, snooze, and automatic recovery lifecycle
-- Google News wrapper resolution before ingest, with historical backfill and stronger deduplication
-- Runtime alerting for degraded health, publication failures, pipeline errors, and source cooldown transitions
-- Prometheus `/metrics`, housekeeping workflow, and Docker Compose monitoring profile with Prometheus and Grafana assets
+- Dedicated published-artifact smoke validation for wheels and source archives
+- Checksum verification against the actual GitHub Release bundle
+- `Release Artifact Smoke` is now part of the release-completion gate
+- PyPI publication is opt-in by default until trusted publishing is configured
 
 ### Quick start
 

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -16,6 +16,8 @@ The repository also includes a GitHub Actions validation workflow:
 
 It downloads the published release assets, verifies checksums, installs the wheel and source archive in clean jobs, and runs minimal CLI and `/health` smoke checks.
 
+Treat this workflow as a release-completion gate. Do not announce a new public tag until it passes.
+
 ## Download And Verify
 
 From a release page, download the wheel, source archive, and `sha256sums.txt`.

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -16,6 +16,8 @@
 
 它会下载已经发布的 release 资产，校验 checksum，在干净环境里分别安装 wheel 和 source archive，并执行最小 CLI 与 `/health` 烟雾测试。
 
+这条 workflow 应该被视为 release 完成前的强制门禁。它没通过之前，不要对外公告新 tag。
+
 ## 下载并校验
 
 从 Release 页面下载 wheel、source archive 和 `sha256sums.txt`。

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -38,6 +38,8 @@ Confirm:
 - `pypi-publish.yml` is present if PyPI publication is intended
 - required repository secrets are configured
 
+Release is not considered complete until `Release Artifact Smoke` passes for the published tag.
+
 ## GitHub Release
 
 1. Create and push the tag:
@@ -66,7 +68,7 @@ python -m ainews --help
 ## After Release
 
 1. Verify the release page and demo page are still reachable.
-2. Confirm `Release Artifact Smoke` passed for the published tag.
+2. Confirm `Release Artifact Smoke` passed for the published tag. This is a mandatory pass gate before you announce or close the release work.
 3. Confirm the package metadata on GitHub and PyPI looks correct.
 4. Confirm `Latest` points to the intended tag.
 5. Announce the release using `docs/releases/` copy if applicable.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -38,6 +38,8 @@ make smoke
 - 如果需要发 PyPI，`pypi-publish.yml` 已配置
 - 仓库 secrets 已补齐
 
+如果已发布 tag 对应的 `Release Artifact Smoke` 还没通过，这次 release 就不算完成。
+
 ## GitHub Release
 
 1. 创建并推送 tag：
@@ -66,7 +68,7 @@ python -m ainews --help
 ## 发版后
 
 1. 检查 Release 页面和 demo 页面仍可访问。
-2. 检查已发布 tag 的 `Release Artifact Smoke` 是否通过。
+2. 检查已发布 tag 的 `Release Artifact Smoke` 是否通过。这一项必须通过后，才能对外公告或结束这次发版。
 3. 检查 GitHub / PyPI 上的包元信息是否正确。
 4. 检查 `Latest` 是否指向预期 tag。
 5. 如需对外公告，可直接复用 `docs/releases/` 里的文案。

--- a/docs/releases/v1.1.1.md
+++ b/docs/releases/v1.1.1.md
@@ -1,0 +1,22 @@
+## AI News Open v1.1.1
+
+AI News Open `v1.1.1` is a release-hardening patch. It does not add end-user features; it makes the release process itself stricter and more trustworthy.
+
+### What changed
+
+- Added a dedicated `Release Artifact Smoke` workflow for published tags
+- The workflow now downloads the GitHub Release assets, verifies `sha256sums.txt`, installs both the wheel and source archive, and runs minimal CLI and `/health` smoke checks
+- Release documentation now treats that workflow as a mandatory pass gate before a release is considered complete
+- PyPI publishing is now opt-in by default through `AINEWS_ENABLE_PYPI_PUBLISH=true`, so repositories that have not configured trusted publishing do not fail every public release
+
+### Why this release matters
+
+- A tag is no longer treated as complete just because the build and GitHub Release succeeded
+- The published artifacts themselves are now part of the automated acceptance path
+- Repositories that are not ready for PyPI can keep shipping GitHub Releases without known-failing PyPI automation on every tag
+
+### Operator notes
+
+- `Release Artifact Smoke` should pass before announcing a new public version
+- Manual PyPI publication is still available through the `Publish To PyPI` workflow
+- Automatic PyPI publication only runs when the repository variable `AINEWS_ENABLE_PYPI_PUBLISH` is set to `true`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.1.0"
+version = "1.1.1"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
## Summary
- mark Release Artifact Smoke as a mandatory release-completion gate in the release docs
- make PyPI publishing opt-in by default so public releases do not fail when trusted publishing is intentionally not configured
- prepare the repository for the v1.1.1 patch release

## Validation
- [x] ./ .venv-dev/bin/python -m ruff check src tests
- [x] ./ .venv-dev/bin/python -m unittest discover -s tests -v
- [x] ./ .venv-dev/bin/python -m build
- [x] release docs and workflow YAML updated
