### PR TITLE
release: prepare v1.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.11] - 2026-04-09
+
+### Added
+
+- Longform analysis and essay extraction fixtures for `theatlantic.com`, `foreignpolicy.com`, and `newstatesman.com`
+
+### Changed
+
+- Package version is now `1.2.11`
+- International extraction coverage now includes analysis-, essay-, and longform-feature-style newsroom layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, and interview/transcript layouts
+
+### Fixed
+
+- Reduced audio prompts, recirculation modules, and subscription or newsletter noise on longform publisher pages
+- Locked another class of essay-heavy newsroom layouts into deterministic fixture coverage so longform cleanup regressions are caught in CI
+
 ## [1.2.10] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.10`
+`v1.2.11`
 
 ### Suggested Title
 
-`AI News Open v1.2.10 · Interview and Transcript Extraction Coverage`
+`AI News Open v1.2.11 · Longform Analysis Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.10
+## AI News Open v1.2.11
 
-AI News Open `v1.2.10` hardens extraction quality for interview, transcript, and Q&A newsroom layouts across more international publishers.
+AI News Open `v1.2.11` hardens extraction quality for analysis-, essay-, and longform-feature newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.10` hardens extraction quality for interview, transcript, and
 
 ### Highlights in this release
 
-- New deterministic interview / transcript extraction fixtures for `Fast Company`, `Business Insider`, and `IEEE Spectrum`
-- Better cleanup for inline audio prompts, read-next modules, and promo blocks on speaker-label-heavy publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, and interview/transcript layouts
+- New deterministic longform analysis fixtures for `The Atlantic`, `Foreign Policy`, and `New Statesman`
+- Better cleanup for audio prompts, subscription banners, and read-more recirculation modules on essay-heavy publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, and longform analysis layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.11.md
+++ b/docs/releases/v1.2.11.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.11
+
+AI News Open `v1.2.11` is a content-quality patch release focused on longform analysis, essay, and feature-style newsroom pages. It extends the deterministic extraction suite so audio prompts, recirculation modules, and subscription or newsletter blocks are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added longform analysis / essay extraction fixtures for:
+  - `theatlantic.com`
+  - `foreignpolicy.com`
+  - `newstatesman.com`
+- Added host-specific cleanup for audio prompts, recirculation modules, and subscription or newsletter blocks on those layouts
+- Extended the extraction regression suite to cover another class of essay-heavy international media pages
+
+### Why this matters
+
+- Longform pages often keep sidebars, author notes, audio prompts, and “read more” modules near or inside the same container as the main body
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, and longform analysis layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.10"
+version = "1.2.11"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -278,6 +278,21 @@ HOST_SELECTORS = {
         ".article-body",
         ".content-body",
     ),
+    "theatlantic.com": (
+        ".ArticleBody",
+        ".article-body",
+        ".ContentBody",
+    ),
+    "foreignpolicy.com": (
+        ".post-content",
+        ".article-content",
+        ".entry-content",
+    ),
+    "newstatesman.com": (
+        ".article__body",
+        ".c-content-body",
+        ".article-body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -571,6 +586,27 @@ HOST_DROP_SELECTORS = {
         ".author-card",
         ".article-footer",
     ),
+    "theatlantic.com": (
+        ".article-sidebar",
+        ".newsletter-callout",
+        ".listen-bar",
+        ".author-note",
+        ".related-content",
+    ),
+    "foreignpolicy.com": (
+        ".subscription-banner",
+        ".read-next",
+        ".podcast-module",
+        ".author-bio",
+        ".related-coverage",
+    ),
+    "newstatesman.com": (
+        ".newsletter-promo",
+        ".audio-player",
+        ".author-box",
+        ".recommended-links",
+        ".article-footer",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -789,6 +825,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^More from IEEE Spectrum$"),
         re.compile(r"^Subscribe to our newsletters$"),
     ),
