### PR TITLE
release: prepare v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.3] - 2026-04-09
+
+### Added
+
+- Live and timeline-style extraction fixtures for `apnews.com`, `bbc.com`, and `theguardian.com`
+
+### Changed
+
+- Package version is now `1.2.3`
+- International content extraction coverage now includes live update and timeline layouts in addition to standard article pages
+
+### Fixed
+
+- Reduced timestamp, live-feed label, share, and recirculation noise on liveblog-style publisher pages
+- Locked another class of noisy newsroom layouts into deterministic fixture coverage so timeline formatting regressions are caught in CI
+
 ## [1.2.2] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.2`
+`v1.2.3`
 
 ### Suggested Title
 
-`AI News Open v1.2.2 · Extraction Coverage and Local Gate Hardening`
+`AI News Open v1.2.3 · Live Timeline Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.2
+## AI News Open v1.2.3
 
-AI News Open `v1.2.2` hardens extraction quality across more international publisher layouts and makes the local maintainer gate match release-quality checks more closely.
+AI News Open `v1.2.3` hardens extraction quality for live updates and timeline-style newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.2` hardens extraction quality across more international publi
 
 ### Highlights in this release
 
-- New deterministic extraction fixtures for `MIT Technology Review` and `Axios`
-- Better Axios article cleanup so newsletter prompts, share tools, and recirculation blocks are filtered out of extracted body text
-- `make check` now runs `lint`, `coverage`, `build`, and `smoke` as the default local maintainer gate
+- New deterministic live/timeline extraction fixtures for `AP News`, `BBC`, and `The Guardian`
+- Better cleanup for timestamp rows, live-feed labels, share widgets, and recirculation blocks on newsroom liveblog pages
+- The international extraction suite now covers standard articles, newsletters, syndication pages, and live-update layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.3.md
+++ b/docs/releases/v1.2.3.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.3
+
+AI News Open `v1.2.3` is a content-quality patch release focused on live and timeline-style newsroom layouts. It expands the deterministic extraction suite so timestamp-heavy live updates and liveblog pages are covered by source-specific cleanup instead of relying on generic article heuristics alone.
+
+### What changed
+
+- Added live/timeline extraction fixtures for:
+  - `apnews.com`
+  - `bbc.com`
+  - `theguardian.com`
+- Added host-specific cleanup for timestamp rows, live-feed labels, share blocks, and recirculation/footer noise on those layouts
+- Extended the extraction regression suite to cover both standard article pages and live-update newsroom formats
+
+### Why this matters
+
+- Liveblog and timeline pages often mix timestamps, share widgets, “top stories” blocks, and inline recirculation into the body container
+- Locking those shapes into fixtures lowers the risk that source cleanup changes silently degrade digest quality for fast-moving newsroom formats
+- The international extraction suite now covers a broader range of real publisher layouts instead of mostly standard long-form pages
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.2"
+version = "1.2.3"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -158,6 +158,11 @@ HOST_SELECTORS = {
         ".RichTextBody",
         ".Page-content",
     ),
