### PR TITLE
release: prepare v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.6] - 2026-04-09
+
+### Added
+
+- Opinion and column-style extraction fixtures for `newyorker.com`, `fortune.com`, and `inc.com`
+
+### Changed
+
+- Package version is now `1.2.6`
+- International extraction coverage now includes opinion, column, and author-driven publisher layouts in addition to standard articles, live updates, briefing pages, and multimedia-heavy pages
+
+### Fixed
+
+- Reduced author bio, premium upsell, newsletter, and most-popular noise on opinion-style publisher pages
+- Locked another class of commentary-heavy media layouts into deterministic fixture coverage so column cleanup regressions are caught in CI
+
 ## [1.2.5] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.5`
+`v1.2.6`
 
 ### Suggested Title
 
-`AI News Open v1.2.5 · Multimedia Extraction Coverage`
+`AI News Open v1.2.6 · Opinion and Column Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.5
+## AI News Open v1.2.6
 
-AI News Open `v1.2.5` hardens extraction quality for multimedia-heavy newsroom layouts across more international publishers.
+AI News Open `v1.2.6` hardens extraction quality for opinion, column, and author-driven newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.5` hardens extraction quality for multimedia-heavy newsroom l
 
 ### Highlights in this release
 
-- New deterministic multimedia extraction fixtures for `Engadget`, `Forbes`, and `ZDNet`
-- Better cleanup for video players, podcast modules, audio summaries, and embed/related CTA blocks on media-heavy publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, and multimedia-heavy layouts
+- New deterministic opinion/column extraction fixtures for `The New Yorker`, `Fortune`, and `Inc.`
+- Better cleanup for author bios, premium upsells, newsletter prompts, and most-popular blocks on commentary-heavy publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, and opinion layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.6.md
+++ b/docs/releases/v1.2.6.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.6
+
+AI News Open `v1.2.6` is a content-quality patch release focused on opinion and column-style newsroom pages. It extends the deterministic extraction suite so author-driven layouts with bios, premium prompts, “most popular” blocks, and newsletter modules are handled with source-specific cleanup instead of relying on generic article heuristics.
+
+### What changed
+
+- Added opinion/column extraction fixtures for:
+  - `newyorker.com`
+  - `fortune.com`
+  - `inc.com`
+- Added host-specific cleanup for author bio modules, premium CTAs, most-popular blocks, and newsletter prompts on those layouts
+- Extended the extraction regression suite to cover another class of commentary-heavy international media pages
+
+### Why this matters
+
+- Opinion and column pages often keep more author metadata, recirculation modules, and premium/newsletter prompts inside the main content container than standard reported articles
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted article text for AI digests
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, and opinion/column layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.5"
+version = "1.2.6"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -203,6 +203,21 @@ HOST_SELECTORS = {
         ".article-body",
         ".c-ShortcodeContent",
     ),