+    "theatlantic.com": (
+        re.compile(r"^Listen to the article$"),
+        re.compile(r"^Read more from The Atlantic$"),
+        re.compile(r"^Sign up for The Atlantic Daily$"),
+    ),
+    "foreignpolicy.com": (
+        re.compile(r"^Subscribe to Foreign Policy$"),
+        re.compile(r"^Read More$"),
+        re.compile(r"^Listen to the conversation$"),
+    ),
+    "newstatesman.com": (
+        re.compile(r"^Listen to this piece$"),
+        re.compile(r"^Continue reading with a subscription$"),
+        re.compile(r"^Recommended$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1001,6 +1052,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-main__content"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "theatlantic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"articlebody"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"contentbody"}},
+    ),
+    "foreignpolicy.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"entry-content"}},
+    ),
+    "newstatesman.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article__body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"c-content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/foreignpolicy-longform.html
+++ b/tests/fixtures/extraction/foreignpolicy-longform.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>AI operations and governance analysis - Foreign Policy</title>
+  </head>
+  <body>
+    <article>
+      <div class="post-content">
+        <p>AI strategy is increasingly judged by how systems are supervised after launch, not by how loudly leaders describe them beforehand.</p>
+        <div class="podcast-module">Listen to the conversation</div>
+        <p>Foreign Policy frames this as a question of institutional control, where approval paths, incident review, and controlled rollback matter as much as technical capability.</p>
+        <div class="subscription-banner">Subscribe to Foreign Policy</div>
+        <p>Longform analysis now treats production oversight as a geopolitical and managerial problem, not just a product-management one.</p>
+        <div class="read-next">Read More</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/newstatesman-longform.html
+++ b/tests/fixtures/extraction/newstatesman-longform.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>How AI operations became a political economy question - New Statesman</title>
+  </head>
+  <body>
+    <main>
+      <section class="article__body">
+        <p>Longform analysis of AI now spends more time on operating discipline than on model spectacle.</p>
+        <div class="audio-player">Listen to this piece</div>
+        <p>The New Statesman argues that fallback planning, escalation rules, and post-incident accountability increasingly define whether AI systems can be trusted in public life.</p>
+        <div class="newsletter-promo">Continue reading with a subscription</div>
+        <p>That focus shifts the conversation from abstract promise to concrete institutional behavior.</p>
+        <div class="recommended-links">Recommended</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/theatlantic-longform.html
+++ b/tests/fixtures/extraction/theatlantic-longform.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Why AI operations became governance - The Atlantic</title>
+  </head>
+  <body>
+    <main>
+      <section class="ArticleBody">
+        <p>AI operations has become the place where governance claims are tested rather than merely announced.</p>
+        <div class="listen-bar">Listen to the article</div>
+        <p>The Atlantic argues that organizations now prove seriousness through review queues, rollback drills, and ownership boundaries rather than through glossy principles.</p>
+        <div class="related-content">Read more from The Atlantic</div>
+        <p>That is why longform reporting on AI increasingly reads like a study of operating institutions instead of product launches.</p>
+        <div class="newsletter-callout">Sign up for The Atlantic Daily</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -533,6 +533,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("More from IEEE Spectrum", content.text)
         self.assertNotIn("Subscribe to our newsletters", content.text)
 
+    def test_prefers_theatlantic_longform_body_and_drops_audio_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("theatlantic-longform.html"),
+            url="https://www.theatlantic.com/technology/archive/2026/04/why-ai-operations-became-governance/123456/",
+        )
+
+        self.assertIn("AI operations has become the place where governance claims are tested", content.text)
+        self.assertIn("review queues, rollback drills, and ownership boundaries", content.text)
+        self.assertNotIn("Listen to the article", content.text)
+        self.assertNotIn("Read more from The Atlantic", content.text)
+        self.assertNotIn("Sign up for The Atlantic Daily", content.text)
+
+    def test_prefers_foreignpolicy_longform_body_and_drops_subscription_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("foreignpolicy-longform.html"),
+            url="https://foreignpolicy.com/2026/04/09/ai-operations-governance-analysis/",
+        )
+
+        self.assertIn("AI strategy is increasingly judged by how systems are supervised after launch", content.text)
+        self.assertIn("approval paths, incident review, and controlled rollback", content.text)
+        self.assertNotIn("Subscribe to Foreign Policy", content.text)
+        self.assertNotIn("Read More", content.text)
+        self.assertNotIn("Listen to the conversation", content.text)
+
+    def test_prefers_newstatesman_longform_body_and_drops_audio_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("newstatesman-longform.html"),
+            url="https://www.newstatesman.com/technology/2026/04/how-ai-operations-became-a-political-economy-question",
+        )
+
+        self.assertIn("Longform analysis of AI now spends more time on operating discipline than on model spectacle", content.text)
+        self.assertIn("fallback planning, escalation rules, and post-incident accountability", content.text)
+        self.assertNotIn("Listen to this piece", content.text)
+        self.assertNotIn("Continue reading with a subscription", content.text)
+        self.assertNotIn("Recommended", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add longform analysis and essay extraction fixtures for The Atlantic, Foreign Policy, and New Statesman
- extend source-specific cleanup for audio prompts, recirculation modules, and subscription or newsletter noise
- bump package metadata and release notes for v1.2.11

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v