### PR TITLE
feat: add operations overview panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 </div>
 
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)
+![AI News Open Operations Overview](docs/assets/operations-panel-preview.svg)
 
 ## Product Snapshot
 
@@ -60,6 +61,7 @@ python -m ainews serve --port 8000
 After startup you can:
 
 - Open the admin console at `http://127.0.0.1:8000/`
+- Use the Operations panel to inspect `/health`, recent pipeline runs, source cooldowns, source alerts, and publication failures in one screen
 - Browse the article pool, digest archive, publication history, and WeChat publish status
 - Trigger ingest, extraction, translation, digest generation, and publishing from the dashboard
 
@@ -70,6 +72,7 @@ After startup you can:
 - Sample digest markdown (EN): [docs/demo/sample-digest.en.md](docs/demo/sample-digest.en.md)
 - Sample digest JSON: [docs/demo/sample-digest.json](docs/demo/sample-digest.json)
 - Sample health payload: [docs/demo/sample-health.json](docs/demo/sample-health.json)
+- Sample operations payload: [docs/demo/sample-operations.json](docs/demo/sample-operations.json)
 - Sample publication history: [docs/demo/sample-publications.json](docs/demo/sample-publications.json)
 
 ## Maintainer Flow

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,7 @@
 </div>
 
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)
+![AI News Open Operations Overview](docs/assets/operations-panel-preview.svg)
 
 ## 产品概览
 
@@ -60,6 +61,7 @@ python -m ainews serve --port 8000
 启动后你可以：
 
 - 在 `http://127.0.0.1:8000/` 打开控制台
+- 直接在 Operations 总览里查看 `/health`、最近 pipeline、来源冷却、来源告警和发布失败
 - 查看新闻池、日报存档、发布历史和微信发布状态
 - 直接从控制台触发抓取、翻译、生成日报和发布
 
@@ -70,6 +72,7 @@ python -m ainews serve --port 8000
 - 示例日报 Markdown（英文）：[docs/demo/sample-digest.en.md](docs/demo/sample-digest.en.md)
 - 示例日报 JSON：[docs/demo/sample-digest.json](docs/demo/sample-digest.json)
 - 示例健康检查返回：[docs/demo/sample-health.json](docs/demo/sample-health.json)
+- 示例运维聚合返回：[docs/demo/sample-operations.json](docs/demo/sample-operations.json)
 - 示例发布记录：[docs/demo/sample-publications.json](docs/demo/sample-publications.json)
 
 ## 维护者工作流

