### PR TITLE
test: add API reference and changelog extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.16] - 2026-04-09
+
+### Added
+
+- API reference, developer guide, and changelog-style extraction fixtures for `docs.cohere.com`, `developer.nvidia.com`, and `vercel.com`
+
+### Changed
+
+- Package version is now `1.2.16`
+- International extraction coverage now includes API-reference, developer-guide, and changelog-update layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, and vendor documentation layouts
+
+### Fixed
+
+- Reduced navigation menus, endpoint sidebars, checklist modules, and changelog recirculation noise on documentation- and update-heavy vendor pages
+- Locked another class of API reference and product-update layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.15] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.15`
+`v1.2.16`
 
 ### Suggested Title
 
-`AI News Open v1.2.15 · Vendor Documentation Extraction Coverage`
+`AI News Open v1.2.16 · API Reference and Changelog Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.15
+## AI News Open v1.2.16
 
-AI News Open `v1.2.15` hardens extraction quality for vendor FAQ, troubleshooting, and best-practices guide layouts across more international publishers.
+AI News Open `v1.2.16` hardens extraction quality for API reference, developer guide, and changelog-style product update layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.15` hardens extraction quality for vendor FAQ, troubleshootin
 
 ### Highlights in this release
 
-- New deterministic documentation-style fixtures for `AWS`, `Anthropic Docs`, and `Microsoft Learn`
-- Better cleanup for resource sidebars, help navigation, feedback modules, and checklist recirculation on vendor documentation pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, and vendor documentation layouts
+- New deterministic documentation-style fixtures for `Cohere Docs`, `NVIDIA Developer`, and `Vercel Changelog`
+- Better cleanup for endpoint navigation, developer sidebars, checklist modules, and changelog recirculation on documentation- and update-heavy vendor pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, and API-reference/changelog layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.16.md
+++ b/docs/releases/v1.2.16.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.16
+
+AI News Open `v1.2.16` is a content-quality patch release focused on API reference, developer guide, and changelog-style product update pages. It extends the deterministic extraction suite so endpoint navigation, checklist modules, and update recirculation are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added API reference / developer guide / changelog-update extraction fixtures for:
+  - `docs.cohere.com`
+  - `developer.nvidia.com`
+  - `vercel.com`
+- Added host-specific cleanup for endpoint navigation, reference sidebars, checklist prompts, and changelog recirculation on those layouts
+- Extended the extraction regression suite to cover another class of documentation-heavy and update-heavy operational pages
+
+### Why this matters
+
+- API reference and changelog pages often mix navigation, related endpoint modules, launch clips, and checklist callouts inside the same content container as the main body
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, and API-reference/changelog layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.15"
+version = "1.2.16"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.15"
+__version__ = "1.2.16"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -353,6 +353,21 @@ HOST_SELECTORS = {
         ".article-body",
         ".main-content",
     ),
+    "docs.cohere.com": (
+        ".theme-doc-markdown",
+        ".docs-content",
+        ".reference-body",
+    ),
+    "developer.nvidia.com": (
+        ".article-body",
+        ".doc-content",
+        ".content-body",
+    ),
+    "vercel.com": (
+        ".prose",
+        ".content-body",
+        ".article-body",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -751,6 +766,27 @@ HOST_DROP_SELECTORS = {
         ".related-content",
         ".metadata-panel",
     ),
+    "docs.cohere.com": (
+        ".table-of-contents",
+        ".feedback-widget",
+        ".related-links",
+        ".changelog-banner",
+        ".breadcrumbs",
+    ),
+    "developer.nvidia.com": (
+        ".sidebar-nav",
+        ".related-resources",
+        ".video-module",
+        ".cta-banner",
+        ".toc",
+    ),
+    "vercel.com": (
+        ".related-updates",
+        ".newsletter-callout",
+        ".timeline-nav",
+        ".video-embed",
+        ".author-card",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -1044,6 +1080,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Feedback$"),
         re.compile(r"^Training available$"),
     ),
+    "docs.cohere.com": (
+        re.compile(r"^API reference menu$"),
+        re.compile(r"^Related endpoints$"),
+        re.compile(r"^Need help with integration\?$"),
+    ),
+    "developer.nvidia.com": (
+        re.compile(r"^Performance checklist$"),
+        re.compile(r"^Related NVIDIA guides$"),
+        re.compile(r"^Watch the walkthrough$"),
+    ),
+    "vercel.com": (
+        re.compile(r"^Read the changelog$"),
+        re.compile(r"^Related updates$"),
+        re.compile(r"^Watch the launch clip$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1331,6 +1382,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"main-content"}},
+    ),
+    "docs.cohere.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"reference-body"}},
+    ),
+    "developer.nvidia.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "vercel.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/cohere-api-reference.html
+++ b/tests/fixtures/extraction/cohere-api-reference.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Cohere API Reference: AI operations recovery playbook</title>
+  </head>
+  <body>
+    <nav class="breadcrumbs">Docs / Reference / AI Operations</nav>
+    <aside class="table-of-contents">API reference menu</aside>
+    <section class="theme-doc-markdown">
+      <h1>AI operations recovery playbook</h1>
+      <p>
+        API reference pages are only useful when operators can map endpoints to real recovery behavior.
+      </p>
+      <p>
+        Teams evaluating AI infrastructure want retry limits, escalation paths, and safe fallback defaults
+        spelled out in the same place as the endpoint contract.
+      </p>
+      <div class="related-links">Related endpoints</div>
+      <div class="feedback-widget">Need help with integration?</div>
+      <div class="changelog-banner">Latest changelog banner</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/nvidia-reference-guide.html
+++ b/tests/fixtures/extraction/nvidia-reference-guide.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>NVIDIA AI operations reference guide</title>
+  </head>
+  <body>
+    <aside class="sidebar-nav">Platform navigation</aside>
+    <article class="article-body">
+      <h1>AI operations reference guide</h1>
+      <p>
+        Reference guides for AI infrastructure now double as operating manuals for teams under load.
+      </p>
+      <p>
+        They are most useful when they document rollback thresholds, observable failure modes, and who owns
+        the response before a model outage reaches customers.
+      </p>
+      <div class="related-resources">Related NVIDIA guides</div>
+      <div class="video-module">Watch the walkthrough</div>
+      <div class="cta-banner">Try the newest toolkit</div>
+      <div class="toc">Performance checklist</div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/vercel-changelog-update.html
+++ b/tests/fixtures/extraction/vercel-changelog-update.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Vercel changelog: AI operations reliability updates</title>
+  </head>
+  <body>
+    <section class="prose">
+      <h1>AI operations reliability updates</h1>
+      <p>
+        Product updates are more credible when changelog entries explain what changed in operations, not
+        just in features.
+      </p>
+      <p>
+        Strong release notes cover deployment sequencing, incident ownership, and how teams should verify
+        recovery after a risky rollout.
+      </p>
+      <div class="related-updates">Related updates</div>
+      <div class="newsletter-callout">Weekly product newsletter</div>
+      <div class="timeline-nav">Read the changelog</div>
+      <div class="video-embed">Watch the launch clip</div>
+      <div class="author-card">Written by the platform team</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -728,6 +728,56 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Feedback", content.text)
         self.assertNotIn("Training available", content.text)
 
+    def test_prefers_cohere_api_reference_body_and_drops_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("cohere-api-reference.html"),
+            url="https://docs.cohere.com/reference/ai-operations-recovery-playbook",
+        )
+
+        self.assertIn(
+            "API reference pages are only useful when operators can map endpoints to real recovery behavior",
+            content.text,
+        )
+        self.assertIn("retry limits, escalation paths, and safe fallback defaults", content.text)
+        self.assertNotIn("API reference menu", content.text)
+        self.assertNotIn("Related endpoints", content.text)
+        self.assertNotIn("Need help with integration?", content.text)
+
+    def test_prefers_nvidia_reference_body_and_drops_checklist_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("nvidia-reference-guide.html"),
+            url="https://developer.nvidia.com/blog/ai-operations-reference-guide",
+        )
+
+        self.assertIn(
+            "Reference guides for AI infrastructure now double as operating manuals for teams under load",
+            content.text,
+        )
+        self.assertIn("rollback thresholds, observable failure modes", content.text)
+        self.assertIn("who owns", content.text)
+        self.assertNotIn("Performance checklist", content.text)
+        self.assertNotIn("Related NVIDIA guides", content.text)
+        self.assertNotIn("Watch the walkthrough", content.text)
+
+    def test_prefers_vercel_changelog_body_and_drops_update_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("vercel-changelog-update.html"),
+            url="https://vercel.com/changelog/ai-operations-reliability-updates",
+        )
+
+        self.assertIn(
+            "Product updates are more credible when changelog entries explain what changed in operations",
+            content.text,
+        )
+        self.assertIn("deployment sequencing, incident ownership", content.text)
+        self.assertIn("how teams should verify", content.text)
+        self.assertNotIn("Read the changelog", content.text)
+        self.assertNotIn("Related updates", content.text)
+        self.assertNotIn("Watch the launch clip", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for Cohere Docs, NVIDIA Developer, and the Vercel changelog
- extend host-specific cleanup for API reference, developer guide, and changelog-style layouts
- prepare the v1.2.16 version bump, changelog entry, and release notes

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python