### PR TITLE
release: prepare v1.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.10] - 2026-04-09
+
+### Added
+
+- Interview, transcript, and Q&A extraction fixtures for `fastcompany.com`, `businessinsider.com`, and `spectrum.ieee.org`
+
+### Changed
+
+- Package version is now `1.2.10`
+- International extraction coverage now includes interview-, transcript-, and Q&A-style newsroom layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, and roundup/what-to-know layouts
+
+### Fixed
+
+- Reduced inline audio prompts, author/promo modules, and read-next noise on interview-style publisher pages
+- Locked another class of speaker-label-heavy newsroom layouts into deterministic fixture coverage so transcript cleanup regressions are caught in CI
+
 ## [1.2.9] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.9`
+`v1.2.10`
 
 ### Suggested Title
 
-`AI News Open v1.2.9 · Roundup and What-to-Know Extraction Coverage`
+`AI News Open v1.2.10 · Interview and Transcript Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.9
+## AI News Open v1.2.10
 
-AI News Open `v1.2.9` hardens extraction quality for roundup, list, and what-to-know newsroom layouts across more international publishers.
+AI News Open `v1.2.10` hardens extraction quality for interview, transcript, and Q&A newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.9` hardens extraction quality for roundup, list, and what-to-
 
 ### Highlights in this release
 
-- New deterministic roundup / what-to-know extraction fixtures for `Vox`, `TIME`, and `NBC News`
-- Better cleanup for newsletter cards, read-next recirculation, video prompts, and related-coverage blocks on list-heavy publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, and roundup/what-to-know layouts
+- New deterministic interview / transcript extraction fixtures for `Fast Company`, `Business Insider`, and `IEEE Spectrum`
+- Better cleanup for inline audio prompts, read-next modules, and promo blocks on speaker-label-heavy publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, and interview/transcript layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.10.md
+++ b/docs/releases/v1.2.10.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.10
+
+AI News Open `v1.2.10` is a content-quality patch release focused on interview, transcript, and Q&A newsroom pages. It extends the deterministic extraction suite so inline audio prompts, read-next modules, and author or subscription promos are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added interview / transcript / Q&A extraction fixtures for:
+  - `fastcompany.com`
+  - `businessinsider.com`
+  - `spectrum.ieee.org`
+- Added host-specific cleanup for inline audio prompts, read-next modules, and newsletter or promo blocks on those layouts
+- Extended the extraction regression suite to cover another class of speaker-label-heavy international media pages
+
+### Why this matters
+
+- Interview and transcript pages often mix speaker labels, subscription prompts, and recirculation modules inside the same reading container as the actual conversation
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, and interview/transcript layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.9"
+version = "1.2.10"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -263,6 +263,21 @@ HOST_SELECTORS = {
         ".article-body__content",
         ".article-content",
     ),
+    "fastcompany.com": (
+        ".article-body",
+        ".prose",
+        ".content-body",
+    ),
+    "businessinsider.com": (
+        ".content-lock-content",
+        ".article-body",
+        ".post-content",
+    ),
+    "spectrum.ieee.org": (
+        ".article-main__content",
+        ".article-body",
+        ".content-body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -535,6 +550,27 @@ HOST_DROP_SELECTORS = {
         ".article-share",
         ".what-to-know",
     ),
+    "fastcompany.com": (
+        ".newsletter-inline",
+        ".related-links",
+        ".audio-player",
+        ".author-bio",
+        ".article-footer",
+    ),
+    "businessinsider.com": (
+        ".signup-inline",
+        ".read-more-list",
+        ".audio-control",
+        ".author-card",
+        ".premium-upsell",
+    ),
+    "spectrum.ieee.org": (
+        ".podcast-player",
+        ".newsletter-signup",
+        ".related-articles",
+        ".author-card",
+        ".article-footer",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -738,6 +774,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Sign up for our newsletters$"),
         re.compile(r"^Related coverage$"),
     ),
