### PR TITLE
release: prepare v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.7] - 2026-04-09
+
+### Added
+
+- Paywall-heavy extraction fixtures for `bloomberg.com`, `wsj.com`, and `economist.com`
+
+### Changed
+
+- Package version is now `1.2.7`
+- International extraction coverage now includes paywall- and subscriber-prompt-heavy newsroom layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, and opinion/column layouts
+
+### Fixed
+
+- Reduced subscription prompts, audio/listen modules, and recirculation noise on paywall-heavy publisher pages
+- Locked another class of premium-news publisher layouts into deterministic fixture coverage so paywall cleanup regressions are caught in CI
+
 ## [1.2.6] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.6`
+`v1.2.7`
 
 ### Suggested Title
 
-`AI News Open v1.2.6 · Opinion and Column Extraction Coverage`
+`AI News Open v1.2.7 · Paywall-Heavy Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.6
+## AI News Open v1.2.7
 
-AI News Open `v1.2.6` hardens extraction quality for opinion, column, and author-driven newsroom layouts across more international publishers.
+AI News Open `v1.2.7` hardens extraction quality for paywall-heavy and subscriber-prompt-heavy newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.6` hardens extraction quality for opinion, column, and author
 
 ### Highlights in this release
 
-- New deterministic opinion/column extraction fixtures for `The New Yorker`, `Fortune`, and `Inc.`
-- Better cleanup for author bios, premium upsells, newsletter prompts, and most-popular blocks on commentary-heavy publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, and opinion layouts
+- New deterministic paywall-heavy extraction fixtures for `Bloomberg`, `The Wall Street Journal`, and `The Economist`
+- Better cleanup for subscription prompts, audio/listen modules, and read-next recirculation blocks on premium publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, and paywall-heavy layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.7.md
+++ b/docs/releases/v1.2.7.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.7
+
+AI News Open `v1.2.7` is a content-quality patch release focused on paywall-heavy international publisher layouts. It extends the deterministic extraction suite so subscription prompts, audio modules, and premium recirculation blocks are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added paywall-heavy extraction fixtures for:
+  - `bloomberg.com`
+  - `wsj.com`
+  - `economist.com`
+- Added host-specific cleanup for subscription prompts, audio/listen modules, and premium recirculation blocks on those layouts
+- Extended the extraction regression suite to cover another class of subscriber-prompt-heavy international media pages
+
+### Why this matters
+
+- Premium publisher pages often keep login prompts, listen modules, and “read next” elements inside or adjacent to the same container as the readable article body
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, and paywall-heavy layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.6"
+version = "1.2.7"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -218,6 +218,21 @@ HOST_SELECTORS = {
         ".article-content",
         ".single-post-content",
     ),