--- a/docs/assets/operations-panel-preview.svg
+++ b/docs/assets/operations-panel-preview.svg
@@ -1,0 +1,105 @@
+<svg width="1280" height="760" viewBox="0 0 1280 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="80" y1="40" x2="1200" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF7EC"/>
+      <stop offset="1" stop-color="#F4E6D0"/>
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="1280" height="760" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#6B4A1A" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+  <rect width="1280" height="760" rx="28" fill="url(#bg)"/>
+  <g opacity="0.35">
+    <path d="M0 72H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 144H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 216H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 288H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 360H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 432H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 504H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 576H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+    <path d="M0 648H1280" stroke="#2A2014" stroke-opacity="0.08"/>
+  </g>
+  <g filter="url(#shadow)">
+    <rect x="34" y="28" width="1212" height="704" rx="28" fill="#FFFDF8" fill-opacity="0.92" stroke="#2A2014" stroke-opacity="0.1"/>
+  </g>
+  <text x="74" y="88" fill="#C93D1A" font-family="JetBrains Mono, monospace" font-size="14" letter-spacing="3.2">OPERATIONS</text>
+  <text x="74" y="130" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="40" font-weight="700">One-screen runtime overview</text>
+  <text x="74" y="164" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="18">Health, pipeline history, source cooldowns, alerts, and publish failures collected into one operator view.</text>
+
+  <g>
+    <rect x="74" y="202" width="176" height="108" rx="22" fill="#FFF7EE" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="98" y="236" fill="#6F665B" font-family="JetBrains Mono, monospace" font-size="13">health</text>
+    <text x="98" y="284" fill="#7B5A14" font-family="Space Grotesk, sans-serif" font-size="34" font-weight="700">degraded</text>
+  </g>
+  <g>
+    <rect x="268" y="202" width="176" height="108" rx="22" fill="#FFF7EE" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="292" y="236" fill="#6F665B" font-family="JetBrains Mono, monospace" font-size="13">cooldowns</text>
+    <text x="292" y="284" fill="#8E1F0A" font-family="Space Grotesk, sans-serif" font-size="34" font-weight="700">1</text>
+  </g>
+  <g>
+    <rect x="462" y="202" width="176" height="108" rx="22" fill="#FFF7EE" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="486" y="236" fill="#6F665B" font-family="JetBrains Mono, monospace" font-size="13">publish errors</text>
+    <text x="486" y="284" fill="#8E1F0A" font-family="Space Grotesk, sans-serif" font-size="34" font-weight="700">1</text>
+  </g>
+  <g>
+    <rect x="656" y="202" width="176" height="108" rx="22" fill="#FFF7EE" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="680" y="236" fill="#6F665B" font-family="JetBrains Mono, monospace" font-size="13">pending publish</text>
+    <text x="680" y="284" fill="#7B5A14" font-family="Space Grotesk, sans-serif" font-size="34" font-weight="700">1</text>
+  </g>
+  <g>
+    <rect x="850" y="202" width="176" height="108" rx="22" fill="#FFF7EE" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="874" y="236" fill="#6F665B" font-family="JetBrains Mono, monospace" font-size="13">scheduled retries</text>
+    <text x="874" y="284" fill="#7B5A14" font-family="Space Grotesk, sans-serif" font-size="34" font-weight="700">2</text>
+  </g>
+  <g>
+    <rect x="1044" y="202" width="176" height="108" rx="22" fill="#FFF7EE" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="1068" y="236" fill="#6F665B" font-family="JetBrains Mono, monospace" font-size="13">alerts sent</text>
+    <text x="1068" y="284" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="34" font-weight="700">9</text>
+  </g>
+
+  <g>
+    <rect x="74" y="336" width="552" height="348" rx="24" fill="#FFFFFF" fill-opacity="0.72" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="98" y="374" fill="#C93D1A" font-family="JetBrains Mono, monospace" font-size="13" letter-spacing="2">HEALTH</text>
+    <text x="98" y="406" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="28" font-weight="700">System status and counters</text>
+    <rect x="98" y="430" width="118" height="34" rx="17" fill="#F6E1B4"/>
+    <text x="126" y="452" fill="#7B5A14" font-family="JetBrains Mono, monospace" font-size="13">degraded</text>
+    <rect x="228" y="430" width="82" height="34" rx="17" fill="#DCEEE1"/>
+    <text x="257" y="452" fill="#2D6E3D" font-family="JetBrains Mono, monospace" font-size="13">ready</text>
+    <text x="98" y="500" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="16">checks: database=ok · sources=ok · llm=ok · publish_targets=ok</text>
+    <text x="98" y="532" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="16">degraded reasons: source_cooldowns_active · publication_errors</text>
+    <text x="98" y="578" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="22" font-weight="700">Metrics snapshot</text>
+    <text x="98" y="614" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="16">pipeline_runs ok=12 · partial_error=2</text>
+    <text x="98" y="644" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="16">extract_failures blocked=3 · throttled=5</text>
+    <text x="98" y="674" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="16">source_recoveries_total=4 · source_cooldowns_active=1 · alert_sends_total=9</text>
+  </g>
+
+  <g>
+    <rect x="652" y="336" width="256" height="348" rx="24" fill="#FFFFFF" fill-opacity="0.72" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="676" y="374" fill="#C93D1A" font-family="JetBrains Mono, monospace" font-size="13" letter-spacing="2">PIPELINE</text>
+    <text x="676" y="406" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="28" font-weight="700">Recent runs</text>
+    <rect x="676" y="434" width="208" height="96" rx="18" fill="#FFF7EE"/>
+    <text x="694" y="462" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="18" font-weight="700">pipeline</text>
+    <rect x="804" y="442" width="62" height="24" rx="12" fill="#F6E1B4"/>
+    <text x="817" y="458" fill="#7B5A14" font-family="JetBrains Mono, monospace" font-size="11">partial</text>
+    <text x="694" y="490" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="14">region=all · since_hours=48</text>
+    <text x="694" y="514" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="14">ingested=19 · extracted=15 · published=1</text>
+  </g>
+
+  <g>
+    <rect x="932" y="336" width="288" height="348" rx="24" fill="#FFFFFF" fill-opacity="0.72" stroke="#2A2014" stroke-opacity="0.08"/>
+    <text x="956" y="374" fill="#C93D1A" font-family="JetBrains Mono, monospace" font-size="13" letter-spacing="2">INCIDENTS</text>
+    <text x="956" y="406" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="28" font-weight="700">Sources and failures</text>
+    <rect x="956" y="434" width="240" height="110" rx="18" fill="#FFF7EE"/>
+    <text x="974" y="462" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="18" font-weight="700">VentureBeat AI</text>
+    <rect x="1102" y="442" width="70" height="24" rx="12" fill="#FBE0D8"/>
+    <text x="1117" y="458" fill="#8E1F0A" font-family="JetBrains Mono, monospace" font-size="11">blocked</text>
+    <text x="974" y="490" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="14">success_rate=40% · failures=2</text>
+    <text x="974" y="514" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="14">until=2026-04-09T12:02:00+08:00</text>
+    <rect x="956" y="560" width="240" height="110" rx="18" fill="#FFF7EE"/>
+    <text x="974" y="588" fill="#171717" font-family="Space Grotesk, sans-serif" font-size="18" font-weight="700">WeChat publish</text>
+    <rect x="1118" y="568" width="54" height="24" rx="12" fill="#FBE0D8"/>
+    <text x="1134" y="584" fill="#8E1F0A" font-family="JetBrains Mono, monospace" font-size="11">error</text>
+    <text x="974" y="616" fill="#6F665B" font-family="Noto Sans SC, sans-serif" font-size="14">digest #17 · operation failed; inspect logs with X-Request-ID</text>
+  </g>
+</svg>

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -114,6 +114,7 @@
             <a class="secondary" href="./sample-digest.en.md">English Digest</a>
             <a class="secondary" href="./sample-digest.json">Digest JSON</a>
             <a class="secondary" href="./sample-health.json">Health JSON</a>
+            <a class="secondary" href="./sample-operations.json">Operations JSON</a>
           </div>
         </div>
         <div class="card">
@@ -142,8 +143,17 @@
           <li>Digest Markdown 输出长什么样。</li>
           <li>下游系统可以依赖的 JSON 顶层结构。</li>
           <li>运维层 `/health` 和发布记录大概长什么样。</li>
