### PR TITLE
release: prepare v1.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.15] - 2026-04-09
+
+### Added
+
+- Vendor FAQ, troubleshooting, and best-practices extraction fixtures for `aws.amazon.com`, `docs.anthropic.com`, and `learn.microsoft.com`
+
+### Changed
+
+- Package version is now `1.2.15`
+- International extraction coverage now includes vendor FAQ, troubleshooting, and best-practices guide layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, and conference recap layouts
+
+### Fixed
+
+- Reduced resource sidebars, help navigation, feedback modules, and checklist noise on documentation-heavy vendor pages
+- Locked another class of documentation-style operational pages into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.14] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.14`
+`v1.2.15`
 
 ### Suggested Title
 
-`AI News Open v1.2.14 · Conference Recap Extraction Coverage`
+`AI News Open v1.2.15 · Vendor Documentation Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.14
+## AI News Open v1.2.15
 
-AI News Open `v1.2.14` hardens extraction quality for conference recap, event takeaways, and transcript-summary hybrid layouts across more international publishers.
+AI News Open `v1.2.15` hardens extraction quality for vendor FAQ, troubleshooting, and best-practices guide layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.14` hardens extraction quality for conference recap, event ta
 
 ### Highlights in this release
 
-- New deterministic recap and session-summary fixtures for `Tech Policy Press`, `a16z`, and `TED`
-- Better cleanup for event metadata, session promos, transcript navigation, and related-content recirculation on recap-heavy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, and conference recap layouts
+- New deterministic documentation-style fixtures for `AWS`, `Anthropic Docs`, and `Microsoft Learn`
+- Better cleanup for resource sidebars, help navigation, feedback modules, and checklist recirculation on vendor documentation pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, and vendor documentation layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.15.md
+++ b/docs/releases/v1.2.15.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.15
+
+AI News Open `v1.2.15` is a content-quality patch release focused on vendor FAQ, troubleshooting, and best-practices guide pages. It extends the deterministic extraction suite so resource sidebars, help navigation, feedback modules, and checklist noise are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added vendor FAQ / troubleshooting / best-practices extraction fixtures for:
+  - `aws.amazon.com`
+  - `docs.anthropic.com`
+  - `learn.microsoft.com`
+- Added host-specific cleanup for resource sidebars, help navigation, feedback modules, and checklist-style recirculation on those layouts
+- Extended the extraction regression suite to cover another class of documentation-heavy operational pages
+
+### Why this matters
+
+- Vendor documentation pages often mix troubleshooting navigation, feedback widgets, and resource sidebars inside the same content container as the main body
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, and vendor documentation layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.14"
+version = "1.2.15"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.14"
+__version__ = "1.2.15"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -338,6 +338,21 @@ HOST_SELECTORS = {
         ".transcript__body",
         ".article-body",
     ),
+    "aws.amazon.com": (
+        ".awsdocs-content",
+        ".article-body",
+        ".doc-content",
+    ),
+    "docs.anthropic.com": (
+        ".theme-doc-markdown",
+        ".docs-content",
+        ".article-body",
+    ),
+    "learn.microsoft.com": (
+        ".content-body",
+        ".article-body",
+        ".main-content",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -715,6 +730,27 @@ HOST_DROP_SELECTORS = {
         ".audio-player",
         ".transcript-nav",
     ),
+    "aws.amazon.com": (
+        ".feedback-section",
+        ".related-links",
+        ".video-module",
+        ".cta-banner",
+        ".sidebar-nav",
+    ),
+    "docs.anthropic.com": (
+        ".table-of-contents",
+        ".docs-feedback",
+        ".related-links",
+        ".callout-banner",
+        ".breadcrumbs",
+    ),
+    "learn.microsoft.com": (
+        ".next-steps",
+        ".feedback-section",
+        ".training-banner",
+        ".related-content",
+        ".metadata-panel",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -993,6 +1029,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^More TED talks on AI$"),
         re.compile(r"^Listen to the episode$"),
     ),
+    "aws.amazon.com": (
+        re.compile(r"^Best practices checklist$"),
+        re.compile(r"^Related AWS guidance$"),
+        re.compile(r"^Watch the walkthrough$"),
+    ),
+    "docs.anthropic.com": (
+        re.compile(r"^Troubleshooting menu$"),
+        re.compile(r"^Related topics$"),
+        re.compile(r"^Need more help\?$"),
+    ),
+    "learn.microsoft.com": (
+        re.compile(r"^Additional resources$"),
+        re.compile(r"^Feedback$"),
+        re.compile(r"^Training available$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1265,6 +1316,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"talk-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"transcript__body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "aws.amazon.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"awsdocs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
+    ),
+    "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "learn.microsoft.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"main-content"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/anthropic-troubleshooting.html
+++ b/tests/fixtures/extraction/anthropic-troubleshooting.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI operations incident response troubleshooting</title>
+  </head>
+  <body>
+    <main>
+      <div class="theme-doc-markdown docs-content article-body">
+        <div class="breadcrumbs">Troubleshooting menu</div>
+        <div class="related-links">Related topics</div>
+        <div class="callout-banner">Need more help?</div>
+        <p>Troubleshooting docs become more useful when they explain how operators should respond after a model misbehaves in production, not just which error message was returned. The real problem is usually procedural: how people decide whether to retry, pause, or escalate.</p>
+        <p>Clear guidance on retry boundaries, human escalation, and how to recover without compounding the incident makes these pages operationally valuable.</p>
+        <p>That kind of troubleshooting guidance turns documentation into a live part of the incident workflow rather than a static appendix.</p>
+        <div class="docs-feedback">Send feedback</div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/aws-best-practices-guide.html
+++ b/tests/fixtures/extraction/aws-best-practices-guide.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>AI operations best practices</title>
+  </head>
+  <body>
+    <article>
+      <section class="awsdocs-content article-body doc-content">
+        <div class="sidebar-nav">Best practices checklist</div>
+        <div class="related-links">Related AWS guidance</div>
+        <div class="video-module">Watch the walkthrough</div>
+        <p>Best-practices guides are increasingly explicit about what AI teams must rehearse before launch. The difference between a safe rollout and a brittle one often comes down to whether teams have practiced the failure modes they say they understand.</p>
+        <p>That is why strong guides now focus on approval checkpoints, rollback exercises, and fallback ownership instead of treating operations as a postscript to model deployment.</p>
+        <p>Once those routines are written down and rehearsed, the guide becomes an operating manual instead of a marketing artifact.</p>
+        <div class="feedback-section">Was this page helpful?</div>
+      </section>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/microsoft-faq-guide.html
+++ b/tests/fixtures/extraction/microsoft-faq-guide.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>Operational governance FAQ</title>
+  </head>
+  <body>
+    <article>
+      <div class="content-body article-body main-content">
+        <div class="metadata-panel">Additional resources</div>
+        <div class="feedback-section">Feedback</div>
+        <div class="training-banner">Training available</div>
+        <p>FAQ pages are valuable when they answer the operational questions teams ask after the first outage or rollback, rather than stopping at setup instructions. Readers want to know what the control flow looks like when things go wrong.</p>
+        <p>The best answers explain who approves risky changes, how recovery is triggered, and what gets documented for review once an AI-driven workflow starts drifting.</p>
+        <p>That moves the page from a generic FAQ into a practical guide for operational governance.</p>
+        <div class="next-steps">Next steps</div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -689,6 +689,45 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("More TED talks on AI", content.text)
         self.assertNotIn("Listen to the episode", content.text)
 
+    def test_prefers_aws_best_practices_body_and_drops_checklist_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("aws-best-practices-guide.html"),
+            url="https://aws.amazon.com/architecture/2026/04/ai-operations-best-practices/",
+        )
+
+        self.assertIn("Best-practices guides are increasingly explicit about what AI teams must rehearse before launch", content.text)
+        self.assertIn("approval checkpoints, rollback exercises, and fallback ownership", content.text)
+        self.assertNotIn("Best practices checklist", content.text)
+        self.assertNotIn("Related AWS guidance", content.text)
+        self.assertNotIn("Watch the walkthrough", content.text)
+
+    def test_prefers_anthropic_troubleshooting_body_and_drops_help_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-troubleshooting.html"),
+            url="https://docs.anthropic.com/en/docs/troubleshooting/ai-operations-incident-response",
+        )
+
+        self.assertIn("Troubleshooting docs become more useful when they explain how operators should respond after a model misbehaves in production", content.text)
+        self.assertIn("retry boundaries, human escalation, and how to recover without compounding the incident", content.text)
+        self.assertNotIn("Troubleshooting menu", content.text)
+        self.assertNotIn("Related topics", content.text)
+        self.assertNotIn("Need more help?", content.text)
+
+    def test_prefers_microsoft_faq_body_and_drops_resource_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("microsoft-faq-guide.html"),
+            url="https://learn.microsoft.com/en-us/azure/ai-services/faq/operational-governance",
+        )
+
+        self.assertIn("FAQ pages are valuable when they answer the operational questions teams ask after the first outage or rollback", content.text)
+        self.assertIn("who approves risky changes, how recovery is triggered, and what gets documented for review", content.text)
+        self.assertNotIn("Additional resources", content.text)
+        self.assertNotIn("Feedback", content.text)
+        self.assertNotIn("Training available", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for AWS, Anthropic Docs, and Microsoft Learn documentation-style layouts
- extend source-specific cleanup for checklist, help navigation, and feedback-module noise
- prepare the v1.2.15 changelog, release notes, and version bump

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python