+    "bbc.com": (
+        ".qa-story-body",
+        ".lx-stream-post-body",
+        ".ssrcss-11r1m41-RichTextComponentWrapper",
+    ),
     "cnbc.com": (
         ".ArticleBody-articleBody",
         ".group",
@@ -167,6 +172,11 @@ HOST_SELECTORS = {
         ".article__content-body",
         ".n-content-body",
         ".article-body",
+    ),
+    "theguardian.com": (
+        ".liveblog__body",
+        ".content__article-body",
+        ".article-body-commercial-selector",
     ),
     "substack.com": (
         ".body.markup",
@@ -285,6 +295,15 @@ HOST_DROP_SELECTORS = {
         ".RelatedTopics-list",
         ".Carousel",
         ".ad-placeholder",
+        ".Timestamp",
+        ".UpdateTime",
+    ),
+    "bbc.com": (
+        ".lx-stream-post__meta",
+        ".lx-stream-post__header",
+        ".lx-stream-post__footer",
+        ".lx-share-tools",
+        ".bbc-article-tags",
     ),
     "cnbc.com": (
         ".InlineNewsletter-inlineNewsletter",
@@ -299,6 +318,15 @@ HOST_DROP_SELECTORS = {
         ".newsletter-signup",
         ".article-footer",
         ".related-articles",
+    ),
+    "theguardian.com": (
+        ".submeta",
+        ".email-sign-up",
+        ".related-content",
+        ".liveblog-block__meta",
+        ".sharecount",
+        ".most-viewed-container",
+        ".liveblog__key-events",
     ),
     "substack.com": (
         ".subscription-widget-wrap",
@@ -386,6 +414,13 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^The Associated Press is an independent global news organization.*$"),
         re.compile(r"^Read more$"),
         re.compile(r"^More stories$"),
+        re.compile(r"^\d{1,2}:\d{2}\s*(?:a\.m\.|p\.m\.)\s*[A-Z]{2,4}$"),
+    ),
+    "bbc.com": (
+        re.compile(r"^Live Reporting$"),
+        re.compile(r"^Posted at \d{1,2}:\d{2}$"),
+        re.compile(r"^\d{1,2}:\d{2}$"),
+        re.compile(r"^Top stories$"),
     ),
     "cnbc.com": (
         re.compile(r"^Watch:.*$"),
@@ -396,6 +431,11 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Sign up to the FT Edit newsletter$"),
         re.compile(r"^Recommended$"),
         re.compile(r"^Read next$"),
+    ),
+    "theguardian.com": (
+        re.compile(r"^Live feed$"),
+        re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
+        re.compile(r"^Most viewed$"),
     ),
     "substack.com": (
         re.compile(r"^Thanks for reading.*$"),
@@ -485,6 +525,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"richtextbody"}},
         {"tags": {"div", "section"}, "class_tokens": {"page-content"}},
     ),
+    "bbc.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"qa-story-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"lx-stream-post-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"ssrcss-11r1m41-richtextcomponentwrapper"}},
+    ),
     "cnbc.com": (
         {"tags": {"div", "section"}, "class_tokens": {"articlebody-articlebody"}},
         {"tags": {"div", "section"}, "class_tokens": {"group"}},
@@ -494,6 +539,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article__content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"n-content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "theguardian.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content__article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body-commercial-selector"}},
     ),
     "substack.com": (
         {"tags": {"div", "section"}, "class_tokens": {"body", "markup"}},

--- a/tests/fixtures/extraction/apnews-live-updates.html
+++ b/tests/fixtures/extraction/apnews-live-updates.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>AP News live updates on AI regulation and operations</title>
+  </head>
+  <body>
+    <main class="Page-content">
+      <article>
+        <h1>Live updates: AI operators face new governance pressure</h1>
+        <div class="RichTextStoryBody">
+          <div class="UpdateTime">9:41 a.m. EDT</div>
+          <p>Associated Press reports that operators rolling out generative AI systems are being pressed to show how model behavior will be monitored after launch.</p>
+          <p>Enterprise buyers increasingly want evidence that policy changes, retrieval failures, and model outages can be contained without forcing a full shutdown.</p>
+          <div class="Page-promos">
+            <p>Read more</p>
+            <p>More stories</p>
+          </div>
+          <p>The shift is turning incident playbooks, audit logs, and fallback controls into procurement requirements instead of afterthoughts.</p>
+        </div>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/bbc-live.html
+++ b/tests/fixtures/extraction/bbc-live.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>BBC live coverage says AI oversight is moving into operations</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="qa-story-body">
+          <p>Live Reporting</p>
+          <div class="lx-stream-post-body">
+            <div class="lx-stream-post__meta">
+              <p>Posted at 10:42</p>
+            </div>
+            <p>BBC reports that executives are asking AI teams to explain how live systems will be supervised after they move beyond pilot deployments.</p>
+            <p>Leaders want clearer answers on who can pause a rollout, how retrieval quality is measured, and what evidence exists when an automated decision must be reviewed.</p>
+            <div class="lx-share-tools">
+              <p>Top stories</p>
+            </div>
+            <p>That is pushing operators to document approval paths, alerting rules, and fallback procedures alongside model quality metrics.</p>
+          </div>
+        </div>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/theguardian-liveblog.html
+++ b/tests/fixtures/extraction/theguardian-liveblog.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <title>The Guardian live blog tracks AI operations pressure</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="liveblog__body content__article-body">
+          <p>Live feed</p>
+          <div class="liveblog-block">
+            <div class="liveblog-block__meta">
+              <p>11.05 AM BST</p>
+            </div>
+            <p>The Guardian reports that enterprise AI programs are now judged on operational resilience as much as on model novelty.</p>
+            <p>Buyers increasingly ask how a deployment behaves when upstream providers change terms, when retrieval quality degrades, or when monitoring flags risky output.</p>
+          </div>
+          <div class="email-sign-up">
+            <p>Sign up for our daily newsletter</p>
+          </div>
+          <div class="liveblog-block">
+            <p>Teams that can show rollback paths, human approvals, and incident review discipline are moving faster through procurement than teams selling benchmarks alone.</p>
+          </div>
+          <div class="most-viewed-container">
+            <p>Most viewed</p>
+          </div>
+        </div>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -208,6 +208,32 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("More stories", content.text)
         self.assertNotIn("The Associated Press is an independent global news organization", content.text)
 
+    def test_prefers_apnews_live_updates_and_drops_timestamp_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("apnews-live-updates.html"),
+            url="https://apnews.com/live/ai-regulation-operations-updates-2026-04-09",
+        )
+
+        self.assertIn("operators rolling out generative AI systems are being pressed", content.text)
+        self.assertIn("incident playbooks, audit logs, and fallback controls", content.text)
+        self.assertNotIn("9:41 a.m. EDT", content.text)
+        self.assertNotIn("Read more", content.text)
+        self.assertNotIn("More stories", content.text)
+
+    def test_prefers_bbc_live_body_and_drops_live_meta_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("bbc-live.html"),
+            url="https://www.bbc.com/news/live/technology-12345678",
+        )
+
+        self.assertIn("executives are asking AI teams to explain how live systems will be supervised", content.text)
+        self.assertIn("document approval paths, alerting rules, and fallback procedures", content.text)
+        self.assertNotIn("Live Reporting", content.text)
+        self.assertNotIn("Posted at 10:42", content.text)
+        self.assertNotIn("Top stories", content.text)
+
     def test_prefers_cnbc_article_body_and_drops_newsletter_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(
@@ -233,6 +259,19 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Sign up to the FT Edit newsletter", content.text)
         self.assertNotIn("Recommended", content.text)
         self.assertNotIn("Read next", content.text)
+
+    def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("theguardian-liveblog.html"),
+            url="https://www.theguardian.com/technology/live/2026/apr/09/ai-operations-live",
+        )
+
+        self.assertIn("enterprise AI programs are now judged on operational resilience", content.text)
+        self.assertIn("rollback paths, human approvals, and incident review discipline", content.text)
+        self.assertNotIn("Live feed", content.text)
+        self.assertNotIn("11.05 AM BST", content.text)
+        self.assertNotIn("Most viewed", content.text)
 
     def test_prefers_venturebeat_article_content_and_drops_related_story_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)


### PR DESCRIPTION
## Summary
- add deterministic live/timeline extraction fixtures for AP News, BBC, and The Guardian
- extend source-specific cleanup for timestamp-heavy live updates and liveblog layouts
- bump package metadata and release docs for v1.2.3

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python
