### PR TITLE
release: prepare v1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.9] - 2026-04-09
+
+### Added
+
+- Roundup and what-to-know extraction fixtures for `vox.com`, `time.com`, and `nbcnews.com`
+
+### Changed
+
+- Package version is now `1.2.9`
+- International extraction coverage now includes roundup-, list-, and what-to-know-style newsroom layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, and explainer/guide layouts
+
+### Fixed
+
+- Reduced newsletter cards, read-next recirculation, video prompts, and related-coverage noise on roundup-style publisher pages
+- Locked another class of list-heavy newsroom layouts into deterministic fixture coverage so roundup cleanup regressions are caught in CI
+
 ## [1.2.8] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.8`
+`v1.2.9`
 
 ### Suggested Title
 
-`AI News Open v1.2.8 · Explainer and Guide Extraction Coverage`
+`AI News Open v1.2.9 · Roundup and What-to-Know Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.8
+## AI News Open v1.2.9
 
-AI News Open `v1.2.8` hardens extraction quality for explainer, FAQ, and guide-style newsroom layouts across more international publishers.
+AI News Open `v1.2.9` hardens extraction quality for roundup, list, and what-to-know newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.8` hardens extraction quality for explainer, FAQ, and guide-s
 
 ### Highlights in this release
 
-- New deterministic explainer/guide extraction fixtures for `CNN`, `The New York Times`, and `The Washington Post`
-- Better cleanup for audio/listen prompts, gift offers, related-coverage blocks, and newsletter modules on service-journalism-heavy publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, and explainer/guide layouts
+- New deterministic roundup / what-to-know extraction fixtures for `Vox`, `TIME`, and `NBC News`
+- Better cleanup for newsletter cards, read-next recirculation, video prompts, and related-coverage blocks on list-heavy publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, and roundup/what-to-know layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.9.md
+++ b/docs/releases/v1.2.9.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.9
+
+AI News Open `v1.2.9` is a content-quality patch release focused on roundup, list, and what-to-know newsroom pages. It extends the deterministic extraction suite so newsletter cards, read-next modules, video prompts, and related-coverage blocks are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added roundup / what-to-know extraction fixtures for:
+  - `vox.com`
+  - `time.com`
+  - `nbcnews.com`
+- Added host-specific cleanup for newsletter cards, read-next modules, video prompts, and related-coverage blocks on those layouts
+- Extended the extraction regression suite to cover another class of list-heavy international media pages
+
+### Why this matters
+
+- Roundup pages often mix bullet-style analysis with recirculation modules, newsletter calls, and “what to read next” blocks inside the main content container
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, and roundup/what-to-know layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.8"
+version = "1.2.9"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -248,6 +248,21 @@ HOST_SELECTORS = {
         ".story-body",
         ".article-body-content",
     ),
