### PR TITLE
test: add MIT Technology Review fixture and harden local gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ make check
 
 - Run `make lint` before opening a pull request.
 - Run `make test` for behavior changes.
-- Run `make coverage` when behavior or contracts change.
+- Run `make check` before merging behavior, contract, release, or workflow changes. It is the local maintainer gate and includes lint, coverage, build, and smoke.
+- Run `make coverage` separately only when you need to iterate on coverage failures without re-running the full local gate.
 - Run `make build` when packaging, entry points, or included assets change.
 - Run `make sbom` when supply chain or release files change.
 - Keep CI green on all supported Python versions before merging.

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ sbom:
 	PYTHON_BIN="$$( $(PYTHON) -c 'import sys; print(sys.executable)' )"; \
 	$(PYTHON) -m cyclonedx_py environment "$$PYTHON_BIN" --pyproject pyproject.toml --mc-type application --output-reproducible --of JSON -o sbom.json
 
-check: lint test build
+check: lint coverage build smoke
 
 serve:
 	$(PYTHON) -m uvicorn ainews.api:create_app --factory --host 0.0.0.0 --port 8000

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ After startup you can:
 python -m pip install -e ".[dev]"
 pre-commit install
 make check
-make coverage
-make smoke
 ```
+
+`make check` is the local maintainer gate. It runs lint, coverage, package build validation, and the `/health` smoke check in one command. Use `make coverage` or `make smoke` separately only when you are iterating on one layer.
 
 ## Operator Docs
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,9 +81,9 @@ python -m ainews serve --port 8000
 python -m pip install -e ".[dev]"
 pre-commit install
 make check
-make coverage
-make smoke
 ```
+
+`make check` 现在就是本地维护者总门禁，会一次跑完 lint、coverage、构建校验和 `/health` smoke。只有在你单独调某一层时，才需要单跑 `make coverage` 或 `make smoke`。
 
 ## 运维与交付文档
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,8 +13,9 @@ Use this checklist before cutting a new public release.
 
 ```bash
 make check
-make smoke
 ```
+
+`make check` now includes the local smoke check, so a separate `make smoke` rerun is only needed when you are debugging startup behavior by itself.
 
 5. Confirm `docker compose config -q` passes with the current compose profile.
 6. Confirm open code scanning alerts are `0`.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -13,8 +13,9 @@
 
 ```bash
 make check
-make smoke
 ```
+
+`make check` 现在已经包含本地 smoke 校验，所以只有在你单独排查启动问题时，才需要额外再跑一次 `make smoke`。
 
 5. 用当前 compose profile 验证 `docker compose config -q` 能通过。
 6. 确认 open code scanning alerts 为 `0`。

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -143,6 +143,11 @@ HOST_SELECTORS = {
         ".post-content",
         "article",
     ),
+    "technologyreview.com": (
+        ".content--body",
+        ".article-body__content",
+        ".article-body",
+    ),
     "substack.com": (
         ".body.markup",
         ".available-content",
@@ -240,6 +245,13 @@ HOST_DROP_SELECTORS = {
         ".sidebar",
         ".newsletter-callout",
     ),
+    "technologyreview.com": (
+        ".inline-newsletter",
+        ".article-callout",
+        ".article-footer__related",
+        ".most-popular",
+        ".paywall-inline",
+    ),
     "substack.com": (
         ".subscription-widget-wrap",
         ".subscribe-widget",
@@ -311,6 +323,11 @@ HOST_NOISE_LINE_PATTERNS = {
     "arstechnica.com": (
         re.compile(r"^Ars Technica may earn compensation.*$"),
         re.compile(r"^Stay tuned for.*$"),
+    ),
+    "technologyreview.com": (
+        re.compile(r"^Subscribe to The Algorithm$"),
+        re.compile(r"^Stay connected with MIT Technology Review.*$"),
+        re.compile(r"^More from MIT Technology Review$"),
     ),
     "substack.com": (
         re.compile(r"^Thanks for reading.*$"),
@@ -384,6 +401,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
         {"tags": {"article"}},
+    ),
+    "technologyreview.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"content--body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "substack.com": (
         {"tags": {"div", "section"}, "class_tokens": {"body", "markup"}},

--- a/tests/fixtures/extraction/technologyreview-article.html
+++ b/tests/fixtures/extraction/technologyreview-article.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <title>MIT Technology Review says AI buyers now demand observability</title>
+  </head>
+  <body>
+    <header class="site-header">MIT Technology Review navigation</header>
+    <article class="article-body">
+      <div class="article-hero">
+        <h1>AI buyers now demand observability before scale</h1>
+      </div>
+      <div class="article-body__content content--body">
+        <p>MIT Technology Review reports that enterprise AI buyers increasingly want observability, rollback controls, and governance before they expand pilots into production systems.</p>
+        <div class="inline-newsletter">
+          <p>Subscribe to The Algorithm</p>
+          <p>Stay connected with MIT Technology Review every week.</p>
+        </div>
+        <p>Teams that once focused on raw model benchmarks are now asking whether deployment workflows can survive outages, policy changes, and retrieval regressions without causing user-visible failures.</p>
+        <div class="article-callout">
+          <p>More from MIT Technology Review</p>
+        </div>
+        <p>The shift means AI operators are treating observability, evaluation, and incident response as product requirements rather than optional infrastructure extras.</p>
+      </div>
+      <aside class="most-popular">
+        <h2>Most Popular</h2>
+        <p>Other stories</p>
+      </aside>
+      <footer class="article-footer__related">
+        <p>Related coverage and newsletter signup links</p>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -169,6 +169,19 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related stories from Ars Technica", content.text)
         self.assertNotIn("Stay tuned", content.text)
 
+    def test_prefers_mit_technology_review_body_and_drops_newsletter_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("technologyreview-article.html"),
+            url="https://www.technologyreview.com/2026/04/09/1111111/ai-buyers-now-demand-observability-before-scale/",
+        )
+
+        self.assertIn("enterprise AI buyers increasingly want observability", content.text)
+        self.assertIn("deployment workflows can survive outages, policy changes, and retrieval regressions", content.text)
+        self.assertNotIn("Subscribe to The Algorithm", content.text)
+        self.assertNotIn("More from MIT Technology Review", content.text)
+        self.assertNotIn("Most Popular", content.text)
+
     def test_prefers_venturebeat_article_content_and_drops_related_story_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add source-specific extraction selectors and cleanup rules for MIT Technology Review article pages
- add a minimal HTML fixture that reproduces newsletter and recirculation noise inside the body wrapper
- turn make check into the full local maintainer gate and align README, CONTRIBUTING, and release checklist docs

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- ./.venv-dev/bin/python -m unittest discover -s tests -v
- ./.venv-dev/bin/python -m ruff check src tests
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m build
