### PR TITLE
release: prepare v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.8] - 2026-04-09
+
+### Added
+
+- Explainer and guide-style extraction fixtures for `cnn.com`, `nytimes.com`, and `washingtonpost.com`
+
+### Changed
+
+- Package version is now `1.2.8`
+- International extraction coverage now includes FAQ-, explainer-, and guide-style newsroom layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, and paywall-heavy layouts
+
+### Fixed
+
+- Reduced listen/audio prompts, newsletter modules, gift offers, and related-coverage noise on explainer-style publisher pages
+- Locked another class of newsroom Q&A and guide layouts into deterministic fixture coverage so explainer cleanup regressions are caught in CI
+
 ## [1.2.7] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.7`
+`v1.2.8`
 
 ### Suggested Title
 
-`AI News Open v1.2.7 · Paywall-Heavy Extraction Coverage`
+`AI News Open v1.2.8 · Explainer and Guide Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.7
+## AI News Open v1.2.8
 
-AI News Open `v1.2.7` hardens extraction quality for paywall-heavy and subscriber-prompt-heavy newsroom layouts across more international publishers.
+AI News Open `v1.2.8` hardens extraction quality for explainer, FAQ, and guide-style newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.7` hardens extraction quality for paywall-heavy and subscribe
 
 ### Highlights in this release
 
-- New deterministic paywall-heavy extraction fixtures for `Bloomberg`, `The Wall Street Journal`, and `The Economist`
-- Better cleanup for subscription prompts, audio/listen modules, and read-next recirculation blocks on premium publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, and paywall-heavy layouts
+- New deterministic explainer/guide extraction fixtures for `CNN`, `The New York Times`, and `The Washington Post`
+- Better cleanup for audio/listen prompts, gift offers, related-coverage blocks, and newsletter modules on service-journalism-heavy publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, and explainer/guide layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.8.md
+++ b/docs/releases/v1.2.8.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.8
+
+AI News Open `v1.2.8` is a content-quality patch release focused on explainer, FAQ, and guide-style newsroom pages. It extends the deterministic extraction suite so listen prompts, gift offers, related-coverage blocks, and newsletter modules are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added explainer/guide extraction fixtures for:
+  - `cnn.com`
+  - `nytimes.com`
+  - `washingtonpost.com`
+- Added host-specific cleanup for audio/listen prompts, gift offers, related-coverage blocks, and newsletter modules on those layouts
+- Extended the extraction regression suite to cover another class of explainer-heavy international media pages
+
+### Why this matters
+
+- Explainer and guide pages often mix article text with inline service journalism modules, recirculation, and subscription prompts inside the main reading container
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, and explainer/guide layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.7"
+version = "1.2.8"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -233,6 +233,21 @@ HOST_SELECTORS = {
         ".layout-article-body",
         ".article-text",
     ),