+          <li>管理台新的 Operations 总览如何把健康状态、pipeline、告警和发布失败收成一屏。</li>
           <li>项目在 GitHub Pages 上公开承载示例站的方式。</li>
         </ul>
+      </section>
+
+      <section class="card" style="margin-top: 24px;">
+        <h2>Operations Overview</h2>
+        <p>
+          这张预览图对应控制台里的新运维总览区。它会把 `/health`、最近 pipeline、来源冷却、来源级告警和发布失败收成一屏。
+        </p>
+        <img src="../assets/operations-panel-preview.svg" alt="AI News Open operations panel preview" />
       </section>
 
       <section class="card" style="margin-top: 24px;">
@@ -153,6 +163,7 @@
           <li><a href="./sample-digest.en.md">English digest sample</a></li>
           <li><a href="./sample-digest.json">Digest JSON payload</a></li>
           <li><a href="./sample-health.json">Health payload sample</a></li>
+          <li><a href="./sample-operations.json">Operations payload sample</a></li>
           <li><a href="./sample-publications.json">Publication history sample</a></li>
           <li><a href="../use-cases.md">Use cases</a> / <a href="../use-cases.zh-CN.md">使用场景</a></li>
         </ul>

--- a/docs/demo/sample-operations.json
+++ b/docs/demo/sample-operations.json
@@ -1,0 +1,216 @@
+{
+  "generated_at": "2026-04-09T10:16:00+08:00",
+  "health": {
+    "status": "degraded",
+    "ready": true,
+    "checks": {
+      "database": "ok",
+      "sources": "ok",
+      "llm": "ok",
+      "publish_targets": "ok"
+    },
+    "schema_version": 8,
+    "degraded_reasons": [
+      "source_cooldowns_active",
+      "publication_errors"
+    ]
+  },
+  "metrics": {
+    "build_version": "1.1.2",
+    "pipeline_runs_total": {
+      "ok": 12,
+      "partial_error": 2
+    },
+    "extract_failures_total": {
+      "blocked": 3,
+      "throttled": 5
+    },
+    "source_cooldowns_active": 1,
+    "source_recoveries_total": 4,
+    "alert_sends_total": 9
+  },
+  "stats": {
+    "active_source_cooldowns": 1,
+    "blocked_source_cooldowns": 1,
+    "throttled_source_cooldowns": 0,
+    "publication_errors": 1,
+    "pending_publications": 1,
+    "scheduled_extraction_retries": 2,
+    "blocked_extractions": 1,
+    "throttled_extractions": 2
+  },
+  "operations": {
+    "pipeline": {
+      "operation_id": "pl_9fa211",
+      "name": "pipeline",
+      "status": "partial_error",
+      "started_at": "2026-04-09T09:42:12+08:00",
+      "finished_at": "2026-04-09T09:43:05+08:00",
+      "duration_ms": 53025.44,
+      "context": {
+        "region": "all",
+        "since_hours": 48
+      },
+      "metrics": {
+        "ingested": 19,
+        "extracted": 15,
+        "published": 1
+      },
+      "error_category": "publication_error"
+    }
+  },
+  "operation_totals": {
+    "pipeline": {
+      "ok": 12,
+      "partial_error": 2
+    },
+    "publish": {
+      "ok": 14,
+      "error": 1
+    }
+  },
+  "failure_categories": {
+    "blocked": 3,
+    "publication_error": 1
+  },
+  "recent_operations": [
+    {
+      "operation_id": "pl_9fa211",
+      "name": "pipeline",
+      "status": "partial_error",
+      "started_at": "2026-04-09T09:42:12+08:00",
+      "finished_at": "2026-04-09T09:43:05+08:00",
+      "duration_ms": 53025.44,
+      "context": {
+        "region": "all",
+        "since_hours": 48
+      },
+      "metrics": {
+        "ingested": 19,
+        "extracted": 15,
+        "published": 1
+      },
+      "error_category": "publication_error"
+    },
+    {
+      "operation_id": "pub_0fa922",
+      "name": "publish",
+      "status": "error",
+      "started_at": "2026-04-09T09:42:56+08:00",
+      "finished_at": "2026-04-09T09:43:02+08:00",
+      "duration_ms": 6201.19,
+      "context": {
+        "targets": [
+          "wechat"
+        ]
+      },
+      "metrics": {
+        "published": 0,
+        "errors": 1
+      },
+      "error_category": "publication_error"
+    }
+  ],
+  "pipeline_runs": [
+    {
+      "operation_id": "pl_9fa211",
+      "name": "pipeline",
+      "status": "partial_error",
+      "started_at": "2026-04-09T09:42:12+08:00",
+      "finished_at": "2026-04-09T09:43:05+08:00",
+      "duration_ms": 53025.44,
+      "context": {
+        "region": "all",
+        "since_hours": 48
+      },
+      "metrics": {
+        "ingested": 19,
+        "extracted": 15,
+        "published": 1
+      },
+      "error_category": "publication_error"
+    }
+  ],
+  "source_runtime": [
+    {
+      "id": "venturebeat-ai",
+      "name": "VentureBeat AI",
+      "region": "international",
+      "language": "en",
+      "topic": "news",
+      "enabled": true,
+      "cooldown_status": "blocked",
+      "cooldown_until": "2026-04-09T12:02:00+08:00",
+      "cooldown_active": true,
+      "consecutive_failures": 2,
+      "consecutive_successes": 0,
+      "last_error_category": "blocked",
+      "last_http_status": 403,
+      "last_error_at": "2026-04-09T09:41:58+08:00",
+      "last_success_at": "2026-04-09T07:20:01+08:00",
+      "silenced_until": "",
+      "silenced_active": false,
+      "maintenance_mode": false,
+      "acknowledged_at": "",
+      "ack_note": "",
+      "recent_success_rate": 40.0,
+      "recent_failure_categories": {
+        "blocked": 3,
+        "temporary_error": 1
+      }
+    }
+  ],
+  "source_alerts": [
+    {
+      "id": 28,
+      "source_id": "venturebeat-ai",
+      "source_name": "VentureBeat AI",
+      "alert_key": "source_cooldown:venturebeat-ai",
+      "alert_status": "sent",
+      "severity": "warning",
+      "title": "source cooldown active: VentureBeat AI",
+      "message": "VentureBeat AI entered blocked cooldown after repeated 403 responses.",
+      "created_at": "2026-04-09T09:42:01+08:00",
+      "targets": [
+        {
+          "target": "telegram",
+          "status": "ok"
+        }
+      ]
+    }
+  ],
+  "publication_failures": [
+    {
+      "id": 91,
+      "digest_id": 17,
+      "target": "wechat",
+      "status": "error",
+      "external_id": "PUBLISH123",
+      "message": "operation failed; inspect server logs with the response X-Request-ID",
+      "response_payload": {
+        "status_query_error": {
+          "message": "operation failed; inspect server logs with the response X-Request-ID"
+        }
+      },
+      "created_at": "2026-04-09T09:43:02+08:00",
+      "updated_at": "2026-04-09T09:43:02+08:00"
+    }
+  ],
+  "pending_publications": [
+    {
+      "id": 92,
+      "digest_id": 17,
+      "target": "wechat",
+      "status": "pending",
+      "external_id": "PUBLISH124",
+      "message": "wechat publish submitted",
+      "response_payload": {
+        "publish": {
+          "publish_id": "PUBLISH124"
+        }
+      },
+      "created_at": "2026-04-09T09:43:04+08:00",
+      "updated_at": "2026-04-09T09:43:04+08:00"
+    }
+  ]
+}

