### PR TITLE
release: prepare v1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.12] - 2026-04-09
+
+### Added
+
+- Policy memo, research note, and magazine-feature extraction fixtures for `brookings.edu`, `rand.org`, and `restofworld.org`
+
+### Changed
+
+- Package version is now `1.2.12`
+- International extraction coverage now includes policy-memo, research-note, and feature-with-pull-quote newsroom layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, and longform analysis layouts
+
+### Fixed
+
+- Reduced pull-quote bleed-through, briefing modules, audio prompts, and related-content noise on policy- and feature-heavy longform pages
+- Locked another class of fragmented longform layouts into deterministic fixture coverage so cleanup regressions are caught in CI
+
 ## [1.2.11] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.11`
+`v1.2.12`
 
 ### Suggested Title
 
-`AI News Open v1.2.11 · Longform Analysis Extraction Coverage`
+`AI News Open v1.2.12 · Policy Memo and Feature Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.11
+## AI News Open v1.2.12
 
-AI News Open `v1.2.11` hardens extraction quality for analysis-, essay-, and longform-feature newsroom layouts across more international publishers.
+AI News Open `v1.2.12` hardens extraction quality for policy memo, research note, and magazine-feature newsroom layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.11` hardens extraction quality for analysis-, essay-, and lon
 
 ### Highlights in this release
 
-- New deterministic longform analysis fixtures for `The Atlantic`, `Foreign Policy`, and `New Statesman`
-- Better cleanup for audio prompts, subscription banners, and read-more recirculation modules on essay-heavy publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, and longform analysis layouts
+- New deterministic policy and feature fixtures for `Brookings`, `RAND`, and `Rest of World`
+- Better cleanup for briefing modules, pull quotes, audio prompts, and related-content recirculation on fragmented longform publisher pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, and policy/research feature layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.12.md
+++ b/docs/releases/v1.2.12.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.12
+
+AI News Open `v1.2.12` is a content-quality patch release focused on policy memo, research note, and magazine-feature newsroom pages. It extends the deterministic extraction suite so pull quotes, briefing modules, audio prompts, and related-content blocks are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added policy memo / research note / feature extraction fixtures for:
+  - `brookings.edu`
+  - `rand.org`
+  - `restofworld.org`
+- Added host-specific cleanup for briefing modules, pull quotes, audio prompts, and related-content recirculation on those layouts
+- Extended the extraction regression suite to cover another class of fragmented longform international pages
+
+### Why this matters
+
+- Policy and research pages often interleave body text with inline promos, audio controls, and pull quotes inside the same top-level content container
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, and policy-feature layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.11"
+version = "1.2.12"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.11"
+__version__ = "1.2.12"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -293,6 +293,21 @@ HOST_SELECTORS = {
         ".c-content-body",
         ".article-body",
     ),
+    "brookings.edu": (
+        ".post-body",
+        ".article__content",
+        ".wysiwyg",
+    ),
+    "rand.org": (
+        ".article-content",
+        ".content-body",
+        ".rich-text",
+    ),
+    "restofworld.org": (
+        ".article-body",
+        ".story-content",
+        ".content-body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -607,6 +622,27 @@ HOST_DROP_SELECTORS = {
         ".recommended-links",
         ".article-footer",
     ),
+    "brookings.edu": (
+        ".newsletter-signup",
+        ".inline-promo",
+        ".book-promo",
+        ".author-bio",
+        ".related-content",
+    ),
+    "rand.org": (
+        ".newsletter-module",
+        ".audio-player",
+        ".related-resources",
+        ".author-card",
+        ".cta-banner",
+    ),
+    "restofworld.org": (
+        ".pullquote",
+        ".newsletter-callout",
+        ".related-stories",
+        ".audio-player",
+        ".author-card",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -840,6 +876,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Continue reading with a subscription$"),
         re.compile(r"^Recommended$"),
     ),