+    "cnn.com": (
+        ".article__content",
+        ".article__main",
+        ".wysiwyg",
+    ),
+    "nytimes.com": (
+        ".StoryBodyCompanionColumn",
+        ".article-body",
+        ".css-at9mc1",
+    ),
+    "washingtonpost.com": (
+        ".article-body",
+        ".story-body",
+        ".article-body-content",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -463,6 +478,27 @@ HOST_DROP_SELECTORS = {
         ".newsletter-signup",
         ".article-share",
     ),
+    "cnn.com": (
+        ".relateds",
+        ".newsletter__container",
+        ".video-resource",
+        ".article__footer",
+        ".zone--recommendations",
+    ),
+    "nytimes.com": (
+        ".newsletter-promo",
+        ".related-coverage",
+        ".css-1bd8bfl",
+        ".css-1r7ky0e",
+        ".audio-control",
+    ),
+    "washingtonpost.com": (
+        ".gift-prompt",
+        ".newsletter-inline",
+        ".related-story-list",
+        ".audio-player",
+        ".story-footer",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -636,6 +672,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Listen to this episode$"),
         re.compile(r"^Read more from this section$"),
     ),
+    "cnn.com": (
+        re.compile(r"^Watch this interactive$"),
+        re.compile(r"^Read more from CNN$"),
+        re.compile(r"^Sign up for our newsletter$"),
+    ),
+    "nytimes.com": (
+        re.compile(r"^Listen to this article$"),
+        re.compile(r"^More on A\.I\.$"),
+        re.compile(r"^Advertisement$"),
+    ),
+    "washingtonpost.com": (
+        re.compile(r"^Listen$"),
+        re.compile(r"^Try 1 month for \$1$"),
+        re.compile(r"^Read more from The Post$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -803,6 +854,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article__body-text"}},
         {"tags": {"div", "section"}, "class_tokens": {"layout-article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-text"}},
+    ),
+    "cnn.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article__main"}},
+        {"tags": {"div", "section"}, "class_tokens": {"wysiwyg"}},
+    ),
+    "nytimes.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"storybodycompanioncolumn"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"css-at9mc1"}},
+    ),
+    "washingtonpost.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"story-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body-content"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/cnn-explainer.html
+++ b/tests/fixtures/extraction/cnn-explainer.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Why AI operations now matter - CNN</title>
+  </head>
+  <body>
+    <main>
+      <section class="article__content">
+        <p>AI oversight is becoming a repeatable operating procedure instead of a one-time model review.</p>
+        <div class="video-resource">Watch this interactive</div>
+        <p>CNN explains that enterprise teams increasingly ask who can pause a rollout, how incidents are reviewed, and what evidence is kept after a failure.</p>
+        <div class="relateds">Read more from CNN</div>
+        <p>That shift puts review queues, rollback drills, and named escalation owners at the center of AI deployment work.</p>
+        <div class="newsletter__container">Sign up for our newsletter</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/nytimes-explainer.html
+++ b/tests/fixtures/extraction/nytimes-explainer.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Why AI operations now matter - The New York Times</title>
+  </head>
+  <body>
+    <article>
+      <section class="StoryBodyCompanionColumn">
+        <p>AI systems now demand operating discipline after launch, not just impressive demos before release.</p>
+        <div class="audio-control">Listen to this article</div>
+        <p>The New York Times describes how companies are formalizing approval chains, fallback procedures, and post-incident review for production models.</p>
+        <div class="related-coverage">More on A.I.</div>
+        <p>That guide-style thinking reflects a broader move from experimentation toward routine control, escalation, and oversight.</p>
+        <div class="css-1bd8bfl">Advertisement</div>
+      </section>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/washingtonpost-guide.html
+++ b/tests/fixtures/extraction/washingtonpost-guide.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>How companies are writing AI operations guidebooks - The Washington Post</title>
+  </head>
+  <body>
+    <main>
+      <div class="article-body">
+        <p>AI deployment teams are building guidebooks instead of one-off launch plans as their systems become harder to supervise.</p>
+        <div class="gift-prompt">Try 1 month for $1</div>
+        <p>The Washington Post reports that operators are now documenting failure thresholds, human review, and rollback ownership before broad release.</p>
+        <div class="audio-player">Listen</div>
+        <p>Those internal guides increasingly spell out who can halt a model, when users are notified, and how incidents are escalated.</p>
+        <div class="related-story-list">Read more from The Post</div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -416,6 +416,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Listen to this episode", content.text)
         self.assertNotIn("Read more from this section", content.text)
 
+    def test_prefers_cnn_explainer_body_and_drops_newsletter_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("cnn-explainer.html"),
+            url="https://www.cnn.com/2026/04/09/tech/ai-explainer-operations-guide/index.html",
+        )
+
+        self.assertIn("AI oversight is becoming a repeatable operating procedure", content.text)
+        self.assertIn("review queues, rollback drills, and named escalation owners", content.text)
+        self.assertNotIn("Watch this interactive", content.text)
+        self.assertNotIn("Read more from CNN", content.text)
+        self.assertNotIn("Sign up for our newsletter", content.text)
+
+    def test_prefers_nytimes_explainer_body_and_drops_audio_and_ad_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("nytimes-explainer.html"),
+            url="https://www.nytimes.com/2026/04/09/technology/ai-explainer-why-operations-now-matter.html",
+        )
+
+        self.assertIn("AI systems now demand operating discipline after launch", content.text)
+        self.assertIn("approval chains, fallback procedures, and post-incident review", content.text)
+        self.assertNotIn("Listen to this article", content.text)
+        self.assertNotIn("More on A.I.", content.text)
+        self.assertNotIn("Advertisement", content.text)
+
+    def test_prefers_washingtonpost_guide_body_and_drops_gift_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("washingtonpost-guide.html"),
+            url="https://www.washingtonpost.com/technology/2026/04/09/ai-operations-guide/",
+        )
+
+        self.assertIn("AI deployment teams are building guidebooks instead of one-off launch plans", content.text)
+        self.assertIn("documenting failure thresholds, human review, and rollback ownership", content.text)
+        self.assertNotIn("Try 1 month for $1", content.text)
+        self.assertNotIn("Listen", content.text)
+        self.assertNotIn("Read more from The Post", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add explainer and guide-style extraction fixtures for CNN, The New York Times, and The Washington Post
- extend source-specific cleanup for audio prompts, newsletter blocks, gift offers, and related coverage noise
- bump package metadata and release notes for v1.2.8

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v