--- a/src/ainews/service.py
+++ b/src/ainews/service.py
@@ -114,7 +114,48 @@ class NewsService:
         return payload
 
     def get_operations(self) -> Dict[str, object]:
-        return self.telemetry.snapshot()
+        telemetry = self.telemetry.snapshot()
+        stats = self.repository.get_stats()
+        health = self.get_health()
+        metrics = self.get_metrics_snapshot()
+        recent_operations = list(telemetry.get("recent_operations", []))
+        pipeline_runs = [
+            item for item in recent_operations if clean_text(str(item.get("name", ""))) == "pipeline"
+        ][:6]
+        recent_publication_failures = self.repository.list_publications(status="error", limit=6)
+        pending_publications = self.repository.list_publications(status="pending", limit=6)
+        source_alerts = self.list_source_alerts(limit=8)
+        runtime_sources = [
+            source
+            for source in self.list_sources(include_runtime=True)
+            if source.get("cooldown_active")
+            or source.get("maintenance_mode")
+            or source.get("silenced_active")
+        ][:8]
+        return {
+            "generated_at": utc_now().isoformat(),
+            "health": health,
+            "metrics": metrics,
+            "stats": {
+                "active_source_cooldowns": int(stats.get("active_source_cooldowns") or 0),
+                "blocked_source_cooldowns": int(stats.get("blocked_source_cooldowns") or 0),
+                "throttled_source_cooldowns": int(stats.get("throttled_source_cooldowns") or 0),
+                "publication_errors": int(stats.get("publication_errors") or 0),
+                "pending_publications": int(stats.get("pending_publications") or 0),
+                "scheduled_extraction_retries": int(stats.get("scheduled_extraction_retries") or 0),
+                "blocked_extractions": int(stats.get("blocked_extractions") or 0),
+                "throttled_extractions": int(stats.get("throttled_extractions") or 0),
+            },
+            "operations": telemetry.get("operations", {}),
+            "operation_totals": telemetry.get("operation_totals", {}),
+            "failure_categories": telemetry.get("failure_categories", {}),
+            "recent_operations": recent_operations[:12],
+            "pipeline_runs": pipeline_runs,
+            "source_runtime": runtime_sources,
+            "source_alerts": source_alerts,
+            "publication_failures": recent_publication_failures,
+            "pending_publications": pending_publications,
+        }
 
     def get_metrics_snapshot(self) -> Dict[str, object]:
         stats = self.repository.get_stats()

--- a/src/ainews/telemetry.py
+++ b/src/ainews/telemetry.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import time
 import uuid
-from collections import Counter
+from collections import Counter, deque
 from dataclasses import dataclass
 from threading import Lock
-from typing import Dict, Optional
+from typing import Deque, Dict, Optional
 
 from .utils import utc_now
 
@@ -20,11 +20,12 @@ class OperationToken:
 
 
 class OperationTracker:
-    def __init__(self) -> None:
+    def __init__(self, *, history_limit: int = 50) -> None:
         self._lock = Lock()
         self._operations: Dict[str, Dict[str, object]] = {}
         self._failure_categories: Counter[str] = Counter()
         self._operation_totals: Dict[str, Counter[str]] = {}
