### PR TITLE
release: prepare v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.5] - 2026-04-09
+
+### Added
+
+- Multimedia-heavy extraction fixtures for `engadget.com`, `forbes.com`, and `zdnet.com`
+
+### Changed
+
+- Package version is now `1.2.5`
+- International extraction coverage now includes video, podcast, and audio-summary-heavy publisher layouts in addition to standard articles, live updates, and briefing pages
+
+### Fixed
+
+- Reduced video player, podcast module, audio summary, and embed CTA noise on multimedia-heavy publisher pages
+- Locked another class of media layouts into deterministic fixture coverage so multimedia cleanup regressions are caught in CI
+
 ## [1.2.4] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.4`
+`v1.2.5`
 
 ### Suggested Title
 
-`AI News Open v1.2.4 · Briefing and Newsletter Extraction Coverage`
+`AI News Open v1.2.5 · Multimedia Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.4
+## AI News Open v1.2.5
 
-AI News Open `v1.2.4` hardens extraction quality for briefing, digest, and subscriber-prompt-heavy newsroom layouts across more international publishers.
+AI News Open `v1.2.5` hardens extraction quality for multimedia-heavy newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.4` hardens extraction quality for briefing, digest, and subsc
 
 ### Highlights in this release
 
-- New deterministic briefing/newsletter extraction fixtures for `Semafor`, `Morning Brew`, and `The Information`
-- Better cleanup for CTA modules, subscriber prompts, signal cards, and related-coverage blocks on digest-style newsroom pages
-- The international extraction suite now covers standard articles, newsletters, syndication pages, live updates, and briefing layouts
+- New deterministic multimedia extraction fixtures for `Engadget`, `Forbes`, and `ZDNet`
+- Better cleanup for video players, podcast modules, audio summaries, and embed/related CTA blocks on media-heavy publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, and multimedia-heavy layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.5.md
+++ b/docs/releases/v1.2.5.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.5
+
+AI News Open `v1.2.5` is a content-quality patch release focused on multimedia-heavy newsroom pages. It extends the deterministic extraction suite so pages with video embeds, podcast modules, audio-summary blocks, and related CTA widgets are handled with source-specific cleanup instead of relying on generic article heuristics.
+
+### What changed
+
+- Added multimedia-heavy extraction fixtures for:
+  - `engadget.com`
+  - `forbes.com`
+  - `zdnet.com`
+- Added host-specific cleanup for video players, podcast blocks, audio summaries, and embed/related CTA modules on those layouts
+- Extended the extraction regression suite to cover another noisy class of international media pages
+
+### Why this matters
+
+- Many tech and business media pages now mix editorial text with video units, podcast players, audio summaries, and engagement blocks inside the same primary content container
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted article text for AI digests
+- The international extraction suite now covers standard articles, live updates, briefing/newsletter pages, and multimedia-heavy layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.4"
+version = "1.2.5"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -188,6 +188,21 @@ HOST_SELECTORS = {
         ".article-body",
         ".paywall-layout__body",
     ),
