### PR TITLE
release: prepare v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.4] - 2026-04-09
+
+### Added
+
+- Briefing and newsletter-style extraction fixtures for `semafor.com`, `morningbrew.com`, and `theinformation.com`
+
+### Changed
+
+- Package version is now `1.2.4`
+- International extraction coverage now includes briefing, digest, and subscriber-prompt-heavy newsroom layouts in addition to standard articles and live updates
+
+### Fixed
+
+- Reduced newsletter CTA, subscriber prompt, and related-coverage noise on briefing-style publisher pages
+- Locked another class of digest-style international media layouts into deterministic fixture coverage so content cleanup regressions are caught in CI
+
 ## [1.2.3] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.3`
+`v1.2.4`
 
 ### Suggested Title
 
-`AI News Open v1.2.3 · Live Timeline Extraction Coverage`
+`AI News Open v1.2.4 · Briefing and Newsletter Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.3
+## AI News Open v1.2.4
 
-AI News Open `v1.2.3` hardens extraction quality for live updates and timeline-style newsroom layouts across more international publishers.
+AI News Open `v1.2.4` hardens extraction quality for briefing, digest, and subscriber-prompt-heavy newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.3` hardens extraction quality for live updates and timeline-s
 
 ### Highlights in this release
 
-- New deterministic live/timeline extraction fixtures for `AP News`, `BBC`, and `The Guardian`
-- Better cleanup for timestamp rows, live-feed labels, share widgets, and recirculation blocks on newsroom liveblog pages
-- The international extraction suite now covers standard articles, newsletters, syndication pages, and live-update layouts
+- New deterministic briefing/newsletter extraction fixtures for `Semafor`, `Morning Brew`, and `The Information`
+- Better cleanup for CTA modules, subscriber prompts, signal cards, and related-coverage blocks on digest-style newsroom pages
+- The international extraction suite now covers standard articles, newsletters, syndication pages, live updates, and briefing layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.4.md
+++ b/docs/releases/v1.2.4.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.4
+
+AI News Open `v1.2.4` is a content-quality patch release focused on briefing and newsletter-style newsroom layouts. It extends the deterministic extraction suite so digest pages with CTA modules, subscriber prompts, and related-coverage blocks are handled with source-specific cleanup instead of relying on generic article heuristics.
+
+### What changed
+
+- Added briefing/newsletter extraction fixtures for:
+  - `semafor.com`
+  - `morningbrew.com`
+  - `theinformation.com`
+- Added host-specific cleanup for signal cards, newsletter signup CTAs, subscriber prompts, and related-coverage modules on those layouts
+- Extended the extraction regression suite to cover briefing-style and digest-like international media pages
+
+### Why this matters
+
+- Many AI news readers consume summary-heavy publisher layouts that mix editorial text with signup prompts, subscriber walls, and recirculation modules inside the main body container
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently degrade extracted digest quality for operator-focused media outlets
+- The international extraction suite now covers standard long-form pages, live updates, and briefing/newsletter layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.3"
+version = "1.2.4"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -173,6 +173,21 @@ HOST_SELECTORS = {
         ".n-content-body",
         ".article-body",
     ),
+    "semafor.com": (
+        ".article-content",
+        ".story-body",
+        ".article-body",
+    ),
+    "morningbrew.com": (
+        ".article-body",
+        ".post-content",
+        ".content-body",
+    ),
+    "theinformation.com": (
+        ".article__body",
+        ".article-body",
+        ".paywall-layout__body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -319,6 +334,27 @@ HOST_DROP_SELECTORS = {
         ".article-footer",
         ".related-articles",
     ),
+    "semafor.com": (
+        ".signals-inline",
+        ".article-recirculation",
+        ".signup-card",
+        ".article-footer",
+        ".related-stories",
+    ),
+    "morningbrew.com": (
+        ".inline-cta",
+        ".newsletter-signup",
+        ".related-brews",
+        ".share-tools",
+        ".post-footer",
+    ),
+    "theinformation.com": (
+        ".subscription-callout",
+        ".related-coverage",
+        ".article-footer",
+        ".signup-promo",
+        ".story-meta",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -432,6 +468,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Recommended$"),
         re.compile(r"^Read next$"),
     ),
