### PR TITLE
release: prepare v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.2] - 2026-04-09
+
+### Added
+
+- New fixture-driven extraction coverage for `technologyreview.com` and `axios.com`, extending the international media regression set with additional newsletter-heavy article layouts
+
+### Changed
+
+- Package version is now `1.2.2`
+- `make check` now runs the full local engineering gate: `lint`, `coverage`, `build`, and `smoke`
+
+### Fixed
+
+- Improved source-specific cleanup for Axios article pages so newsletter prompts, share tools, and recirculation blocks are excluded from extracted body text
+- Reduced regression risk on MIT Technology Review and Axios layouts by locking both shapes into deterministic fixture coverage
+
 ## [1.2.1] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.1`
+`v1.2.2`
 
 ### Suggested Title
 
-`AI News Open v1.2.1 · Fixture Coverage Expansion`
+`AI News Open v1.2.2 · Extraction Coverage and Local Gate Hardening`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.1
+## AI News Open v1.2.2
 
-AI News Open `v1.2.1` hardens the fixture-driven regression layer with broader pipeline coverage across domestic, international, newsletter, and syndication source shapes.
+AI News Open `v1.2.2` hardens extraction quality across more international publisher layouts and makes the local maintainer gate match release-quality checks more closely.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.1` hardens the fixture-driven regression layer with broader p
 
 ### Highlights in this release
 
-- Multi-source feed fixtures for `Jiqizhixin`, `Ars Technica`, `Substack`, and `Yahoo`
-- A deterministic partial-error pipeline scenario that keeps timeout handling under regression coverage
-- Issue `#8` is now closed with CI-safe, network-free fixture expansion
+- New deterministic extraction fixtures for `MIT Technology Review` and `Axios`
+- Better Axios article cleanup so newsletter prompts, share tools, and recirculation blocks are filtered out of extracted body text
+- `make check` now runs `lint`, `coverage`, `build`, and `smoke` as the default local maintainer gate
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.2.md
+++ b/docs/releases/v1.2.2.md
@@ -1,0 +1,27 @@
+## AI News Open v1.2.2
+
+AI News Open `v1.2.2` is a content-quality and engineering-gate patch release. It extends extraction regression coverage to more international publisher layouts and makes the local maintainer gate match the full release-quality path more closely.
+
+### What changed
+
+- Added fixture-driven extraction coverage for:
+  - `technologyreview.com`
+  - `axios.com`
+- Added source-specific cleanup for Axios story pages so newsletter prompts, share tools, and recirculation blocks do not leak into extracted article text
+- Promoted `make check` into the full local gate:
+  - `lint`
+  - `coverage`
+  - `build`
+  - `smoke`
+
+### Why this matters
+
+- More international publisher shapes are now locked into deterministic extraction fixtures, which lowers the chance of cleanup regressions shipping unnoticed
+- Maintainers can run one local command and get the same practical quality bar that matters for release readiness, instead of stopping at lint and unit tests
+- This keeps the project closer to a release-quality engineering loop even before a pull request reaches GitHub checks
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.1"
+version = "1.2.2"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -148,6 +148,11 @@ HOST_SELECTORS = {
         ".article-body__content",
         ".article-body",
     ),
+    "axios.com": (
+        ".gtm-story-text",
+        ".story-body",
+        ".article-body",
+    ),
     "substack.com": (
         ".body.markup",
         ".available-content",
@@ -252,6 +257,13 @@ HOST_DROP_SELECTORS = {
         ".most-popular",
         ".paywall-inline",
     ),
+    "axios.com": (
+        ".newsletter-card",
+        ".story-share-tools",
+        ".related-story-list",
+        ".sidebar-list",
+        ".story-footer",
+    ),
     "substack.com": (
         ".subscription-widget-wrap",
         ".subscribe-widget",
@@ -329,6 +341,11 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Stay connected with MIT Technology Review.*$"),
         re.compile(r"^More from MIT Technology Review$"),
     ),
+    "axios.com": (
+        re.compile(r"^Sign up for Axios AI\+$"),
+        re.compile(r"^By signing up, you agree to receive.*$"),
+        re.compile(r"^More from Axios$"),
+    ),
     "substack.com": (
         re.compile(r"^Thanks for reading.*$"),
         re.compile(r"^Subscribe (?:now|for free).*$"),
@@ -405,6 +422,11 @@ FALLBACK_HOST_RULES = {
     "technologyreview.com": (
         {"tags": {"div", "section"}, "class_tokens": {"content--body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "axios.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"gtm-story-text"}},
+        {"tags": {"div", "section"}, "class_tokens": {"story-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "substack.com": (

--- a/tests/fixtures/extraction/axios-article.html
+++ b/tests/fixtures/extraction/axios-article.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <title>Axios AI buyers want rollback plans before model rollouts</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <header>
+          <h1>Axios AI buyers want rollback plans before model rollouts</h1>
+        </header>
+        <div class="gtm-story-text">
+          <p>Axios reports that enterprise AI buyers increasingly ask vendors to prove rollback paths before large model rollouts.</p>
+          <p>Teams want evidence that deployment workflows can survive outages, policy changes, and retrieval regressions without forcing a full product freeze.</p>
+          <div class="newsletter-card">
+            <p>Sign up for Axios AI+</p>
+            <p>By signing up, you agree to receive newsletters and promotional content.</p>
+          </div>
+          <p>That pushes infrastructure teams to show audit logs, feature flags, circuit breakers, and clear human escalation paths earlier in procurement cycles.</p>
+          <div class="related-story-list">
+            <p>More from Axios</p>
+            <p>Why chip buyers are rethinking data center budgets</p>
+          </div>
+        </div>
+        <footer class="story-footer">
+          <p>Share this story</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -182,6 +182,19 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("More from MIT Technology Review", content.text)
         self.assertNotIn("Most Popular", content.text)
 
+    def test_prefers_axios_story_body_and_drops_newsletter_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("axios-article.html"),
+            url="https://www.axios.com/2026/04/09/ai-buyers-rollback-plans-before-rollouts",
+        )
+
+        self.assertIn("enterprise AI buyers increasingly ask vendors to prove rollback paths", content.text)
+        self.assertIn("deployment workflows can survive outages, policy changes, and retrieval regressions", content.text)
+        self.assertNotIn("Sign up for Axios AI+", content.text)
+        self.assertNotIn("More from Axios", content.text)
+        self.assertNotIn("Share this story", content.text)
+
     def test_prefers_venturebeat_article_content_and_drops_related_story_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic Axios extraction coverage and source-specific cleanup
- bump package metadata and release docs for v1.2.2
- keep the next patch release aligned with the stronger local python3 -m ruff check src tests gate

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python