+        self._history: Deque[Dict[str, object]] = deque(maxlen=max(10, history_limit))
 
     def start(self, name: str, *, context: Optional[Dict[str, object]] = None) -> OperationToken:
         return OperationToken(
@@ -60,6 +61,7 @@ class OperationTracker:
 
         with self._lock:
             self._operations[token.name] = record
+            self._history.append(dict(record))
             if error_category:
                 self._failure_categories[error_category] += 1
             totals = self._operation_totals.setdefault(token.name, Counter())
@@ -74,4 +76,5 @@ class OperationTracker:
                 "operation_totals": {
                     name: dict(counter) for name, counter in self._operation_totals.items()
                 },
+                "recent_operations": [dict(item) for item in reversed(self._history)],
             }

--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -42,6 +42,13 @@ const refs = {
   retryExtractionSelectionButton: document.getElementById("retryExtractionSelectionButton"),
   sourceAlertsList: document.getElementById("sourceAlertsList"),
   refreshSourceAlertsButton: document.getElementById("refreshSourceAlertsButton"),
+  operationsSummary: document.getElementById("operationsSummary"),
+  operationsHealth: document.getElementById("operationsHealth"),
+  operationsMetrics: document.getElementById("operationsMetrics"),
+  operationsPipelineRuns: document.getElementById("operationsPipelineRuns"),
+  operationsSources: document.getElementById("operationsSources"),
+  operationsAlerts: document.getElementById("operationsAlerts"),
+  operationsPublicationFailures: document.getElementById("operationsPublicationFailures"),
   publishTargetInputs: Array.from(document.querySelectorAll(".publish-target")),
   wechatSubmitCheckbox: document.getElementById("wechatSubmitCheckbox"),
 };
@@ -103,6 +110,251 @@ function renderStats(stats) {
     )
     .join("");
   renderExtractionOpsSummary(stats);