+    "vox.com": (
+        ".duet--article--article-body-component",
+        ".c-entry-content",
+        ".article-body",
+    ),
+    "time.com": (
+        ".article-body__content",
+        ".body-wrapper",
+        ".article-content",
+    ),
+    "nbcnews.com": (
+        ".article-body",
+        ".article-body__content",
+        ".article-content",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -499,6 +514,27 @@ HOST_DROP_SELECTORS = {
         ".audio-player",
         ".story-footer",
     ),
+    "vox.com": (
+        ".duet--recirculation--related-card-list",
+        ".newsletter-signup",
+        ".duet--media--embed",
+        ".c-entry-box--compact",
+        ".duet--article--inline-newsletter",
+    ),
+    "time.com": (
+        ".newsletter-card",
+        ".related-articles",
+        ".inline-audio",
+        ".what-to-read-next",
+        ".article-footer",
+    ),
+    "nbcnews.com": (
+        ".related-content",
+        ".newsletter-inline",
+        ".video-player",
+        ".article-share",
+        ".what-to-know",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -687,6 +723,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Try 1 month for \$1$"),
         re.compile(r"^Read more from The Post$"),
     ),
+    "vox.com": (
+        re.compile(r"^Most Popular$"),
+        re.compile(r"^Sign up for the newsletter$"),
+        re.compile(r"^Read More Vox coverage$"),
+    ),
+    "time.com": (
+        re.compile(r"^Listen to the story$"),
+        re.compile(r"^What to read next$"),
+        re.compile(r"^Subscribe to the Time newsletter$"),
+    ),
+    "nbcnews.com": (
+        re.compile(r"^Watch more from NBC News$"),
+        re.compile(r"^Sign up for our newsletters$"),
+        re.compile(r"^Related coverage$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -869,6 +920,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"story-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body-content"}},
+    ),
+    "vox.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"duet--article--article-body-component"}},
+        {"tags": {"div", "section"}, "class_tokens": {"c-entry-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "time.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"body-wrapper"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+    ),
+    "nbcnews.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/nbcnews-roundup.html
+++ b/tests/fixtures/extraction/nbcnews-roundup.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>What to know about AI operations - NBC News</title>
+  </head>
+  <body>
+    <main>
+      <section class="article-body">
+        <p>AI operators are spending more time on supervision than on launch-day demos as systems move into wider use.</p>
+        <div class="video-player">Watch more from NBC News</div>
+        <p>NBC News reports that companies increasingly want documented guardrails, human review, and clear rollback thresholds before scaling assistants.</p>
+        <div class="newsletter-inline">Sign up for our newsletters</div>
+        <p>That makes “what to know” coverage look more like an operating playbook than a product recap.</p>
+        <div class="related-content">Related coverage</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/time-roundup.html
+++ b/tests/fixtures/extraction/time-roundup.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>What to know about enterprise AI operations - TIME</title>
+  </head>
+  <body>
+    <article>
+      <div class="article-body__content">
+        <p>AI adoption now depends less on model novelty and more on operating discipline after release.</p>
+        <div class="inline-audio">Listen to the story</div>
+        <p>TIME reports that teams increasingly formalize approval queues, fallback plans, and incident ownership before expanding access to new tools.</p>
+        <div class="what-to-read-next">What to read next</div>
+        <p>Those roundup-style guides now emphasize operational readiness as much as benchmark performance.</p>
+        <div class="newsletter-card">Subscribe to the Time newsletter</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/vox-roundup.html
+++ b/tests/fixtures/extraction/vox-roundup.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>What to know about AI operations this week - Vox</title>
+  </head>
+  <body>
+    <main>
+      <section class="duet--article--article-body-component">
+        <p>AI teams are increasingly judged on the quality of their operating routines rather than on a single launch announcement.</p>
+        <div class="duet--recirculation--related-card-list">Read More Vox coverage</div>
+        <p>Vox notes that leaders now compare observability reviews, rollback drills, and named escalation paths when choosing vendors and internal platforms.</p>
+        <div class="newsletter-signup">Sign up for the newsletter</div>
+        <p>That shift turns weekly AI roundups into operating checklists for procurement, oversight, and incident response.</p>
+        <div class="c-entry-box--compact">Most Popular</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -455,6 +455,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Listen", content.text)
         self.assertNotIn("Read more from The Post", content.text)
 
+    def test_prefers_vox_roundup_body_and_drops_recirculation_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("vox-roundup.html"),
+            url="https://www.vox.com/technology/2026/04/09/ai-what-to-know-this-week",
+        )
+
+        self.assertIn("AI teams are increasingly judged on the quality of their operating routines", content.text)
+        self.assertIn("observability reviews, rollback drills, and named escalation paths", content.text)
+        self.assertNotIn("Most Popular", content.text)
+        self.assertNotIn("Sign up for the newsletter", content.text)
+        self.assertNotIn("Read More Vox coverage", content.text)
+
+    def test_prefers_time_roundup_body_and_drops_audio_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("time-roundup.html"),
+            url="https://time.com/7270012/ai-what-to-know-enterprise-operations/",
+        )
+
+        self.assertIn("AI adoption now depends less on model novelty and more on operating discipline", content.text)
+        self.assertIn("approval queues, fallback plans, and incident ownership", content.text)
+        self.assertNotIn("Listen to the story", content.text)
+        self.assertNotIn("What to read next", content.text)
+        self.assertNotIn("Subscribe to the Time newsletter", content.text)
+
+    def test_prefers_nbcnews_roundup_body_and_drops_related_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("nbcnews-roundup.html"),
+            url="https://www.nbcnews.com/tech/ai/what-to-know-about-ai-operations-rcna123456",
+        )
+
+        self.assertIn("AI operators are spending more time on supervision than on launch-day demos", content.text)
+        self.assertIn("documented guardrails, human review, and clear rollback thresholds", content.text)
+        self.assertNotIn("Watch more from NBC News", content.text)
+        self.assertNotIn("Sign up for our newsletters", content.text)
+        self.assertNotIn("Related coverage", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add roundup and what-to-know extraction fixtures for Vox, TIME, and NBC News
- extend source-specific cleanup for newsletter cards, video prompts, read-next recirculation, and related coverage noise
- bump package metadata and release notes for v1.2.9

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v