### PR TITLE
release: prepare v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.1] - 2026-04-09
+
+### Added
+
+- Multi-source feed fixtures for `Jiqizhixin`, `Ars Technica`, `Substack`, and `Yahoo` syndication pages in the pipeline end-to-end suite
+- A deterministic partial-error pipeline regression that keeps extraction timeout handling covered without depending on live network behavior
+
+### Changed
+
+- Package version is now `1.2.1`
+- Fixture-driven pipeline coverage now spans domestic media, international media, newsletter/blog layouts, and syndication targets in one CI-safe bundle
+
+### Fixed
+
+- Closed issue `#8` by expanding pipeline fixture coverage across more sources while keeping the regression suite deterministic
+
 ## [1.2.0] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.0`
+`v1.2.1`
 
 ### Suggested Title
 
-`AI News Open v1.2.0 · Operations And Content Quality`
+`AI News Open v1.2.1 · Fixture Coverage Expansion`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.0
+## AI News Open v1.2.1
 
-AI News Open `v1.2.0` upgrades both the operator surface and the extraction layer with a unified Operations dashboard and broader fixture-driven cleanup coverage across more media layouts.
+AI News Open `v1.2.1` hardens the fixture-driven regression layer with broader pipeline coverage across domestic, international, newsletter, and syndication source shapes.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.0` upgrades both the operator surface and the extraction laye
 
 ### Highlights in this release
 
-- One-screen `Operations` panel for health, pipeline, incidents, and publication failures
-- Richer `/admin/operations` payload for dashboard and automation consumers
-- New extraction fixtures and cleanup rules for `Jiqizhixin`, `Ars Technica`, `Substack`, and `Yahoo`
+- Multi-source feed fixtures for `Jiqizhixin`, `Ars Technica`, `Substack`, and `Yahoo`
+- A deterministic partial-error pipeline scenario that keeps timeout handling under regression coverage
+- Issue `#8` is now closed with CI-safe, network-free fixture expansion
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.1
+
+AI News Open `v1.2.1` is a content-quality patch release focused on regression depth. It expands the fixture-driven pipeline suite so more source shapes are exercised end to end without live network dependencies.
+
+### What changed
+
+- Added multi-source feed fixtures for:
+  - `jiqizhixin.com`
+  - `arstechnica.com`
+  - `substack.com`
+  - `yahoo.com` syndication targets
+- Added a deterministic multi-source pipeline happy path that runs ingest, extract, enrich, digest, and static-site publish in one test
+- Added a deterministic partial-error pipeline path where one source times out during extraction and the pipeline still completes with `partial_error`
+
+### Why this matters
+
+- The regression suite now covers more than a single-feed happy path, so future source-specific cleanup changes are less likely to break the overall workflow silently
+- Domestic media, international media, newsletter/blog layouts, and syndication targets are now represented together in CI-safe pipeline fixtures
+- Issue `#8` is closed with broader fixture-driven pipeline coverage instead of ad hoc live checks
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- `Release Artifact Smoke` remains the published-release gate and continues to run automatically after release publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.0"
+version = "1.2.1"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
## Summary
- bump the package and release notes to v1.2.1
- publish the new multi-source pipeline fixture coverage and deterministic partial-error regression as a patch release
- record issue #8 completion in the changelog and release notes

## Validation
- ./.venv-dev/bin/python -m unittest discover -s tests -v
- ./.venv-dev/bin/python -m ruff check src tests
- ./.venv-dev/bin/python -m build