### PR TITLE
release: prepare v1.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   attestations: write
   id-token: write
@@ -87,3 +88,8 @@ jobs:
           else
             gh release create "${TAG}" dist/* --title "${TAG}" --notes-file /tmp/release-notes.md
           fi
+
+      - name: Trigger release artifact smoke
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh workflow run release-artifact-smoke.yml --ref main -f tag="${TAG}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.1.2] - 2026-04-08
+
+### Changed
+
+- The tag release workflow now explicitly dispatches `Release Artifact Smoke` after publishing the GitHub Release
+- Release documentation now reflects that published tags trigger artifact smoke automatically, while manual reruns remain available
+- Package version is now `1.1.2`
+
+### Fixed
+
+- Closed the last manual step in the release flow by wiring release publication to post-release artifact validation
+
 ## [1.1.1] - 2026-04-08
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.1.1`
+`v1.1.2`
 
 ### Suggested Title
 
-`AI News Open v1.1.1 · Release Hardening Patch`
+`AI News Open v1.1.2 · Automated Release Validation`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.1.1
+## AI News Open v1.1.2
 
-AI News Open `v1.1.1` hardens the release process itself with published-artifact smoke checks and stricter release-completion rules.
+AI News Open `v1.1.2` closes the last manual step in the release process by automatically dispatching published-artifact smoke validation after each GitHub Release.
 
 ### What it does
 
@@ -40,10 +40,10 @@ AI News Open `v1.1.1` hardens the release process itself with published-artifact
 
 ### Highlights in this release
 
-- Dedicated published-artifact smoke validation for wheels and source archives
-- Checksum verification against the actual GitHub Release bundle
-- `Release Artifact Smoke` is now part of the release-completion gate
-- PyPI publication is opt-in by default until trusted publishing is configured
+- Automatic dispatch from `release.yml` to `release-artifact-smoke.yml`
+- Published-artifact smoke validation remains the release-completion gate
+- Manual reruns remain available for any already-published tag
+- PyPI publication remains opt-in by default until trusted publishing is configured
 
 ### Quick start
 

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -17,6 +17,7 @@ The repository also includes a GitHub Actions validation workflow:
 It downloads the published release assets, verifies checksums, installs the wheel and source archive in clean jobs, and runs minimal CLI and `/health` smoke checks.
 
 Treat this workflow as a release-completion gate. Do not announce a new public tag until it passes.
+For tags created through `.github/workflows/release.yml`, the smoke workflow is dispatched automatically after the GitHub Release is published. You can still re-run it manually for any published tag.
 
 ## Download And Verify
 

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -17,6 +17,7 @@
 它会下载已经发布的 release 资产，校验 checksum，在干净环境里分别安装 wheel 和 source archive，并执行最小 CLI 与 `/health` 烟雾测试。
 
 这条 workflow 应该被视为 release 完成前的强制门禁。它没通过之前，不要对外公告新 tag。
+如果 tag 是通过 `.github/workflows/release.yml` 发出来的，这条 smoke workflow 会在 GitHub Release 发布后自动触发。你仍然可以针对任意已发布 tag 手动重跑。
 
 ## 下载并校验
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -39,6 +39,7 @@ Confirm:
 - required repository secrets are configured
 
 Release is not considered complete until `Release Artifact Smoke` passes for the published tag.
+The standard release flow now dispatches that smoke workflow automatically after publishing the GitHub Release.
 
 ## GitHub Release
 

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -39,6 +39,7 @@ make smoke
 - 仓库 secrets 已补齐
 
 如果已发布 tag 对应的 `Release Artifact Smoke` 还没通过，这次 release 就不算完成。
+标准 release 流程现在会在 GitHub Release 发布后自动触发这条 smoke workflow。
 
 ## GitHub Release
 

--- a/docs/releases/v1.1.2.md
+++ b/docs/releases/v1.1.2.md
@@ -1,0 +1,18 @@
+## AI News Open v1.1.2
+
+AI News Open `v1.1.2` is a release automation patch. It closes the last manual step in the GitHub release flow by dispatching published-artifact smoke checks automatically after a tag release is created.
+
+### What changed
+
+- `.github/workflows/release.yml` now dispatches `.github/workflows/release-artifact-smoke.yml` automatically after the GitHub Release is published
+- Release docs now describe the smoke workflow as auto-triggered for the standard tag release flow, while preserving manual reruns for any published tag
+
+### Why this matters
+
+- A new public tag no longer depends on a separate manual click to start artifact validation
+- The release process now matches the policy in the release checklist: publish first, then automatically prove that the published wheel and source archive install and start correctly
+
+### Operator notes
+
+- `Release Artifact Smoke` is still the release-completion gate; automation removes the manual trigger, not the requirement
+- Manual reruns remain useful when you want to re-verify an existing release tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.1.1"
+version = "1.1.2"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"


### PR DESCRIPTION
## Summary\n- auto-dispatch release artifact smoke from the release workflow using the current tag\n- document that release smoke is triggered automatically while still allowing manual reruns\n- prepare the v1.1.2 patch release notes and version metadata\n\n## Testing\n- ./.venv-dev/bin/python -m ruff check src tests\n- ./.venv-dev/bin/python -m unittest discover -s tests -v\n- ./.venv-dev/bin/python -m build\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'\n