+    "bloomberg.com": (
+        ".body-copy-v2",
+        ".article-body",
+        ".paywall-content",
+    ),
+    "wsj.com": (
+        ".wsj-snippet-body",
+        ".article-content",
+        ".paywall",
+    ),
+    "economist.com": (
+        ".article__body-text",
+        ".layout-article-body",
+        ".article-text",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -427,6 +442,27 @@ HOST_DROP_SELECTORS = {
         ".premium-cta",
         ".article-share",
     ),
+    "bloomberg.com": (
+        ".terminal-promo",
+        ".signup-banner",
+        ".read-next",
+        ".up-next",
+        ".inline-newsletter",
+    ),
+    "wsj.com": (
+        ".snippet-promotion",
+        ".login-prompt",
+        ".related-coverage",
+        ".audio-player",
+        ".article-share",
+    ),
+    "economist.com": (
+        ".subscription-prompt",
+        ".podcast-promo",
+        ".related-reading",
+        ".newsletter-signup",
+        ".article-share",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -585,6 +621,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Recommended Reading$"),
         re.compile(r"^Subscribe to the newsletter$"),
     ),
+    "bloomberg.com": (
+        re.compile(r"^Before it's here, it's on the Bloomberg Terminal\.$"),
+        re.compile(r"^Read next$"),
+        re.compile(r"^Sign up for the New Economy Daily$"),
+    ),
+    "wsj.com": (
+        re.compile(r"^Listen to article$"),
+        re.compile(r"^Continue reading your article with a WSJ subscription$"),
+        re.compile(r"^Recommended Videos$"),
+    ),
+    "economist.com": (
+        re.compile(r"^Subscribers only$"),
+        re.compile(r"^Listen to this episode$"),
+        re.compile(r"^Read more from this section$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -737,6 +788,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"single-post-content"}},
+    ),
+    "bloomberg.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"body-copy-v2"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"paywall-content"}},
+    ),
+    "wsj.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"wsj-snippet-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"paywall"}},
+    ),
+    "economist.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article__body-text"}},
+        {"tags": {"div", "section"}, "class_tokens": {"layout-article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-text"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/bloomberg-paywall.html
+++ b/tests/fixtures/extraction/bloomberg-paywall.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI governance shifts into operations - Bloomberg</title>
+  </head>
+  <body>
+    <main>
+      <section class="body-copy-v2">
+        <p>AI governance is moving out of policy decks and into operating routines inside enterprise teams.</p>
+        <p>Bloomberg reports that buyers now ask who can pause a rollout, who signs off on changes, and how incidents are reviewed.</p>
+        <div class="terminal-promo">Before it's here, it's on the Bloomberg Terminal.</div>
+        <p>That pushes platform groups toward workflow review points, rollback ownership, and incident drills instead of slideware.</p>
+        <div class="signup-banner">Sign up for the New Economy Daily</div>
+        <p>Executives increasingly treat AI deployment discipline as a measurable operating capability rather than a research milestone.</p>
+        <div class="read-next">Read next</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/economist-paywall.html
+++ b/tests/fixtures/extraction/economist-paywall.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Why AI operations now look like risk management - The Economist</title>
+  </head>
+  <body>
+    <main>
+      <section class="article__body-text">
+        <p>AI operations now resemble risk management more than experimental prototyping at large companies.</p>
+        <div class="subscription-prompt">Subscribers only</div>
+        <p>The Economist argues that deployment controls, auditable approval paths, and fallback procedures are replacing informal launch decisions.</p>
+        <div class="podcast-promo">Listen to this episode</div>
+        <p>Firms that once celebrated shipping quickly are increasingly rewarded for documenting who can override a system and when it must roll back.</p>
+        <div class="related-reading">Read more from this section</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/wsj-paywall.html
+++ b/tests/fixtures/extraction/wsj-paywall.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Companies turn AI oversight into daily operations - WSJ</title>
+  </head>
+  <body>
+    <article>
+      <div class="wsj-snippet-body">
+        <p>Companies are treating AI oversight as a daily operating system problem rather than a quarterly policy discussion.</p>
+        <div class="audio-player">Listen to article</div>
+        <p>The Wall Street Journal describes teams that now embed procurement checks, approval queues, and post-incident review into every deployment path.</p>
+        <div class="login-prompt">Continue reading your article with a WSJ subscription</div>
+        <p>Managers increasingly want named owners for exceptions, rollback triggers, and escalation routes when model behavior changes in production.</p>
+        <div class="related-coverage">Recommended Videos</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -377,6 +377,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Recommended Reading", content.text)
         self.assertNotIn("Subscribe to the newsletter", content.text)
 
+    def test_prefers_bloomberg_paywall_body_and_drops_terminal_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("bloomberg-paywall.html"),
+            url="https://www.bloomberg.com/news/articles/2026-04-09/ai-governance-shifts-into-operations",
+        )
+
+        self.assertIn("AI governance is moving out of policy decks and into operating routines", content.text)
+        self.assertIn("workflow review points, rollback ownership, and incident drills", content.text)
+        self.assertNotIn("Before it's here, it's on the Bloomberg Terminal.", content.text)
+        self.assertNotIn("Read next", content.text)
+        self.assertNotIn("Sign up for the New Economy Daily", content.text)
+
+    def test_prefers_wsj_paywall_body_and_drops_subscription_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("wsj-paywall.html"),
+            url="https://www.wsj.com/tech/ai/companies-turn-ai-oversight-into-daily-operations-12345678",
+        )
+
+        self.assertIn("Companies are treating AI oversight as a daily operating system problem", content.text)
+        self.assertIn("procurement checks, approval queues, and post-incident review", content.text)
+        self.assertNotIn("Continue reading your article with a WSJ subscription", content.text)
+        self.assertNotIn("Listen to article", content.text)
+        self.assertNotIn("Recommended Videos", content.text)
+
+    def test_prefers_economist_body_and_drops_subscriber_audio_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("economist-paywall.html"),
+            url="https://www.economist.com/business/2026/04/09/why-ai-operations-now-look-like-risk-management",
+        )
+
+        self.assertIn("AI operations now resemble risk management more than experimental prototyping", content.text)
+        self.assertIn("deployment controls, auditable approval paths, and fallback procedures", content.text)
+        self.assertNotIn("Subscribers only", content.text)
+        self.assertNotIn("Listen to this episode", content.text)
+        self.assertNotIn("Read more from this section", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add paywall-heavy extraction fixtures for Bloomberg, WSJ, and The Economist
- extend source-specific cleanup for subscription prompts, audio modules, and premium recirculation noise
- bump package metadata and release notes for v1.2.7

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v