### PR TITLE
release: prepare v1.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.14] - 2026-04-09
+
+### Added
+
+- Conference recap, event takeaways, and transcript-summary extraction fixtures for `techpolicy.press`, `a16z.com`, and `ted.com`
+
+### Changed
+
+- Package version is now `1.2.14`
+- International extraction coverage now includes conference-recap, event-takeaways, and transcript-summary hybrid layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, and vendor benchmark layouts
+
+### Fixed
+
+- Reduced event metadata, session promos, transcript navigation, and related-content noise on recap-heavy publisher pages
+- Locked another class of conference and session-summary layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.13] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.13`
+`v1.2.14`
 
 ### Suggested Title
 
-`AI News Open v1.2.13 · Whitepaper and Benchmark Extraction Coverage`
+`AI News Open v1.2.14 · Conference Recap Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.13
+## AI News Open v1.2.14
 
-AI News Open `v1.2.13` hardens extraction quality for whitepaper, vendor benchmark, and enterprise case-study layouts across more international publishers.
+AI News Open `v1.2.14` hardens extraction quality for conference recap, event takeaways, and transcript-summary hybrid layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.13` hardens extraction quality for whitepaper, vendor benchma
 
 ### Highlights in this release
 
-- New deterministic whitepaper and case-study fixtures for `McKinsey`, `Google Cloud`, and `Databricks`
-- Better cleanup for methodology blurbs, download prompts, video modules, and related-resource recirculation on vendor and research pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, and vendor benchmark layouts
+- New deterministic recap and session-summary fixtures for `Tech Policy Press`, `a16z`, and `TED`
+- Better cleanup for event metadata, session promos, transcript navigation, and related-content recirculation on recap-heavy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, and conference recap layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.14.md
+++ b/docs/releases/v1.2.14.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.14
+
+AI News Open `v1.2.14` is a content-quality patch release focused on conference recap, event takeaways, and transcript-summary hybrid pages. It extends the deterministic extraction suite so event metadata, session promos, transcript navigation, and related-content blocks are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added conference recap / event takeaways / transcript-summary extraction fixtures for:
+  - `techpolicy.press`
+  - `a16z.com`
+  - `ted.com`
+- Added host-specific cleanup for event metadata, session promos, transcript navigation, and related-content recirculation on those layouts
+- Extended the extraction regression suite to cover another class of conference and summary-heavy publisher pages
+
+### Why this matters
+
+- Recap and summary pages often mix event metadata, session links, and transcript navigation inside the same content container as the main body
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, and conference recap layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.13"
+version = "1.2.14"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.13"
+__version__ = "1.2.14"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -323,6 +323,21 @@ HOST_SELECTORS = {
         ".resource-body",
         ".content-body",
     ),
+    "techpolicy.press": (
+        ".entry-content",
+        ".article-content",
+        ".post-content",
+    ),
+    "a16z.com": (
+        ".post-content",
+        ".article-content",
+        ".entry-content",
+    ),
+    "ted.com": (
+        ".talk-body",
+        ".transcript__body",
+        ".article-body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -679,6 +694,27 @@ HOST_DROP_SELECTORS = {
         ".author-card",
         ".newsletter-signup",
     ),
+    "techpolicy.press": (
+        ".newsletter-signup",
+        ".event-meta",
+        ".related-posts",
+        ".audio-player",
+        ".author-bio",
+    ),
+    "a16z.com": (
+        ".signup-module",
+        ".podcast-player",
+        ".related-insights",
+        ".video-embed",
+        ".author-card",
+    ),
+    "ted.com": (
+        ".talk-sidebar",
+        ".related-talks",
+        ".cta-banner",
+        ".audio-player",
+        ".transcript-nav",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -942,6 +978,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Read related resources$"),
         re.compile(r"^Sign up for Databricks updates$"),
     ),
+    "techpolicy.press": (
+        re.compile(r"^Event recap hub$"),
+        re.compile(r"^Related posts$"),
+        re.compile(r"^Listen to the session recap$"),
+    ),
+    "a16z.com": (
+        re.compile(r"^Watch the full session$"),
+        re.compile(r"^More from a16z$"),
+        re.compile(r"^Subscribe for future updates$"),
+    ),
+    "ted.com": (
+        re.compile(r"^Transcript navigation$"),
+        re.compile(r"^More TED talks on AI$"),
+        re.compile(r"^Listen to the episode$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1199,6 +1250,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"resource-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "techpolicy.press": (
+        {"tags": {"div", "section"}, "class_tokens": {"entry-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+    ),
+    "a16z.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"post-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"entry-content"}},
+    ),
+    "ted.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"talk-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"transcript__body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/a16z-event-takeaways.html
+++ b/tests/fixtures/extraction/a16z-event-takeaways.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI infrastructure event takeaways</title>
+  </head>
+  <body>
+    <main>
+      <section class="post-content article-content entry-content">
+        <div class="video-embed">Watch the full session</div>
+        <div class="related-insights">More from a16z</div>
+        <div class="signup-module">Subscribe for future updates</div>
+        <p>Event takeaway posts now spend less time on stagecraft and more on the systems that keep AI products reliable once they leave demo mode. Operators want to hear about how companies document risk, test fallbacks, and enforce review ownership between product and platform teams.</p>
+        <p>The strongest sessions highlighted review checkpoints, rollback readiness, and how teams practice failure before customers see it, because that is what turns model capability into a dependable service.</p>
+        <p>As events mature, the most useful recap is the one that captures the operating lessons people can take back to their launch process the next day.</p>
+        <div class="author-card">Speaker profiles</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/techpolicypress-recap.html
+++ b/tests/fixtures/extraction/techpolicypress-recap.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>What the AI governance summit revealed about operations</title>
+  </head>
+  <body>
+    <article>
+      <div class="entry-content article-content post-content">
+        <div class="event-meta">Event recap hub</div>
+        <div class="related-posts">Related posts</div>
+        <div class="audio-player">Listen to the session recap</div>
+        <p>Conference recaps are increasingly about the operational systems behind AI promises rather than about keynotes alone. The most revealing moments often come when teams explain how review queues, rollback decisions, and exception handling actually work once the lights are off.</p>
+        <p>That is why more policy gatherings now focus on incident review, escalation ownership, and fallback discipline instead of treating governance as a separate layer that appears only after launch.</p>
+        <p>The practical question is no longer whether teams have principles, but whether they can turn those principles into stable operating routines under real pressure.</p>
+        <div class="author-bio">Author notes</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/ted-transcript-summary.html
+++ b/tests/fixtures/extraction/ted-transcript-summary.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI operators and the hidden work of reliability</title>
+  </head>
+  <body>
+    <article>
+      <div class="talk-body transcript__body article-body">
+        <div class="transcript-nav">Transcript navigation</div>
+        <div class="talk-sidebar">More TED talks on AI</div>
+        <div class="audio-player">Listen to the episode</div>
+        <p>Transcript-summary pages are useful only when the editorial framing survives the transcript scaffolding that surrounds it. Readers need the argument, not just the interface around the spoken version.</p>
+        <p>In this case, the argument is that what matters after launch is who reviews exceptions and how teams recover when models drift, not just how impressive the system looked on stage.</p>
+        <p>Once you strip away the navigation and talk prompts, the piece reads like an operating memo about accountability, supervision, and recovery under load.</p>
+        <div class="cta-banner">Watch next</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -650,6 +650,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Read related resources", content.text)
         self.assertNotIn("Sign up for Databricks updates", content.text)
 
+    def test_prefers_techpolicy_press_recap_body_and_drops_event_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("techpolicypress-recap.html"),
+            url="https://www.techpolicy.press/2026/04/09/what-the-ai-governance-summit-revealed-about-operations/",
+        )
+
+        self.assertIn("Conference recaps are increasingly about the operational systems behind AI promises", content.text)
+        self.assertIn("incident review, escalation ownership, and fallback discipline", content.text)
+        self.assertNotIn("Event recap hub", content.text)
+        self.assertNotIn("Related posts", content.text)
+        self.assertNotIn("Listen to the session recap", content.text)
+
+    def test_prefers_a16z_event_takeaways_body_and_drops_session_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("a16z-event-takeaways.html"),
+            url="https://a16z.com/2026/04/09/ai-infrastructure-event-takeaways/",
+        )
+
+        self.assertIn("Event takeaway posts now spend less time on stagecraft and more on the systems that keep AI products reliable", content.text)
+        self.assertIn("review checkpoints, rollback readiness, and how teams practice failure before customers see it", content.text)
+        self.assertNotIn("Watch the full session", content.text)
+        self.assertNotIn("More from a16z", content.text)
+        self.assertNotIn("Subscribe for future updates", content.text)
+
+    def test_prefers_ted_transcript_summary_body_and_drops_transcript_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("ted-transcript-summary.html"),
+            url="https://www.ted.com/talks/2026/ai_operators_and_the_hidden_work_of_reliability/transcript",
+        )
+
+        self.assertIn("Transcript-summary pages are useful only when the editorial framing survives the transcript scaffolding", content.text)
+        self.assertIn("what matters after launch is who reviews exceptions and how teams recover when models drift", content.text)
+        self.assertNotIn("Transcript navigation", content.text)
+        self.assertNotIn("More TED talks on AI", content.text)
+        self.assertNotIn("Listen to the episode", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for Tech Policy Press, a16z, and TED recap-style layouts
- extend source-specific cleanup for event metadata, session promos, and transcript navigation noise
- prepare the v1.2.14 changelog, release notes, and version bump

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python