+    "semafor.com": (
+        re.compile(r"^View in browser$"),
+        re.compile(r"^Read the full signal$"),
+        re.compile(r"^More from Semafor$"),
+    ),
+    "morningbrew.com": (
+        re.compile(r"^Join millions of readers.*$"),
+        re.compile(r"^Was this forwarded to you\?$"),
+        re.compile(r"^Read more from Morning Brew$"),
+    ),
+    "theinformation.com": (
+        re.compile(r"^Subscriber-only content$"),
+        re.compile(r"^Read more from The Information$"),
+        re.compile(r"^Already a subscriber\?$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -539,6 +590,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article__content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"n-content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "semafor.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"story-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "morningbrew.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "theinformation.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article__body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"paywall-layout__body"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/morningbrew-digest.html
+++ b/tests/fixtures/extraction/morningbrew-digest.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Morning Brew says AI deployment discipline is becoming mainstream</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article-body content-body">
+          <p>Morning Brew reports that AI deployment discipline is becoming a mainstream concern for operators who have to keep business workflows stable after launch.</p>
+          <div class="newsletter-signup">
+            <p>Join millions of readers who start their day with Morning Brew.</p>
+          </div>
+          <p>Teams are being asked how they will monitor retrieval drift, pause risky rollouts, and explain automated outcomes when executives or customers want answers quickly.</p>
+          <div class="related-brews">
+            <p>Read more from Morning Brew</p>
+          </div>
+          <p>The result is that kill switches, audit logs, and review queues are moving from “nice to have” infrastructure to expected parts of AI product delivery.</p>
+        </div>
+        <footer class="post-footer">
+          <p>Was this forwarded to you?</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/semafor-briefing.html
+++ b/tests/fixtures/extraction/semafor-briefing.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Semafor says AI buyers are now operating like reliability teams</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article-content story-body">
+          <p>Semafor reports that enterprise AI buyers are increasingly judging vendors on operational discipline rather than launch theatrics.</p>
+          <div class="signals-inline">
+            <p>Read the full signal</p>
+          </div>
+          <p>Procurement teams now ask whether rollback controls, evaluation history, and escalation paths are ready before deployments expand into customer-facing workflows.</p>
+          <div class="signup-card">
+            <p>View in browser</p>
+          </div>
+          <p>That pressure is making observability and incident response a bigger part of AI purchasing decisions than benchmark scores alone.</p>
+        </div>
+        <footer class="article-footer">
+          <p>More from Semafor</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/theinformation-briefing.html
+++ b/tests/fixtures/extraction/theinformation-briefing.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>The Information on AI governance and operator pressure</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article__body paywall-layout__body">
+          <p>The Information reports that AI operators are facing more pressure to prove governance discipline before internal pilots expand into core business systems.</p>
+          <div class="story-meta">
+            <p>Subscriber-only content</p>
+          </div>
+          <p>Executives increasingly want to know who can override a model-driven workflow, what evidence is logged after an incident, and how quickly a rollout can be rolled back.</p>
+          <div class="subscription-callout">
+            <p>Already a subscriber?</p>
+          </div>
+          <p>That is pushing teams to document human approvals, fallback procedures, and review checkpoints much earlier in the deployment process.</p>
+        </div>
+        <aside class="related-coverage">
+          <p>Read more from The Information</p>
+        </aside>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -260,6 +260,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Recommended", content.text)
         self.assertNotIn("Read next", content.text)
 
+    def test_prefers_semafor_briefing_body_and_drops_signal_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("semafor-briefing.html"),
+            url="https://www.semafor.com/article/2026/04/09/ai-buyers-operating-like-reliability-teams",
+        )
+
+        self.assertIn("enterprise AI buyers are increasingly judging vendors on operational discipline", content.text)
+        self.assertIn("rollback controls, evaluation history, and escalation paths", content.text)
+        self.assertNotIn("Read the full signal", content.text)
+        self.assertNotIn("View in browser", content.text)
+        self.assertNotIn("More from Semafor", content.text)
+
+    def test_prefers_morningbrew_digest_body_and_drops_newsletter_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("morningbrew-digest.html"),
+            url="https://www.morningbrew.com/stories/2026/04/09/ai-deployment-discipline-becoming-mainstream",
+        )
+
+        self.assertIn("AI deployment discipline is becoming a mainstream concern", content.text)
+        self.assertIn("kill switches, audit logs, and review queues", content.text)
+        self.assertNotIn("Join millions of readers", content.text)
+        self.assertNotIn("Read more from Morning Brew", content.text)
+        self.assertNotIn("Was this forwarded to you?", content.text)
+
+    def test_prefers_theinformation_briefing_body_and_drops_subscriber_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("theinformation-briefing.html"),
+            url="https://www.theinformation.com/articles/ai-governance-and-operator-pressure",
+        )
+
+        self.assertIn("AI operators are facing more pressure to prove governance discipline", content.text)
+        self.assertIn("document human approvals, fallback procedures, and review checkpoints", content.text)
+        self.assertNotIn("Subscriber-only content", content.text)
+        self.assertNotIn("Already a subscriber?", content.text)
+        self.assertNotIn("Read more from The Information", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic briefing/newsletter extraction fixtures for Semafor, Morning Brew, and The Information
- extend source-specific cleanup for CTA-heavy digest and subscriber-prompt layouts
- bump package metadata and release docs for v1.2.4

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python