+    "newyorker.com": (
+        ".body__inner-container",
+        ".article__body",
+        ".content-body",
+    ),
+    "fortune.com": (
+        ".article-body",
+        ".paywall",
+        ".content-wrapper",
+    ),
+    "inc.com": (
+        ".article-body",
+        ".article-content",
+        ".single-post-content",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -391,6 +406,27 @@ HOST_DROP_SELECTORS = {
         ".relatedContent",
         ".adSlot",
     ),
+    "newyorker.com": (
+        ".contributors__bio",
+        ".newsletter-promo",
+        ".related-stories",
+        ".podcast-unit",
+        ".most-popular",
+    ),
+    "fortune.com": (
+        ".inline-newsletter",
+        ".most-popular",
+        ".premium-upsell",
+        ".related-content",
+        ".article-footer",
+    ),
+    "inc.com": (
+        ".inline-newsletter",
+        ".author-bio",
+        ".recommended-reading",
+        ".premium-cta",
+        ".article-share",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -534,6 +570,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch now$"),
         re.compile(r"^Editor's note:.*$"),
     ),
+    "newyorker.com": (
+        re.compile(r"^More from The New Yorker$"),
+        re.compile(r"^Listen to this story$"),
+        re.compile(r"^Most Popular$"),
+    ),
+    "fortune.com": (
+        re.compile(r"^Subscribe to Fortune.*$"),
+        re.compile(r"^Most Popular$"),
+        re.compile(r"^Read more from Fortune$"),
+    ),
+    "inc.com": (
+        re.compile(r"^Inc\. Premium$"),
+        re.compile(r"^Recommended Reading$"),
+        re.compile(r"^Subscribe to the newsletter$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -671,6 +722,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"storybody"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"c-shortcodecontent"}},
+    ),
+    "newyorker.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"body__inner-container"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article__body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "fortune.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"paywall"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-wrapper"}},
+    ),
+    "inc.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"single-post-content"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/fortune-column.html
+++ b/tests/fixtures/extraction/fortune-column.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Fortune says AI oversight is moving from policy to operations</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article-body paywall">
+          <p>Fortune reports that AI oversight is moving from policy memos into day-to-day operations as companies connect model behavior to revenue and customer support workflows.</p>
+          <div class="inline-newsletter">
+            <p>Subscribe to Fortune Daily</p>
+          </div>
+          <p>Executives now want to know how a deployment is supervised, who can pause it, and what evidence remains after a model-driven action is reviewed or reversed.</p>
+          <div class="premium-upsell">
+            <p>Read more from Fortune</p>
+          </div>
+          <p>This is making observability, controlled rollback, and explicit review ownership central parts of AI delivery instead of post-launch cleanup.</p>
+        </div>
+        <footer class="article-footer">
+          <p>Most Popular</p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/inc-column.html
+++ b/tests/fixtures/extraction/inc-column.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Inc. says founders are being forced to operationalize AI risk</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="article-body article-content">
+          <p>Inc. reports that founders are being forced to operationalize AI risk because buyers now expect production controls instead of presentation-ready prototypes.</p>
+          <div class="premium-cta">
+            <p>Inc. Premium</p>
+          </div>
+          <p>Teams are being asked how they handle model drift, when a human can intervene, and how quickly a risky workflow can be rolled back without freezing the whole product.</p>
+          <div class="recommended-reading">
+            <p>Recommended Reading</p>
+          </div>
+          <p>That pressure is turning approval paths, auditability, and fallback logic into practical go-to-market requirements for AI startups.</p>
+        </div>
+        <aside class="author-bio">
+          <p>Subscribe to the newsletter</p>
+        </aside>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/newyorker-column.html
+++ b/tests/fixtures/extraction/newyorker-column.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>The New Yorker on why AI governance became product work</title>
+  </head>
+  <body>
+    <main>
+      <article>
+        <div class="body__inner-container article__body">
+          <p>The New Yorker argues that AI governance has quietly become product work because deployment failures now show up in customer-facing systems rather than internal demos.</p>
+          <div class="podcast-unit">
+            <p>Listen to this story</p>
+          </div>
+          <p>That means operators are being judged on whether they can explain a model decision, slow a rollout safely, and document what changed after an incident.</p>
+          <div class="contributors__bio">
+            <p>About the author</p>
+          </div>
+          <p>The strongest teams increasingly treat review queues, approval steps, and rollback design as editorial decisions about product quality as much as technical safeguards.</p>
+        </div>
+        <aside class="most-popular">
+          <p>Most Popular</p>
+        </aside>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -338,6 +338,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("ZDNET Recommends", content.text)
         self.assertNotIn("Editor's note:", content.text)
 
+    def test_prefers_newyorker_column_body_and_drops_author_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("newyorker-column.html"),
+            url="https://www.newyorker.com/news/columnists/why-ai-governance-became-product-work",
+        )
+
+        self.assertIn("AI governance has quietly become product work", content.text)
+        self.assertIn("review queues, approval steps, and rollback design", content.text)
+        self.assertNotIn("Listen to this story", content.text)
+        self.assertNotIn("About the author", content.text)
+        self.assertNotIn("Most Popular", content.text)
+
+    def test_prefers_fortune_column_body_and_drops_promo_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("fortune-column.html"),
+            url="https://fortune.com/2026/04/09/ai-oversight-moving-from-policy-to-operations/",
+        )
+
+        self.assertIn("AI oversight is moving from policy memos into day-to-day operations", content.text)
+        self.assertIn("observability, controlled rollback, and explicit review ownership", content.text)
+        self.assertNotIn("Subscribe to Fortune Daily", content.text)
+        self.assertNotIn("Read more from Fortune", content.text)
+        self.assertNotIn("Most Popular", content.text)
+
+    def test_prefers_inc_column_body_and_drops_premium_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("inc-column.html"),
+            url="https://www.inc.com/2026/04/09/founders-forced-to-operationalize-ai-risk.html",
+        )
+
+        self.assertIn("founders are being forced to operationalize AI risk", content.text)
+        self.assertIn("approval paths, auditability, and fallback logic", content.text)
+        self.assertNotIn("Inc. Premium", content.text)
+        self.assertNotIn("Recommended Reading", content.text)
+        self.assertNotIn("Subscribe to the newsletter", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add opinion and column-style extraction fixtures for The New Yorker, Fortune, and Inc.
- extend source-specific cleanup for author bio, premium, newsletter, and most-popular noise
- bump package metadata and release notes for v1.2.6

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v