### PR TITLE
release: prepare v1.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.13] - 2026-04-09
+
+### Added
+
+- Whitepaper, vendor benchmark, and enterprise case-study extraction fixtures for `mckinsey.com`, `cloud.google.com`, and `databricks.com`
+
+### Changed
+
+- Package version is now `1.2.13`
+- International extraction coverage now includes whitepaper, benchmark, and case-study publisher layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, and policy-feature layouts
+
+### Fixed
+
+- Reduced methodology blurbs, download prompts, video modules, and related-resource noise on benchmark- and case-study-heavy pages
+- Locked another class of vendor and research content-marketing layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.12] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.12`
+`v1.2.13`
 
 ### Suggested Title
 
-`AI News Open v1.2.12 · Policy Memo and Feature Extraction Coverage`
+`AI News Open v1.2.13 · Whitepaper and Benchmark Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.12
+## AI News Open v1.2.13
 
-AI News Open `v1.2.12` hardens extraction quality for policy memo, research note, and magazine-feature newsroom layouts across more international publishers.
+AI News Open `v1.2.13` hardens extraction quality for whitepaper, vendor benchmark, and enterprise case-study layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.12` hardens extraction quality for policy memo, research note
 
 ### Highlights in this release
 
-- New deterministic policy and feature fixtures for `Brookings`, `RAND`, and `Rest of World`
-- Better cleanup for briefing modules, pull quotes, audio prompts, and related-content recirculation on fragmented longform publisher pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, and policy/research feature layouts
+- New deterministic whitepaper and case-study fixtures for `McKinsey`, `Google Cloud`, and `Databricks`
+- Better cleanup for methodology blurbs, download prompts, video modules, and related-resource recirculation on vendor and research pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, and vendor benchmark layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.13.md
+++ b/docs/releases/v1.2.13.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.13
+
+AI News Open `v1.2.13` is a content-quality patch release focused on whitepaper, vendor benchmark, and enterprise case-study pages. It extends the deterministic extraction suite so methodology blurbs, download prompts, video modules, and related-resource blocks are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added whitepaper / benchmark / case-study extraction fixtures for:
+  - `mckinsey.com`
+  - `cloud.google.com`
+  - `databricks.com`
+- Added host-specific cleanup for methodology blurbs, download prompts, video modules, and related-resource recirculation on those layouts
+- Extended the extraction regression suite to cover another class of vendor and research longform pages
+
+### Why this matters
+
+- Vendor and research pages often mix article text with benchmark methodology notes, download CTAs, and product-promotional recirculation inside the same body container
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, and vendor benchmark layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.12"
+version = "1.2.13"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.12"
+__version__ = "1.2.13"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -308,6 +308,21 @@ HOST_SELECTORS = {
         ".story-content",
         ".content-body",
     ),
+    "mckinsey.com": (
+        ".content-body",
+        ".article-body",
+        ".wysiwyg",
+    ),
+    "cloud.google.com": (
+        ".devsite-article-body",
+        ".article-body",
+        ".case-study-body",
+    ),
+    "databricks.com": (
+        ".article-body",
+        ".resource-body",
+        ".content-body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -643,6 +658,27 @@ HOST_DROP_SELECTORS = {
         ".audio-player",
         ".author-card",
     ),
+    "mckinsey.com": (
+        ".newsletter-signup",
+        ".listen-module",
+        ".related-insights",
+        ".author-bio",
+        ".download-prompt",
+    ),
+    "cloud.google.com": (
+        ".devsite-page-rating",
+        ".newsletter-callout",
+        ".benchmark-cta",
+        ".related-products",
+        ".audio-player",
+    ),
+    "databricks.com": (
+        ".case-study-cta",
+        ".related-resources",
+        ".video-module",
+        ".author-card",
+        ".newsletter-signup",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -891,6 +927,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Read more from Rest of World$"),
         re.compile(r"^Sign up for our weekly newsletter$"),
     ),
+    "mckinsey.com": (
+        re.compile(r"^Listen to the article$"),
+        re.compile(r"^Explore more insights$"),
+        re.compile(r"^Download the full report$"),
+    ),
+    "cloud.google.com": (
+        re.compile(r"^Benchmark methodology$"),
+        re.compile(r"^Related products$"),
+        re.compile(r"^Listen to this benchmark note$"),
+    ),
+    "databricks.com": (
+        re.compile(r"^Watch the customer story$"),
+        re.compile(r"^Read related resources$"),
+        re.compile(r"^Sign up for Databricks updates$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1132,6 +1183,21 @@ FALLBACK_HOST_RULES = {
     "restofworld.org": (
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"story-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "mckinsey.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"wysiwyg"}},
+    ),
+    "cloud.google.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"devsite-article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"case-study-body"}},
+    ),
+    "databricks.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"resource-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
     ),
     "theguardian.com": (

--- a/tests/fixtures/extraction/cloud-google-benchmark.html
+++ b/tests/fixtures/extraction/cloud-google-benchmark.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI inference benchmarks and the operations question</title>
+  </head>
+  <body>
+    <main>
+      <div class="devsite-article-body article-body case-study-body">
+        <div class="benchmark-cta">Benchmark methodology</div>
+        <div class="related-products">Related products</div>
+        <div class="audio-player">Listen to this benchmark note</div>
+        <p>Benchmark writeups now matter less for raw throughput than for the operating discipline around rollout. Buyers want to know what happens when latency shifts, policy filters change, or retrieval quality drops under live load.</p>
+        <p>The strongest teams describe fallback controls, rollback sequencing, and clear human escalation alongside the charts, because production AI is judged by recoverability as much as by speed.</p>
+        <p>That turns benchmark coverage into an operational document: one that explains not only how a system performs, but how operators maintain trust once conditions change.</p>
+        <div class="newsletter-callout">Cloud updates newsletter</div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/databricks-case-study.html
+++ b/tests/fixtures/extraction/databricks-case-study.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>How enterprises operationalize AI governance at scale</title>
+  </head>
+  <body>
+    <article>
+      <section class="resource-body article-body content-body">
+        <div class="video-module">Watch the customer story</div>
+        <div class="related-resources">Read related resources</div>
+        <div class="newsletter-signup">Sign up for Databricks updates</div>
+        <p>Enterprise case studies now emphasize the operating work required after AI launch rather than the launch moment itself. Teams are expected to show how decisions are reviewed, how exceptions are handled, and how problems are reversed before they spread across workflows.</p>
+        <p>The most convincing stories focus on named owners, incident review, and the safeguards that keep models useful during drift, prompt changes, and data quality failures.</p>
+        <p>That shift is turning customer stories into operating blueprints, where success is measured by how reliably a system can be supervised over time.</p>
+        <div class="author-card">Case study contributors</div>
+      </section>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/mckinsey-whitepaper.html
+++ b/tests/fixtures/extraction/mckinsey-whitepaper.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>Why AI operations benchmarks now focus on control</title>
+  </head>
+  <body>
+    <article>
+      <section class="content-body article-body wysiwyg">
+        <div class="listen-module">Listen to the article</div>
+        <div class="related-insights">Explore more insights</div>
+        <div class="download-prompt">Download the full report</div>
+        <p>Executives reviewing AI programs now ask for evidence that operating controls survive real incident pressure instead of failing once models reach customer-facing workflows. The benchmark that matters is not just throughput but whether teams can see a problem, route it for review, and keep service running responsibly.</p>
+        <p>That is pushing leaders to compare approval checkpoints, rollback ownership, and escalation paths with the same rigor they once reserved for infrastructure cost and raw performance.</p>
+        <p>Across large enterprises, operators are documenting recovery routines in advance so governance can be tested as a practical discipline rather than a slide-deck promise.</p>
+        <div class="author-bio">Contributor notes</div>
+      </section>
+    </article>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -611,6 +611,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Read more from Rest of World", content.text)
         self.assertNotIn("The system is only as trustworthy as the people rehearsing the fallback path.", content.text)
 
+    def test_prefers_mckinsey_whitepaper_body_and_drops_report_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("mckinsey-whitepaper.html"),
+            url="https://www.mckinsey.com/capabilities/quantumblack/our-insights/2026/04/ai-operations-benchmark",
+        )
+
+        self.assertIn("Executives reviewing AI programs now ask for evidence that operating controls survive real incident pressure", content.text)
+        self.assertIn("approval checkpoints, rollback ownership, and escalation paths", content.text)
+        self.assertNotIn("Listen to the article", content.text)
+        self.assertNotIn("Explore more insights", content.text)
+        self.assertNotIn("Download the full report", content.text)
+
+    def test_prefers_cloud_google_benchmark_body_and_drops_methodology_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("cloud-google-benchmark.html"),
+            url="https://cloud.google.com/blog/products/ai-machine-learning/ai-inference-benchmark-operations-guide",
+        )
+
+        self.assertIn("Benchmark writeups now matter less for raw throughput than for the operating discipline around rollout", content.text)
+        self.assertIn("fallback controls, rollback sequencing, and clear human escalation", content.text)
+        self.assertNotIn("Benchmark methodology", content.text)
+        self.assertNotIn("Related products", content.text)
+        self.assertNotIn("Listen to this benchmark note", content.text)
+
+    def test_prefers_databricks_case_study_body_and_drops_video_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("databricks-case-study.html"),
+            url="https://www.databricks.com/resources/case-studies/ai-ops-governance-at-scale",
+        )
+
+        self.assertIn("Enterprise case studies now emphasize the operating work required after AI launch", content.text)
+        self.assertIn("named owners, incident review, and the safeguards that keep models useful during drift", content.text)
+        self.assertNotIn("Watch the customer story", content.text)
+        self.assertNotIn("Read related resources", content.text)
+        self.assertNotIn("Sign up for Databricks updates", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for McKinsey, Google Cloud, and Databricks whitepaper and benchmark layouts
- extend source-specific cleanup for methodology blurbs, download prompts, and case-study promo modules
- prepare the v1.2.13 changelog, release notes, and version bump

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python