+    "engadget.com": (
+        ".article-text",
+        ".article-body",
+        ".body-text",
+    ),
+    "forbes.com": (
+        ".article-body",
+        ".body-container",
+        ".article-content",
+    ),
+    "zdnet.com": (
+        ".storyBody",
+        ".article-body",
+        ".c-ShortcodeContent",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -355,6 +370,27 @@ HOST_DROP_SELECTORS = {
         ".signup-promo",
         ".story-meta",
     ),
+    "engadget.com": (
+        ".video-embed",
+        ".podcast-player",
+        ".newsletter-inline",
+        ".engadget-share",
+        ".read-more-links",
+    ),
+    "forbes.com": (
+        ".embed-base",
+        ".newsletter-box",
+        ".article-share-wrap",
+        ".related-articles",
+        ".vestpocket",
+    ),
+    "zdnet.com": (
+        ".c-shortcodePodcast",
+        ".c-shortcodeVideo",
+        ".newsletterSignup",
+        ".relatedContent",
+        ".adSlot",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -483,6 +519,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Read more from The Information$"),
         re.compile(r"^Already a subscriber\?$"),
     ),
+    "engadget.com": (
+        re.compile(r"^Listen to this article$"),
+        re.compile(r"^Watch:.*$"),
+        re.compile(r"^Recommended by Engadget$"),
+    ),
+    "forbes.com": (
+        re.compile(r"^Listen to article$"),
+        re.compile(r"^More From Forbes$"),
+        re.compile(r"^Watch Forbes.*$"),
+    ),
+    "zdnet.com": (
+        re.compile(r"^ZDNET Recommends$"),
+        re.compile(r"^Watch now$"),
+        re.compile(r"^Editor's note:.*$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -605,6 +656,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article__body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"paywall-layout__body"}},
+    ),
+    "engadget.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-text"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"body-text"}},
+    ),
+    "forbes.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"body-container"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+    ),
+    "zdnet.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"storybody"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"c-shortcodecontent"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/engadget-article.html
+++ b/tests/fixtures/extraction/engadget-article.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Engadget says AI operators now care about rollback readiness</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article-text body-text">
+          <p>Engadget reports that AI operators are increasingly judged on how quickly they can unwind a problematic rollout without breaking downstream workflows.</p>
+          <div class="video-embed">
+            <p>Watch: Demo of the latest AI gadget</p>
+          </div>
+          <p>Infrastructure teams are being asked to show evidence of circuit breakers, audit logs, and clear human escalation before new models move into production.</p>
+          <div class="podcast-player">
+            <p>Listen to this article</p>
+          </div>
+          <p>That pressure is making reliability engineering and product operations much more central to AI deployment reviews than a year ago.</p>
+        </div>
+        <footer class="read-more-links">
+          <p>Recommended by Engadget</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/forbes-article.html
+++ b/tests/fixtures/extraction/forbes-article.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Forbes on why AI governance is becoming operational work</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article-body body-container">
+          <p>Forbes reports that enterprise AI governance is becoming an operations problem rather than a slide-deck topic as deployments move closer to revenue workflows.</p>
+          <div class="embed-base">
+            <p>Watch Forbes: Why AI spending is rising again</p>
+          </div>
+          <p>Executives want to know how a team will detect drift, pause a risky model path, and document what happened after an automated decision fails.</p>
+          <div class="newsletter-box">
+            <p>Listen to article</p>
+          </div>
+          <p>That is pushing teams to treat observability, review queues, and rollback design as core product requirements instead of optional infrastructure work.</p>
+        </div>
+        <aside class="related-articles">
+          <p>More From Forbes</p>
+        </aside>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/zdnet-article.html
+++ b/tests/fixtures/extraction/zdnet-article.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>ZDNET says AI platform teams are rebuilding around observability</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="storyBody article-body">
+          <p>ZDNET reports that AI platform teams are rebuilding their deployment playbooks around observability, rollback discipline, and tighter review loops.</p>
+          <div class="c-shortcodeVideo">
+            <p>Watch now</p>
+          </div>
+          <p>Leaders are asking how fast they can disable a failing path, what signals indicate retrieval quality is slipping, and how operators prove a fix after an incident.</p>
+          <div class="c-shortcodePodcast">
+            <p>ZDNET Recommends</p>
+          </div>
+          <p>The result is that teams shipping AI into production are documenting more explicit fallback paths and audit checkpoints before expansion.</p>
+        </div>
+        <footer class="relatedContent">
+          <p>Editor's note: This article was updated after publication.</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -299,6 +299,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Already a subscriber?", content.text)
         self.assertNotIn("Read more from The Information", content.text)
 
+    def test_prefers_engadget_article_body_and_drops_multimedia_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("engadget-article.html"),
+            url="https://www.engadget.com/ai-operators-now-care-about-rollback-readiness-090000123.html",
+        )
+
+        self.assertIn("AI operators are increasingly judged on how quickly they can unwind a problematic rollout", content.text)
+        self.assertIn("circuit breakers, audit logs, and clear human escalation", content.text)
+        self.assertNotIn("Watch: Demo of the latest AI gadget", content.text)
+        self.assertNotIn("Listen to this article", content.text)
+        self.assertNotIn("Recommended by Engadget", content.text)
+
+    def test_prefers_forbes_article_body_and_drops_embed_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("forbes-article.html"),
+            url="https://www.forbes.com/sites/2026/04/09/why-ai-governance-is-becoming-operational-work/",
+        )
+
+        self.assertIn("enterprise AI governance is becoming an operations problem", content.text)
+        self.assertIn("observability, review queues, and rollback design", content.text)
+        self.assertNotIn("Watch Forbes", content.text)
+        self.assertNotIn("Listen to article", content.text)
+        self.assertNotIn("More From Forbes", content.text)
+
+    def test_prefers_zdnet_article_body_and_drops_podcast_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("zdnet-article.html"),
+            url="https://www.zdnet.com/article/ai-platform-teams-rebuild-around-observability/",
+        )
+
+        self.assertIn("AI platform teams are rebuilding their deployment playbooks around observability", content.text)
+        self.assertIn("documenting more explicit fallback paths and audit checkpoints", content.text)
+        self.assertNotIn("Watch now", content.text)
+        self.assertNotIn("ZDNET Recommends", content.text)
+        self.assertNotIn("Editor's note:", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic multimedia-heavy extraction fixtures for Engadget, Forbes, and ZDNet
- extend source-specific cleanup for video, podcast, audio-summary, and embed-heavy layouts
- bump package metadata and release docs for v1.2.5

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python