+}
+
+function operationStatusClass(status) {
+  if (status === "ok" || status === "ready") return "good";
+  if (status === "degraded" || status === "pending" || status === "partial_error") return "pending";
+  if (status === "error" || status === "blocked") return "warn";
+  return "";
+}
+
+function summarizePairs(payload) {
+  if (!payload || typeof payload !== "object") return "";
+  return Object.entries(payload)
+    .filter(([, value]) => value !== null && value !== undefined && value !== "" && value !== 0)
+    .slice(0, 4)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" · ");
+}
+
+function renderOperationsSummary(payload) {
+  const health = payload.health || {};
+  const stats = payload.stats || {};
+  const metrics = payload.metrics || {};
+  const cards = [
+    ["health", health.status || "unknown", operationStatusClass(health.status)],
+    ["cooldowns", stats.active_source_cooldowns || 0, stats.active_source_cooldowns ? "warn" : "good"],
+    ["publish errors", stats.publication_errors || 0, stats.publication_errors ? "warn" : "good"],
+    ["pending publish", stats.pending_publications || 0, stats.pending_publications ? "pending" : "good"],
+    ["scheduled retries", stats.scheduled_extraction_retries || 0, stats.scheduled_extraction_retries ? "pending" : "good"],
+    ["alerts sent", metrics.alert_sends_total || 0, metrics.alert_sends_total ? "" : "good"],
+  ];
+  refs.operationsSummary.innerHTML = cards
+    .map(
+      ([label, value, klass]) => `
+        <article class="stat-card operations-stat-card">
+          <p class="stat-label">${escapeHtml(String(label))}</p>
+          <div class="stat-value ${klass ? `status-${klass}` : ""}">${escapeHtml(String(value))}</div>
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderOperationsHealth(payload) {
+  const health = payload.health || {};
+  const checks = Object.entries(health.checks || {})
+    .map(
+      ([key, value]) =>
+        `<span class="chip ${operationStatusClass(String(value))}">${escapeHtml(String(key))}: ${escapeHtml(String(value))}</span>`
+    )
+    .join("");
+  const reasons = (health.degraded_reasons || []).length
+    ? (health.degraded_reasons || [])
+        .map((reason) => `<span class="chip warn">${escapeHtml(reason)}</span>`)
+        .join("")
+    : '<span class="chip good">no degraded reasons</span>';
+  refs.operationsHealth.innerHTML = `
+    <article class="publication-card">
+      <header class="publication-head">
+        <div>
+          <strong>status</strong>
+          <div class="publication-meta">
+            <span>generated_at: ${escapeHtml(payload.generated_at || "")}</span>
+            <span>ready: ${escapeHtml(String(Boolean(health.ready)))}</span>
+            <span>schema: ${escapeHtml(String(health.schema_version || ""))}</span>
+          </div>
+        </div>
+        <span class="chip ${operationStatusClass(health.status)}">${escapeHtml(health.status || "unknown")}</span>
+      </header>
+      <div class="chip-row compact">${checks}</div>
+      <div class="chip-row">${reasons}</div>
+    </article>
+  `;
+  const metrics = payload.metrics || {};
+  const pipelineTotals = summarizePairs(metrics.pipeline_runs_total);
+  const extractFailures = summarizePairs(metrics.extract_failures_total);
+  refs.operationsMetrics.innerHTML = [
+    ["pipeline_runs", pipelineTotals || "none"],
+    ["extract_failures", extractFailures || "none"],
+    ["source_recoveries_total", metrics.source_recoveries_total || 0],
+    ["source_cooldowns_active", metrics.source_cooldowns_active || 0],
+    ["alert_sends_total", metrics.alert_sends_total || 0],
+  ]
+    .map(
+      ([label, value]) =>
+        `<span class="chip">${escapeHtml(String(label))}: ${escapeHtml(String(value))}</span>`
+    )
+    .join("");
+}
+
+function renderOperationsPipelineRuns(runs) {
+  refs.operationsPipelineRuns.innerHTML = runs.length
+    ? runs
+        .map(
+          (item) => `
+            <article class="publication-card operations-card">
+              <header class="publication-head">
+                <strong>${escapeHtml(item.name || "pipeline")}</strong>
+                <span class="chip ${operationStatusClass(item.status)}">${escapeHtml(item.status || "unknown")}</span>
+              </header>
+              <div class="publication-meta">
+                <span>started: ${escapeHtml(item.started_at || "")}</span>
+                <span>finished: ${escapeHtml(item.finished_at || "")}</span>
+                <span>duration: ${escapeHtml(String(item.duration_ms || 0))}ms</span>
+              </div>
+              ${
+                summarizePairs(item.context)
+                  ? `<p class="article-brief"><strong>context:</strong> ${escapeHtml(summarizePairs(item.context))}</p>`
+                  : ""
+              }
+              ${
+                summarizePairs(item.metrics)
+                  ? `<p class="article-brief"><strong>metrics:</strong> ${escapeHtml(summarizePairs(item.metrics))}</p>`
+                  : ""
+              }
+            </article>
+          `
+        )
+        .join("")
+    : '<p class="muted">最近还没有记录到 pipeline 运行。</p>';
+}
+
+function renderOperationsSources(sources) {
+  refs.operationsSources.innerHTML = sources.length
+    ? sources
+        .map(
+          (source) => `
+            <article class="publication-card operations-card">
+              <header class="publication-head">
+                <strong>${escapeHtml(source.name || source.id || "unknown source")}</strong>
+                <div class="chip-row compact">
+                  ${
+                    source.cooldown_active
+                      ? `<span class="chip ${source.cooldown_status === "blocked" ? "warn" : "pending"}">${escapeHtml(source.cooldown_status || "cooldown")}</span>`
+                      : '<span class="chip good">normal</span>'
+                  }
+                  ${source.maintenance_mode ? '<span class="chip pending">maintenance</span>' : ""}
+                  ${source.silenced_active ? '<span class="chip">silenced</span>' : ""}
+                </div>
+              </header>
+              <div class="publication-meta">
+                ${
+                  source.recent_success_rate !== null && source.recent_success_rate !== undefined
+                    ? `<span>success_rate: ${escapeHtml(String(source.recent_success_rate))}%</span>`
+                    : "<span>success_rate: n/a</span>"
+                }
+                <span>failures: ${escapeHtml(String(source.consecutive_failures || 0))}</span>
+                ${
+                  source.cooldown_until
+                    ? `<span>until: ${escapeHtml(source.cooldown_until)}</span>`
+                    : "<span>until: none</span>"
+                }
+              </div>
+              ${
+                Object.keys(source.recent_failure_categories || {}).length
+                  ? `<p class="article-brief"><strong>failure_mix:</strong> ${escapeHtml(
+                      Object.entries(source.recent_failure_categories)
+                        .map(([key, value]) => `${key}=${value}`)
+                        .join(", ")
+                    )}</p>`
+                  : ""
+              }
+            </article>
+          `
+        )
+        .join("")
+    : '<p class="muted">当前没有处于冷却、静默或维护中的来源。</p>';
+}
+
+function renderOperationsAlerts(sourceAlerts) {
+  refs.operationsAlerts.innerHTML = sourceAlerts.length
+    ? sourceAlerts
+        .map(
+          (item) => `
+            <article class="publication-card operations-card">
+              <header class="publication-head">
+                <strong>${escapeHtml(item.source_name || item.source_id || "unknown source")}</strong>
+                <span class="chip ${sourceAlertStatusClass(item.alert_status)}">${escapeHtml(sourceAlertStatusLabel(item.alert_status))}</span>
+              </header>
+              <div class="publication-meta">
+                <span>${escapeHtml(item.created_at || "")}</span>
+                ${item.severity ? `<span>${escapeHtml(item.severity)}</span>` : ""}
+              </div>
+              <p class="article-brief">${escapeHtml(item.title || "source alert")}</p>
+            </article>
+          `
+        )
+        .join("")
+    : '<p class="muted">最近没有来源级告警。</p>';
+}
+
+function renderOperationsPublicationFailures(failures, pending) {
+  const cards = [];
+  if (failures.length) {
+    cards.push(
+      ...failures.map(
+        (item) => `
+          <article class="publication-card operations-card">
+            <header class="publication-head">
+              <strong>${escapeHtml(publicationTargetLabel(item.target))}</strong>
+              <span class="chip warn">error</span>
+            </header>
+            <div class="publication-meta">
+              <span>digest #${escapeHtml(String(item.digest_id || ""))}</span>
+              <span>${escapeHtml(item.updated_at || item.created_at || "")}</span>
+            </div>
+            <p class="article-brief">${escapeHtml(item.message || "publication failed")}</p>
+          </article>
+        `
+      )
+    );
+  }
+  if (pending.length) {
+    cards.push(
+      ...pending.map(
+        (item) => `
+          <article class="publication-card operations-card">
+            <header class="publication-head">
+              <strong>${escapeHtml(publicationTargetLabel(item.target))}</strong>
+              <span class="chip pending">pending</span>
+            </header>
+            <div class="publication-meta">
+              <span>digest #${escapeHtml(String(item.digest_id || ""))}</span>
+              <span>${escapeHtml(item.updated_at || item.created_at || "")}</span>
+            </div>
+            <p class="article-brief">${escapeHtml(item.message || "publication pending")}</p>
+          </article>
+        `
+      )
+    );
+  }
+  refs.operationsPublicationFailures.innerHTML = cards.length
+    ? cards.join("")
+    : '<p class="muted">最近没有发布失败或待完成记录。</p>';
+}
+
+function renderOperations(payload) {
+  renderOperationsSummary(payload);
+  renderOperationsHealth(payload);
+  renderOperationsPipelineRuns(payload.pipeline_runs || []);
+  renderOperationsSources(payload.source_runtime || []);
+  renderOperationsAlerts(payload.source_alerts || []);
+  renderOperationsPublicationFailures(
+    payload.publication_failures || [],
+    payload.pending_publications || []
+  );
 }
 
 function renderSources(sources) {
@@ -603,6 +855,13 @@ async function loadStats() {
   renderStats(stats);
 }
 
+async function loadOperations() {
+  const payload = await fetchJson("/admin/operations", {
+    headers: adminHeaders(),
+  });
+  renderOperations(payload);
+}
+
 async function loadSources() {
   const payload = await fetchJson("/admin/sources", { headers: adminHeaders() });
   renderSources(payload.sources || []);
@@ -717,6 +976,7 @@ async function refreshPublications() {
 async function refreshAll() {
   try {
     await Promise.all([
+      loadOperations(),
       loadStats(),
       loadSources(),
       loadArticles(),

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -35,6 +35,62 @@
 
       <section class="stats-grid" id="statsGrid"></section>
 
+      <section class="panel operations-panel">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Operations</p>
+            <h2>运维总览</h2>
+          </div>
+        </div>
+        <p class="muted">
+          把 `/health`、最近 pipeline、冷却来源、来源告警和发布失败收成一屏。细节操作仍保留在下方来源与抽取面板里。
+        </p>
+        <div id="operationsSummary" class="operations-summary-grid"></div>
+        <div class="operations-grid">
+          <article class="operations-slab">
+            <div class="section-head">
+              <div>
+                <p class="eyebrow">Health</p>
+                <h3>系统状态</h3>
+              </div>
+            </div>
+            <div id="operationsHealth"></div>
+            <div id="operationsMetrics" class="chip-row"></div>
+          </article>
+
+          <article class="operations-slab">
+            <div class="section-head">
+              <div>
+                <p class="eyebrow">Pipeline</p>
+                <h3>最近运行</h3>
+              </div>
+            </div>
+            <div id="operationsPipelineRuns" class="publication-list compact-list"></div>
+          </article>
+
+          <article class="operations-slab">
+            <div class="section-head">
+              <div>
+                <p class="eyebrow">Runtime</p>
+                <h3>热点来源</h3>
+              </div>
+            </div>
+            <div id="operationsSources" class="publication-list compact-list"></div>
+          </article>
+
+          <article class="operations-slab">
+            <div class="section-head">
+              <div>
+                <p class="eyebrow">Incidents</p>
+                <h3>告警与发布失败</h3>
+              </div>
+            </div>
+            <div id="operationsAlerts" class="publication-list compact-list"></div>
+            <div id="operationsPublicationFailures" class="publication-list compact-list"></div>
+          </article>
+        </div>
+      </section>
+
       <section class="controls-grid">
         <article class="panel">
           <div class="section-head">

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -169,6 +169,7 @@ textarea {
 }
 
 .stats-grid,
+.operations-summary-grid,
 .controls-grid,
 .content-grid {
   display: grid;
@@ -176,13 +177,56 @@ textarea {
   margin-bottom: 18px;
 }
 
-.stats-grid {
+.stats-grid,
+.operations-summary-grid {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
 .controls-grid,
 .content-grid {
   grid-template-columns: 1.25fr 0.95fr;
+}
+
+.operations-panel {
+  margin-bottom: 18px;
+}
+
+.operations-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.operations-slab {
+  border: 1px solid rgba(23, 23, 23, 0.1);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.44);
+}
+
+.operations-stat-card .stat-value {
+  font-size: 24px;
+}
+
+.status-good {
+  color: #2d6e3d;
+}
+
+.status-pending {
+  color: #7b5a14;
+}
+
+.status-warn {
+  color: var(--accent-deep);
+}
+
+.operations-card {
+  padding: 12px;
+}
+
+.compact-list {
+  gap: 10px;
 }
 
 .side-stack {
@@ -439,6 +483,7 @@ textarea {
 
 @media (max-width: 1100px) {
   .hero,
+  .operations-grid,
   .controls-grid,
   .content-grid,
   .stats-grid {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,65 @@ class ApiTestCase(unittest.TestCase):
         self.assertIn("publish", payload["operations"])
         self.assertEqual(payload["operations"]["publish"]["status"], "ok")
 
+    def test_admin_operations_includes_runtime_summary_sections(self) -> None:
+        repository = ArticleRepository(Path(self._temp_dir.name) / "data" / "ainews.db")
+        repository.upsert_source_state(
+            source_id="openai-news",
+            source_name="OpenAI News",
+            cooldown_status="blocked",
+            cooldown_until="2999-01-01T00:00:00+00:00",
+            consecutive_failures=2,
+            last_error_category="blocked",
+            last_http_status=403,
+            last_error="blocked",
+            last_error_at=utc_now().isoformat(),
+        )
+        repository.record_source_event(
+            source_id="openai-news",
+            source_name="OpenAI News",
+            event_type="extract",
+            status="blocked",
+            error_category="blocked",
+            http_status=403,
+            message="blocked extraction",
+        )
+        repository.record_source_alert(
+            source_id="openai-news",
+            source_name="OpenAI News",
+            alert_key="source_cooldown:openai-news",
+            alert_status="sent",
+            severity="warning",
+            title="source cooldown active: OpenAI News",
+            message="OpenAI News entered blocked cooldown",
+            fingerprint="blocked|2999-01-01T00:00:00+00:00|2|403",
+            targets=[{"target": "telegram", "status": "ok"}],
+        )
+        repository.save_publication(
+            digest_id=1,
+            target="wechat",
+            status="error",
+            external_id="PUBLISH123",
+            message="publish failed",
+            response_payload={"status_query_error": {"message": "publish failed"}},
+        )
+
+        response = self.client.get(
+            "/admin/operations",
+            headers={"X-Admin-Token": "secret-token"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn("health", payload)
+        self.assertIn("metrics", payload)
+        self.assertIn("source_runtime", payload)
+        self.assertIn("source_alerts", payload)
+        self.assertIn("publication_failures", payload)
+        self.assertEqual(payload["health"]["status"], "degraded")
+        self.assertEqual(payload["source_runtime"][0]["id"], "openai-news")
+        self.assertEqual(payload["source_alerts"][0]["source_id"], "openai-news")
+        self.assertEqual(payload["publication_failures"][0]["status"], "error")
+
     def test_admin_extract_sanitizes_internal_error_message(self) -> None:
         with patch(
             "ainews.api.NewsService.extract_articles",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2118,6 +2118,87 @@ class ServiceFilterTestCase(unittest.TestCase):
             self.assertIn("digest", stats["operations"])
             self.assertIn("configured_publish_targets", stats)
 
+    def test_get_operations_aggregates_runtime_context(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = Settings(
+                database_path=Path(temp_dir) / "ainews.db",
+                sources_file=Path(temp_dir) / "sources.json",
+            )
+            repository = ArticleRepository(settings.database_path)
+            source = SourceDefinition(
+                id="openai-news",
+                name="OpenAI News",
+                url="https://openai.com/news/rss",
+                region="international",
+                language="en",
+                country="US",
+                topic="company",
+            )
+            service = NewsService(
+                settings,
+                repository=repository,
+                source_registry=StubRegistry([source]),
+                llm_client=StubLLMClient(),
+            )
+
+            pipeline_token = service.telemetry.start("pipeline", context={"region": "all"})
+            service.telemetry.finish(
+                pipeline_token,
+                status="partial_error",
+                metrics={"published": 0},
+                error_category="publication_error",
+            )
+            repository.upsert_source_state(
+                source_id="openai-news",
+                source_name="OpenAI News",
+                cooldown_status="blocked",
+                cooldown_until="2999-01-01T00:00:00+00:00",
+                consecutive_failures=2,
+                last_error_category="blocked",
+                last_http_status=403,
+                last_error="blocked by site",
+                last_error_at=utc_now().isoformat(),
+            )
+            repository.record_source_event(
+                source_id="openai-news",
+                source_name="OpenAI News",
+                event_type="extract",
+                status="blocked",
+                error_category="blocked",
+                http_status=403,
+                message="blocked extraction",
+            )
+            repository.record_source_alert(
+                source_id="openai-news",
+                source_name="OpenAI News",
+                alert_key="source_cooldown:openai-news",
+                alert_status="sent",
+                severity="warning",
+                title="source cooldown active: OpenAI News",
+                message="OpenAI News entered blocked cooldown",
+                fingerprint="blocked|2999-01-01T00:00:00+00:00|2|403",
+                targets=[{"target": "telegram", "status": "ok"}],
+            )
+            repository.save_publication(
+                digest_id=1,
+                target="wechat",
+                status="error",
+                external_id="PUBLISH123",
+                message="publish failed",
+                response_payload={"status_query_error": {"message": PUBLIC_ERROR_MESSAGE}},
+            )
+
+            payload = service.get_operations()
+
+            self.assertEqual(payload["health"]["status"], "degraded")
+            self.assertEqual(payload["pipeline_runs"][0]["name"], "pipeline")
+            self.assertEqual(payload["pipeline_runs"][0]["status"], "partial_error")
+            self.assertEqual(payload["source_runtime"][0]["id"], "openai-news")
+            self.assertEqual(payload["source_alerts"][0]["source_id"], "openai-news")
+            self.assertEqual(payload["publication_failures"][0]["status"], "error")
+            self.assertIn("publication_error", payload["failure_categories"])
+            self.assertIn("pipeline", payload["operation_totals"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- aggregate health, metrics, pipeline runs, source runtime, source alerts, and publication failures into `/admin/operations`
- add a one-screen Operations panel to the zero-build admin dashboard
- update demo/readme assets and add regression coverage for the new operator surface

## Testing
- `./.venv-dev/bin/python -m ruff check src tests`
- `node --check src/ainews/web/app.js`
- `./.venv-dev/bin/python -m unittest discover -s tests -v`
- `./.venv-dev/bin/python -m build`