+    "fastcompany.com": (
+        re.compile(r"^Listen to the interview$"),
+        re.compile(r"^Read more from Fast Company$"),
+        re.compile(r"^Sign up for the newsletter$"),
+    ),
+    "businessinsider.com": (
+        re.compile(r"^Read next$"),
+        re.compile(r"^Get Business Insider intelligence in your inbox$"),
+        re.compile(r"^Listen to the conversation$"),
+    ),
+    "spectrum.ieee.org": (
+        re.compile(r"^Listen to this episode$"),
+        re.compile(r"^More from IEEE Spectrum$"),
+        re.compile(r"^Subscribe to our newsletters$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -935,6 +986,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body__content"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+    ),
+    "fastcompany.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "businessinsider.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"content-lock-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+    ),
+    "spectrum.ieee.org": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-main__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/businessinsider-qa.html
+++ b/tests/fixtures/extraction/businessinsider-qa.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>Why governance became an operations problem - Business Insider</title>
+  </head>
+  <body>
+    <article>
+      <div class="content-lock-content">
+        <p>Q: What changed once companies moved AI tools into regular workflows?</p>
+        <p>A: Teams started tracking review ownership, exception paths, and rollback triggers.</p>
+        <div class="audio-control">Listen to the conversation</div>
+        <p>Q: What do buyers ask about now?</p>
+        <p>A: They want evidence that incidents are logged, people can intervene, and operators know when to halt a rollout.</p>
+        <div class="read-more-list">Read next</div>
+        <div class="signup-inline">Get Business Insider intelligence in your inbox</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/fastcompany-interview.html
+++ b/tests/fixtures/extraction/fastcompany-interview.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>AI operations interview - Fast Company</title>
+  </head>
+  <body>
+    <main>
+      <section class="article-body">
+        <p>Interviewers increasingly ask AI operators how they handle failure after launch instead of how quickly they can ship.</p>
+        <div class="audio-player">Listen to the interview</div>
+        <p>Fast Company reports that teams now describe approval ladders, rollback drills, and incident notes as core parts of product readiness.</p>
+        <div class="related-links">Read more from Fast Company</div>
+        <p>Those answers increasingly matter more than model demos when buyers judge whether a system is trustworthy in day-to-day use.</p>
+        <div class="newsletter-inline">Sign up for the newsletter</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/ieee-spectrum-transcript.html
+++ b/tests/fixtures/extraction/ieee-spectrum-transcript.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI operations transcript - IEEE Spectrum</title>
+  </head>
+  <body>
+    <main>
+      <section class="article-main__content">
+        <p>Q: Why are companies treating AI operations as a governance problem now?</p>
+        <div class="podcast-player">Listen to this episode</div>
+        <p>A: Because production systems need documented fallback plans and accountable human review.</p>
+        <p>Q: What separates mature teams from the rest?</p>
+        <p>A: Mature teams define who can approve changes, who can roll them back, and how incidents are reviewed after the fact.</p>
+        <div class="related-articles">More from IEEE Spectrum</div>
+        <div class="newsletter-signup">Subscribe to our newsletters</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -494,6 +494,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Sign up for our newsletters", content.text)
         self.assertNotIn("Related coverage", content.text)
 
+    def test_prefers_fastcompany_interview_body_and_drops_newsletter_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("fastcompany-interview.html"),
+            url="https://www.fastcompany.com/2026/04/09/ai-operations-interview",
+        )
+
+        self.assertIn("Interviewers increasingly ask AI operators how they handle failure after launch", content.text)
+        self.assertIn("approval ladders, rollback drills, and incident notes", content.text)
+        self.assertNotIn("Listen to the interview", content.text)
+        self.assertNotIn("Read more from Fast Company", content.text)
+        self.assertNotIn("Sign up for the newsletter", content.text)
+
+    def test_prefers_businessinsider_qa_body_and_drops_promo_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("businessinsider-qa.html"),
+            url="https://www.businessinsider.com/ai-ops-qa-why-governance-became-an-operations-problem-2026-4",
+        )
+
+        self.assertIn("Q: What changed once companies moved AI tools into regular workflows?", content.text)
+        self.assertIn("A: Teams started tracking review ownership, exception paths, and rollback triggers.", content.text)
+        self.assertNotIn("Read next", content.text)
+        self.assertNotIn("Get Business Insider intelligence in your inbox", content.text)
+        self.assertNotIn("Listen to the conversation", content.text)
+
+    def test_prefers_ieee_spectrum_transcript_body_and_drops_audio_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("ieee-spectrum-transcript.html"),
+            url="https://spectrum.ieee.org/ai-operations-transcript",
+        )
+
+        self.assertIn("Q: Why are companies treating AI operations as a governance problem now?", content.text)
+        self.assertIn("A: Because production systems need documented fallback plans and accountable human review.", content.text)
+        self.assertNotIn("Listen to this episode", content.text)
+        self.assertNotIn("More from IEEE Spectrum", content.text)
+        self.assertNotIn("Subscribe to our newsletters", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add interview, transcript, and Q&A extraction fixtures for Fast Company, Business Insider, and IEEE Spectrum
- extend source-specific cleanup for inline audio prompts, read-next modules, and promo blocks
- bump package metadata and release notes for v1.2.10

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v