+    "brookings.edu": (
+        re.compile(r"^Sign up for Brookings newsletters$"),
+        re.compile(r"^Related Content$"),
+        re.compile(r"^Listen to this policy brief$"),
+    ),
+    "rand.org": (
+        re.compile(r"^Listen to the article$"),
+        re.compile(r"^Related RAND research$"),
+        re.compile(r"^Get RAND insights in your inbox$"),
+    ),
+    "restofworld.org": (
+        re.compile(r"^Listen to the story$"),
+        re.compile(r"^Read more from Rest of World$"),
+        re.compile(r"^Sign up for our weekly newsletter$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1067,6 +1118,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article__body"}},
         {"tags": {"div", "section"}, "class_tokens": {"c-content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "brookings.edu": (
+        {"tags": {"div", "section"}, "class_tokens": {"post-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article__content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"wysiwyg"}},
+    ),
+    "rand.org": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"rich-text"}},
+    ),
+    "restofworld.org": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"story-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/brookings-policy-memo.html
+++ b/tests/fixtures/extraction/brookings-policy-memo.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>Why AI governance needs operators, not just policies</title>
+  </head>
+  <body>
+    <article>
+      <div class="article__content post-body wysiwyg">
+        <div class="newsletter-signup">Sign up for Brookings newsletters</div>
+        <div class="inline-promo">Related Content</div>
+        <div class="book-promo">Listen to this policy brief</div>
+        <p>Policy teams are learning that AI governance only works when operators own the control points that determine how a model behaves in production. That means moving beyond approval documents and into the practical routines that shape deployment every day.</p>
+        <p>Teams that succeed are building approval ladders, rollback drills, and escalation playbooks directly into product operations so exceptions can be reviewed without improvising under pressure.</p>
+        <p>In practice, durable AI oversight now depends on named owners, clearer incident thresholds, and rehearsed fallback paths that can survive real outages instead of presentation slides.</p>
+        <div class="author-bio">Author bio and contributor credits</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/rand-research-note.html
+++ b/tests/fixtures/extraction/rand-research-note.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI operations under pressure</title>
+  </head>
+  <body>
+    <main>
+      <section class="article-content content-body rich-text">
+        <div class="audio-player">Listen to the article</div>
+        <div class="related-resources">Related RAND research</div>
+        <div class="newsletter-module">Get RAND insights in your inbox</div>
+        <p>Research teams studying enterprise AI deployments now focus on how systems fail after launch rather than on benchmark scores alone. The operating question is whether teams can spot regressions, route decisions for review, and recover without losing control of business workflows.</p>
+        <p>The strongest programs use review queues, monitored rollback paths, and incident rehearsal to keep model behavior legible once it touches customers, analysts, and support staff.</p>
+        <p>That operational framing is increasingly visible in procurement, where buyers ask for evidence that governance processes remain usable during outages, policy updates, and retrieval failures.</p>
+        <div class="author-card">Researcher profile</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/restofworld-feature.html
+++ b/tests/fixtures/extraction/restofworld-feature.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>The unseen work of AI governance</title>
+  </head>
+  <body>
+    <article>
+      <div class="story-content article-body content-body">
+        <div class="audio-player">Listen to the story</div>
+        <aside class="pullquote">The system is only as trustworthy as the people rehearsing the fallback path.</aside>
+        <div class="newsletter-callout">Sign up for our weekly newsletter</div>
+        <p>Magazine-style features about AI now spend more time on the invisible operating labor after launch than on splashy product reveals. The real story is often the team responsible for deciding what happens when a model slows down, refuses the wrong request, or routes customers into the wrong workflow.</p>
+        <p>Editors and operators increasingly describe runbooks, exception handling, and who gets paged when a model starts drifting as the practical center of AI governance.</p>
+        <p>Those routines matter because they turn abstract principles into repeatable operational choices that can be audited, reviewed, and improved after each incident.</p>
+        <div class="related-stories">Read more from Rest of World</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -572,6 +572,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Continue reading with a subscription", content.text)
         self.assertNotIn("Recommended", content.text)
 
+    def test_prefers_brookings_policy_memo_body_and_drops_briefing_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("brookings-policy-memo.html"),
+            url="https://www.brookings.edu/articles/2026/04/09/ai-governance-needs-operators-not-just-policies/",
+        )
+
+        self.assertIn("Policy teams are learning that AI governance only works when operators own the control points", content.text)
+        self.assertIn("approval ladders, rollback drills, and escalation playbooks", content.text)
+        self.assertNotIn("Sign up for Brookings newsletters", content.text)
+        self.assertNotIn("Related Content", content.text)
+        self.assertNotIn("Listen to this policy brief", content.text)
+
+    def test_prefers_rand_research_note_body_and_drops_audio_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("rand-research-note.html"),
+            url="https://www.rand.org/pubs/research_reports/2026/ai-operations-under-pressure.html",
+        )
+
+        self.assertIn("Research teams studying enterprise AI deployments now focus on how systems fail after launch", content.text)
+        self.assertIn("review queues, monitored rollback paths, and incident rehearsal", content.text)
+        self.assertNotIn("Listen to the article", content.text)
+        self.assertNotIn("Related RAND research", content.text)
+        self.assertNotIn("Get RAND insights in your inbox", content.text)
+
+    def test_prefers_restofworld_feature_body_and_drops_pullquote_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("restofworld-feature.html"),
+            url="https://restofworld.org/2026/ai-operators-are-doing-the-unseen-work-of-governance/",
+        )
+
+        self.assertIn("Magazine-style features about AI now spend more time on the invisible operating labor after launch", content.text)
+        self.assertIn("runbooks, exception handling, and who gets paged when a model starts drifting", content.text)
+        self.assertNotIn("Listen to the story", content.text)
+        self.assertNotIn("Read more from Rest of World", content.text)
+        self.assertNotIn("The system is only as trustworthy as the people rehearsing the fallback path.", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for Brookings, RAND, and Rest of World longform layouts
- extend source-specific cleanup for policy memo, research note, and feature-with-pull-quote pages
- prepare the v1.2.12 changelog, release notes, and version bump

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python