### PR TITLE
test: expand international extraction fixtures

### DIFF
--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -153,6 +153,21 @@ HOST_SELECTORS = {
         ".story-body",
         ".article-body",
     ),
+    "apnews.com": (
+        ".RichTextStoryBody",
+        ".RichTextBody",
+        ".Page-content",
+    ),
+    "cnbc.com": (
+        ".ArticleBody-articleBody",
+        ".group",
+        ".ArticleBodyWrapper",
+    ),
+    "ft.com": (
+        ".article__content-body",
+        ".n-content-body",
+        ".article-body",
+    ),
     "substack.com": (
         ".body.markup",
         ".available-content",
@@ -264,6 +279,27 @@ HOST_DROP_SELECTORS = {
         ".sidebar-list",
         ".story-footer",
     ),
+    "apnews.com": (
+        ".Page-promos",
+        ".Page-footer",
+        ".RelatedTopics-list",
+        ".Carousel",
+        ".ad-placeholder",
+    ),
+    "cnbc.com": (
+        ".InlineNewsletter-inlineNewsletter",
+        ".RelatedContent-relatedContent",
+        ".SocialShare-socialShare",
+        ".ArticleBody-extra",
+        ".group[data-module='recirc']",
+    ),
+    "ft.com": (
+        ".n-content-recommended",
+        ".o-teaser-collection",
+        ".newsletter-signup",
+        ".article-footer",
+        ".related-articles",
+    ),
     "substack.com": (
         ".subscription-widget-wrap",
         ".subscribe-widget",
@@ -346,6 +382,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^By signing up, you agree to receive.*$"),
         re.compile(r"^More from Axios$"),
     ),
+    "apnews.com": (
+        re.compile(r"^The Associated Press is an independent global news organization.*$"),
+        re.compile(r"^Read more$"),
+        re.compile(r"^More stories$"),
+    ),
+    "cnbc.com": (
+        re.compile(r"^Watch:.*$"),
+        re.compile(r"^Subscribe to CNBC PRO$"),
+        re.compile(r"^Related Tags$"),
+    ),
+    "ft.com": (
+        re.compile(r"^Sign up to the FT Edit newsletter$"),
+        re.compile(r"^Recommended$"),
+        re.compile(r"^Read next$"),
+    ),
     "substack.com": (
         re.compile(r"^Thanks for reading.*$"),
         re.compile(r"^Subscribe (?:now|for free).*$"),
@@ -427,6 +478,21 @@ FALLBACK_HOST_RULES = {
     "axios.com": (
         {"tags": {"div", "section"}, "class_tokens": {"gtm-story-text"}},
         {"tags": {"div", "section"}, "class_tokens": {"story-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "apnews.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"richtextstorybody"}},
+        {"tags": {"div", "section"}, "class_tokens": {"richtextbody"}},
+        {"tags": {"div", "section"}, "class_tokens": {"page-content"}},
+    ),
+    "cnbc.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"articlebody-articlebody"}},
+        {"tags": {"div", "section"}, "class_tokens": {"group"}},
+        {"tags": {"div", "section"}, "class_tokens": {"articlebodywrapper"}},
+    ),
+    "ft.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article__content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"n-content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "substack.com": (

--- a/tests/fixtures/extraction/apnews-article.html
+++ b/tests/fixtures/extraction/apnews-article.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>AP News reports AI buyers are moving past pilot theater</title>
+  </head>
+  <body>
+    <main class="Page-content">
+      <article>
+        <header>
+          <h1>AI buyers are moving past pilot theater</h1>
+        </header>
+        <div class="RichTextStoryBody RichTextBody">
+          <p>Associated Press reports that enterprise AI teams are pushing vendors to prove they can run production systems, not just flashy pilot programs.</p>
+          <p>Procurement groups increasingly want evidence that rollback controls, evaluation logs, and human escalation paths exist before large contracts are signed.</p>
+          <div class="Page-promos">
+            <p>Read more</p>
+            <p>More stories</p>
+          </div>
+          <p>That shift is forcing suppliers to show how their model operations fit incident response, policy review, and internal audit processes.</p>
+        </div>
+        <footer class="Page-footer">
+          <p>The Associated Press is an independent global news organization dedicated to factual reporting.</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/cnbc-article.html
+++ b/tests/fixtures/extraction/cnbc-article.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>CNBC says AI operating discipline is becoming a board topic</title>
+  </head>
+  <body>
+    <article>
+      <div class="ArticleBodyWrapper">
+        <div class="group ArticleBody-articleBody">
+          <p>CNBC reports that AI operating discipline is becoming a board-level topic as enterprises move from experiments to revenue-linked deployments.</p>
+          <div class="InlineNewsletter-inlineNewsletter">
+            <p>Subscribe to CNBC PRO</p>
+          </div>
+          <p>Technology leaders are being asked how they will measure reliability, control rollback windows, and explain model-driven failures to executives.</p>
+          <div class="RelatedContent-relatedContent">
+            <p>Related Tags</p>
+            <p>Generative AI</p>
+          </div>
+          <p>The strongest internal programs now pair model launches with observability dashboards, policy guardrails, and explicit kill switches.</p>
+        </div>
+      </div>
+      <aside class="SocialShare-socialShare">
+        <p>Watch: Why AI spending is accelerating again</p>
+      </aside>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/ft-article.html
+++ b/tests/fixtures/extraction/ft-article.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Financial Times on enterprise AI governance pressure</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article__content-body n-content-body">
+          <p>Financial Times reports that enterprise buyers now evaluate AI vendors on governance and recoverability as much as on raw model performance.</p>
+          <div class="newsletter-signup">
+            <p>Sign up to the FT Edit newsletter</p>
+          </div>
+          <p>Boards increasingly expect deployment teams to explain what happens when retrieval quality drifts, upstream providers change policy, or output monitoring flags a business risk.</p>
+          <div class="n-content-recommended">
+            <p>Recommended</p>
+            <p>How finance teams are budgeting for AI oversight</p>
+          </div>
+          <p>That is pushing operators to document fallback paths, human approvals, and incident playbooks before AI systems scale into core workflows.</p>
+        </div>
+        <footer class="article-footer">
+          <p>Read next</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -195,6 +195,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("More from Axios", content.text)
         self.assertNotIn("Share this story", content.text)
 
+    def test_prefers_apnews_story_body_and_drops_wire_footer_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("apnews-article.html"),
+            url="https://apnews.com/article/ai-buyers-moving-past-pilot-theater-1234567890",
+        )
+
+        self.assertIn("enterprise AI teams are pushing vendors to prove they can run production systems", content.text)
+        self.assertIn("rollback controls, evaluation logs, and human escalation paths", content.text)
+        self.assertNotIn("Read more", content.text)
+        self.assertNotIn("More stories", content.text)
+        self.assertNotIn("The Associated Press is an independent global news organization", content.text)
+
+    def test_prefers_cnbc_article_body_and_drops_newsletter_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("cnbc-article.html"),
+            url="https://www.cnbc.com/2026/04/09/ai-operating-discipline-becomes-board-topic.html",
+        )
+
+        self.assertIn("AI operating discipline is becoming a board-level topic", content.text)
+        self.assertIn("measure reliability, control rollback windows, and explain model-driven failures", content.text)
+        self.assertNotIn("Subscribe to CNBC PRO", content.text)
+        self.assertNotIn("Related Tags", content.text)
+        self.assertNotIn("Watch: Why AI spending is accelerating again", content.text)
+
+    def test_prefers_ft_article_body_and_drops_recommended_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("ft-article.html"),
+            url="https://www.ft.com/content/ai-governance-pressure-2026-04-09",
+        )
+
+        self.assertIn("enterprise buyers now evaluate AI vendors on governance and recoverability", content.text)
+        self.assertIn("document fallback paths, human approvals, and incident playbooks", content.text)
+        self.assertNotIn("Sign up to the FT Edit newsletter", content.text)
+        self.assertNotIn("Recommended", content.text)
+        self.assertNotIn("Read next", content.text)
+
     def test_prefers_venturebeat_article_content_and_drops_related_story_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for AP News, CNBC, and Financial Times article layouts
- extend source-specific cleanup rules to drop inline newsletter, recirculation, and footer noise on those hosts
- keep international extraction coverage moving beyond the existing TechCrunch/Reuters/Wired/Axios set

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- ./.venv-dev/bin/python -m ruff check src tests
- make check PYTHON=./.venv-dev/bin/python
