### PR TITLE
release: prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.0] - 2026-04-09
+
+### Added
+
+- A one-screen `Operations` dashboard panel that aggregates `/health`, metrics, recent pipeline runs, source cooldown hotspots, source alerts, and publication failures
+- A richer `/admin/operations` payload with runtime summaries for operators and demo assets for the new operations surface
+- New source-specific extraction regression fixtures for `Jiqizhixin`, `Ars Technica`, `Substack`, and `Yahoo` syndication targets
+
+### Changed
+
+- Package version is now `1.2.0`
+- Content extraction cleanup now covers more Chinese media, English media, blog/newsletter layouts, and syndication-style article pages
+- README and public demo assets now show the operator-focused overview and sample operations payload
+
+### Fixed
+
+- Reduced over-cleaning risk on Chinese publisher pages by separating editorial label noise from the first body paragraph
+- Improved article body extraction on additional noisy layouts where share widgets, subscribe prompts, and recirculation blocks previously contaminated the output
+
 ## [1.1.2] - 2026-04-08
 
 ### Changed

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.1.2`
+`v1.2.0`
 
 ### Suggested Title
 
-`AI News Open v1.1.2 · Automated Release Validation`
+`AI News Open v1.2.0 · Operations And Content Quality`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.1.2
+## AI News Open v1.2.0
 
-AI News Open `v1.1.2` closes the last manual step in the release process by automatically dispatching published-artifact smoke validation after each GitHub Release.
+AI News Open `v1.2.0` upgrades both the operator surface and the extraction layer with a unified Operations dashboard and broader fixture-driven cleanup coverage across more media layouts.
 
 ### What it does
 
@@ -40,10 +40,10 @@ AI News Open `v1.1.2` closes the last manual step in the release process by auto
 
 ### Highlights in this release
 
-- Automatic dispatch from `release.yml` to `release-artifact-smoke.yml`
-- Published-artifact smoke validation remains the release-completion gate
-- Manual reruns remain available for any already-published tag
-- PyPI publication remains opt-in by default until trusted publishing is configured
+- One-screen `Operations` panel for health, pipeline, incidents, and publication failures
+- Richer `/admin/operations` payload for dashboard and automation consumers
+- New extraction fixtures and cleanup rules for `Jiqizhixin`, `Ars Technica`, `Substack`, and `Yahoo`
+- Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start
 

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,25 @@
+## AI News Open v1.2.0
+
+AI News Open `v1.2.0` is a product-surface and content-quality release. It promotes the operator workflow with a unified Operations overview, while expanding source-specific extraction coverage across more page layouts.
+
+### What changed
+
+- The zero-build admin console now includes an `Operations` panel that collects `/health`, metrics, recent pipeline runs, source cooldown state, source alerts, and publication failures into one screen
+- `/admin/operations` now returns a richer operator payload with runtime summaries, recent pipeline history, active source incidents, and publication failure snapshots
+- Extraction coverage now includes new fixture-driven cleanup for:
+  - `jiqizhixin.com`
+  - `arstechnica.com`
+  - `substack.com`
+  - `yahoo.com` syndication targets
+
+### Why this matters
+
+- Operators no longer need to jump between health, alerts, and publication history just to understand whether the system is degraded
+- Content quality is now more stable across four additional page archetypes: Chinese media, English media, newsletter/blog posts, and aggregation jump targets
+- The release moves the project closer to a reliable editorial product, not just a backend workflow
+
+### Operator notes
+
+- `Release Artifact Smoke` remains the release-completion gate and is still auto-triggered by the release workflow
+- The new extraction fixtures are regression locks for cleanup behavior; future source-specific rules should follow the same fixture-first pattern
+- `sample-operations.json` and the new operations preview asset are included in the public demo content for faster onboarding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.1.2"
+version = "1.2.0"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -95,6 +95,11 @@ HOST_SELECTORS = {
         ".post-content",
         ".content",
     ),
+    "jiqizhixin.com": (
+        ".article__content",
+        ".article-content",
+        ".post-content",
+    ),
     "huggingface.co": (
         ".blog-content.prose",
         ".blog-content",
@@ -133,6 +138,21 @@ HOST_SELECTORS = {
         ".article-body__content",
         "[data-testid='paragraph-0']",
     ),
+    "arstechnica.com": (
+        ".article-content",
+        ".post-content",
+        "article",
+    ),
+    "substack.com": (
+        ".body.markup",
+        ".available-content",
+        ".post-content",
+    ),
+    "yahoo.com": (
+        "[data-test-locator='articleBody']",
+        ".caas-body",
+        ".article-body",
+    ),
 }
 HOST_DROP_SELECTORS = {
     "36kr.com": (
@@ -156,6 +176,15 @@ HOST_DROP_SELECTORS = {
         ".post-nav",
         ".content-breadcrumb",
         ".video-box",
+    ),
+    "jiqizhixin.com": (
+        ".article__copyright",
+        ".article__tags",
+        ".related-posts",
+        ".recommend-list",
+        ".share-box",
+        ".author-card",
+        ".sidebar-recommend",
     ),
     "huggingface.co": (
         ".blog-content > .mb-4",
@@ -204,6 +233,28 @@ HOST_DROP_SELECTORS = {
         ".related-news",
         ".article-topics",
     ),
+    "arstechnica.com": (
+        ".post-meta",
+        ".video-block",
+        ".related-stories",
+        ".sidebar",
+        ".newsletter-callout",
+    ),
+    "substack.com": (
+        ".subscription-widget-wrap",
+        ".subscribe-widget",
+        ".comments-page",
+        ".footer-wrap",
+        ".pencraft",
+    ),
+    "yahoo.com": (
+        ".caas-share-section",
+        ".caas-readmore",
+        ".caas-3p-blocked",
+        ".caas-da",
+        ".video-player-element",
+        ".caas-vertical-video",
+    ),
 }
 HOST_NOISE_LINE_PATTERNS = {
     "36kr.com": (
@@ -212,6 +263,10 @@ HOST_NOISE_LINE_PATTERNS = {
     ),
     "ithome.com": (
         re.compile(r"^广告声明"),
+    ),
+    "jiqizhixin.com": (
+        re.compile(r"^机器之心(报道|编辑部).*$"),
+        re.compile(r"^原标题[:：].*$"),
     ),
     "huggingface.co": (
         re.compile(r"^Back to Articles$"),
@@ -253,6 +308,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Our Standards: The Thomson Reuters Trust Principles$"),
         re.compile(r"^Reporting by .+$"),
     ),
+    "arstechnica.com": (
+        re.compile(r"^Ars Technica may earn compensation.*$"),
+        re.compile(r"^Stay tuned for.*$"),
+    ),
+    "substack.com": (
+        re.compile(r"^Thanks for reading.*$"),
+        re.compile(r"^Subscribe (?:now|for free).*$"),
+        re.compile(r"^Share this post$"),
+        re.compile(r"^Leave a comment$"),
+    ),
+    "yahoo.com": (
+        re.compile(r"^Recommended Stories$"),
+        re.compile(r"^Advertisement$"),
+        re.compile(r"^Read more:.*$"),
+    ),
 }
 FALLBACK_HOST_RULES = {
     "36kr.com": (
@@ -267,6 +337,11 @@ FALLBACK_HOST_RULES = {
     "tmtpost.com": (
         {"tags": {"article"}},
         {"tags": {"div", "section"}, "class_tokens": {"article__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+    ),
+    "jiqizhixin.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
     ),
     "huggingface.co": (
@@ -304,6 +379,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-body__content__17yit"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body__content"}},
         {"tags": {"div", "section"}, "id_tokens": {"paragraph-0"}},
+    ),
+    "arstechnica.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+        {"tags": {"article"}},
+    ),
+    "substack.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"body", "markup"}},
+        {"tags": {"div", "section"}, "class_tokens": {"available-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+    ),
+    "yahoo.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"caas-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "id_tokens": {"articlebody"}},
     ),
 }
 TEXT_BLOCK_TAGS = {

--- a/tests/fixtures/extraction/arstechnica-article.html
+++ b/tests/fixtures/extraction/arstechnica-article.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <title>Why AI teams are rebuilding their observability stacks</title>
+  </head>
+  <body>
+    <header>Ars Technica navigation</header>
+    <article>
+      <div class="post-meta">By Ars Staff</div>
+      <div class="article-content">
+        <h1>Why AI teams are rebuilding their observability stacks</h1>
+        <p>Ars Technica reports that teams deploying language models are replacing one-off dashboards with operational tooling built for latency, quality drift, and fallback behavior.</p>
+        <p>As pilot projects move into business workflows, operators want the same confidence they already expect from databases, queues, and application infrastructure.</p>
+        <p>That shift is pushing vendors to package evaluation, tracing, and incident response features as core product requirements instead of optional extras.</p>
+        <p>The result is a more disciplined AI operations market, where instrumentation and rollback paths matter almost as much as model quality itself.</p>
+      </div>
+      <div class="newsletter-callout">Stay tuned for our latest AI coverage.</div>
+      <div class="related-stories">Related stories from Ars Technica</div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/jiqizhixin.html
+++ b/tests/fixtures/extraction/jiqizhixin.html
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>机器之心观察：企业正在重建 AI 运维栈</title>
+  </head>
+  <body>
+    <header>机器之心首页 导航</header>
+    <main>
+      <article class="article-page">
+        <div class="author-card">作者 机器之心编辑部</div>
+        <div class="article__content">
+          <h1>机器之心观察：企业正在重建 AI 运维栈</h1>
+          <p>机器之心报道</p>
+          <p>过去一年里，大模型项目从试验进入生产，团队开始重新评估推理成本、日志留存与模型回退策略。</p>
+          <p>不少企业发现，真正决定 AI 系统能否稳定落地的，不只是模型能力，而是监控、告警、权限控制与故障演练这些运维能力。</p>
+          <p>随着多模型路由、缓存和检索增强被广泛采用，AI 平台团队也在把原本分散的工具整合成更完整的内部控制面。</p>
+          <p>这意味着，AI 基础设施的采购标准正在从“模型够不够强”转向“是否足够可观测、可治理、可恢复”。</p>
+        </div>
+        <div class="share-box">分享 微信 微博 收藏</div>
+        <div class="related-posts">相关阅读：更多企业案例</div>
+        <div class="article__copyright">原标题：本文转载自合作媒体</div>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/substack-article.html
+++ b/tests/fixtures/extraction/substack-article.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>What changes when AI tooling becomes a managed operations problem</title>
+  </head>
+  <body>
+    <div class="post-shell">
+      <div class="subscription-widget-wrap">Subscribe now to unlock the full archive</div>
+      <section class="body markup">
+        <h1>What changes when AI tooling becomes a managed operations problem</h1>
+        <p>As more model teams move beyond prototypes, the hardest work shifts from prompts to operating procedures, budgets, and incident reviews.</p>
+        <p>Newsletter authors covering enterprise AI have started to focus less on benchmark wins and more on how teams measure output quality once systems are connected to real workflows.</p>
+        <p>That operational lens is changing how buyers compare vendors: the most useful tools now explain where failures happen, how to replay them, and what to do next.</p>
+        <p>It also creates a new editorial pattern for AI media, where deployment lessons matter as much as research announcements.</p>
+      </section>
+      <div class="comments-page">Leave a comment</div>
+      <footer class="footer-wrap">Thanks for reading Latent Ops. Share this post</footer>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/yahoo-syndication.html
+++ b/tests/fixtures/extraction/yahoo-syndication.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <title>AI deployment discipline is becoming a board-level topic</title>
+  </head>
+  <body>
+    <main>
+      <div class="caas-share-section">Share this article</div>
+      <section class="caas-body" data-test-locator="articleBody">
+        <h1>AI deployment discipline is becoming a board-level topic</h1>
+        <p>Yahoo syndication pages increasingly surface reporting about how companies are formalizing approval, rollback, and monitoring procedures for AI systems tied to customer workflows.</p>
+        <p>That change reflects a broader shift: executives no longer treat model rollouts as isolated experiments, but as production changes that can trigger compliance, support, and security consequences.</p>
+        <p>In practice, teams are responding with clearer ownership, staged rollouts, and better incident timelines so that AI features can be operated like the rest of the software stack.</p>
+        <p>For operators, the lesson is straightforward: reliable AI products need observability and governance before they need another benchmark chart.</p>
+      </section>
+      <div class="caas-readmore">Read more: related coverage</div>
+      <div class="caas-da">Advertisement</div>
+      <div class="video-player-element">Recommended Stories</div>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -83,6 +83,18 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("责任编辑", content.text)
         self.assertNotIn("来源：钛媒体", content.text)
 
+    def test_prefers_jiqizhixin_article_body_and_drops_share_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("jiqizhixin.html"),
+            url="https://www.jiqizhixin.com/articles/2026-04-09-ops-stack",
+        )
+
+        self.assertIn("大模型项目从试验进入生产", content.text)
+        self.assertIn("是否足够可观测、可治理、可恢复", content.text)
+        self.assertNotIn("分享 微信 微博 收藏", content.text)
+        self.assertNotIn("原标题", content.text)
+
     def test_prefers_huggingface_blog_content_and_drops_author_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(
@@ -145,6 +157,18 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Sign up for the TechCrunch AI newsletter", content.text)
         self.assertNotIn("Share this article", content.text)
 
+    def test_prefers_arstechnica_article_content_and_drops_related_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("arstechnica-article.html"),
+            url="https://arstechnica.com/ai/2026/04/why-ai-teams-are-rebuilding-their-observability-stacks/",
+        )
+
+        self.assertIn("teams deploying language models are replacing one-off dashboards", content.text)
+        self.assertIn("instrumentation and rollback paths matter almost as much as model quality", content.text)
+        self.assertNotIn("Related stories from Ars Technica", content.text)
+        self.assertNotIn("Stay tuned", content.text)
+
     def test_prefers_venturebeat_article_content_and_drops_related_story_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(
@@ -178,6 +202,30 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertIn("Reuters writes that enterprise buyers are shifting from pilot programs", content.text)
         self.assertIn("fit procurement, security review, and incident response processes", content.text)
         self.assertNotIn("Thomson Reuters Trust Principles", content.text)
+
+    def test_prefers_substack_body_and_drops_subscription_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("substack-article.html"),
+            url="https://latentops.substack.com/p/managed-ai-operations",
+        )
+
+        self.assertIn("the hardest work shifts from prompts to operating procedures", content.text)
+        self.assertIn("deployment lessons matter as much as research announcements", content.text)
+        self.assertNotIn("Subscribe now", content.text)
+        self.assertNotIn("Leave a comment", content.text)
+
+    def test_prefers_yahoo_syndication_body_and_drops_recirculation_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("yahoo-syndication.html"),
+            url="https://finance.yahoo.com/news/ai-deployment-discipline-board-level-topic-090000123.html",
+        )
+
+        self.assertIn("Yahoo syndication pages increasingly surface reporting", content.text)
+        self.assertIn("reliable AI products need observability and governance", content.text)
+        self.assertNotIn("Recommended Stories", content.text)
+        self.assertNotIn("Advertisement", content.text)
 
     def test_prefers_techcrunch_post_content_variant(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)


### PR DESCRIPTION
## Summary
- add fixture-driven extraction coverage for Jiqizhixin, Ars Technica, Substack, and Yahoo syndication pages
- bump the package and release notes to v1.2.0
- roll the operations dashboard and broader extraction cleanup into the next tagged release

## Validation
- ./.venv-dev/bin/python -m unittest discover -s tests -v
- ./.venv-dev/bin/python -m ruff check src tests
- ./.venv-dev/bin/python -m build