### PR TITLE
test: add migration and deprecation extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.17] - 2026-04-09
+
+### Added
+
+- Migration guide, deprecation notice, and upgrade guide extraction fixtures for `docs.langchain.com`, `developer.atlassian.com`, and `supabase.com`
+
+### Changed
+
+- Package version is now `1.2.17`
+- International extraction coverage now includes migration-guide, deprecation-notice, and upgrade-guide layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, and API-reference/changelog layouts
+
+### Fixed
+
+- Reduced migration menus, deprecation banners, upgrade CTAs, and related-doc recirculation noise on developer-doc and change-management pages
+- Locked another class of migration and deprecation layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.16] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.16`
+`v1.2.17`
 
 ### Suggested Title
 
-`AI News Open v1.2.16 · API Reference and Changelog Extraction Coverage`
+`AI News Open v1.2.17 · Migration and Deprecation Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.16
+## AI News Open v1.2.17
 
-AI News Open `v1.2.16` hardens extraction quality for API reference, developer guide, and changelog-style product update layouts across more international publishers.
+AI News Open `v1.2.17` hardens extraction quality for migration guides, deprecation notices, and upgrade-guide layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.16` hardens extraction quality for API reference, developer g
 
 ### Highlights in this release
 
-- New deterministic documentation-style fixtures for `Cohere Docs`, `NVIDIA Developer`, and `Vercel Changelog`
-- Better cleanup for endpoint navigation, developer sidebars, checklist modules, and changelog recirculation on documentation- and update-heavy vendor pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, and API-reference/changelog layouts
+- New deterministic documentation-style fixtures for `LangChain Docs`, `Atlassian Developer`, and `Supabase Docs`
+- Better cleanup for migration navigation, deprecation banners, upgrade CTAs, and related-doc recirculation on change-management-heavy developer pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, and migration/deprecation layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.17.md
+++ b/docs/releases/v1.2.17.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.17
+
+AI News Open `v1.2.17` is a content-quality patch release focused on migration guides, deprecation notices, and upgrade-guide pages. It extends the deterministic extraction suite so migration navigation, deprecation banners, and upgrade CTAs are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added migration-guide / deprecation-notice / upgrade-guide extraction fixtures for:
+  - `docs.langchain.com`
+  - `developer.atlassian.com`
+  - `supabase.com`
+- Added host-specific cleanup for migration navigation, deprecation banners, related-doc blocks, and upgrade CTAs on those layouts
+- Extended the extraction regression suite to cover another class of change-management-heavy developer documentation pages
+
+### Why this matters
+
+- Migration and deprecation pages often mix navigation, banners, upgrade prompts, and related-doc modules inside the same container as the actual operational guidance
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, and migration/deprecation layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.16"
+version = "1.2.17"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -368,6 +368,21 @@ HOST_SELECTORS = {
         ".content-body",
         ".article-body",
     ),
+    "docs.langchain.com": (
+        ".theme-doc-markdown",
+        ".docs-content",
+        ".migration-guide",
+    ),
+    "developer.atlassian.com": (
+        ".doc-content",
+        ".article-body",
+        ".content-body",
+    ),
+    "supabase.com": (
+        ".prose",
+        ".content-body",
+        ".docs-content",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -787,6 +802,27 @@ HOST_DROP_SELECTORS = {
         ".video-embed",
         ".author-card",
     ),
+    "docs.langchain.com": (
+        ".table-of-contents",
+        ".pagination-nav",
+        ".related-links",
+        ".feedback-widget",
+        ".theme-doc-breadcrumbs",
+    ),
+    "developer.atlassian.com": (
+        ".left-nav",
+        ".deprecation-banner",
+        ".related-resources",
+        ".feedback-prompt",
+        ".page-actions",
+    ),
+    "supabase.com": (
+        ".steps-nav",
+        ".video-callout",
+        ".related-guides",
+        ".cta-panel",
+        ".sidebar-toc",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -1095,6 +1131,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Related updates$"),
         re.compile(r"^Watch the launch clip$"),
     ),
+    "docs.langchain.com": (
+        re.compile(r"^Migration guide menu$"),
+        re.compile(r"^Related migration steps$"),
+        re.compile(r"^Was this page helpful\?$"),
+    ),
+    "developer.atlassian.com": (
+        re.compile(r"^Deprecation timeline$"),
+        re.compile(r"^Related Atlassian docs$"),
+        re.compile(r"^Was this helpful\?$"),
+    ),
+    "supabase.com": (
+        re.compile(r"^Watch the migration walkthrough$"),
+        re.compile(r"^Related upgrade guides$"),
+        re.compile(r"^Start building$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1397,6 +1448,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "docs.langchain.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"migration-guide"}},
+    ),
+    "developer.atlassian.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+    ),
+    "supabase.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/atlassian-deprecation-notice.html
+++ b/tests/fixtures/extraction/atlassian-deprecation-notice.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Atlassian deprecation notice for incident response API</title>
+  </head>
+  <body>
+    <aside class="left-nav">Developer navigation</aside>
+    <article class="doc-content">
+      <h1>Incident response API deprecation notice</h1>
+      <p>
+        Deprecation notices matter when they tell operators what breaks, when it breaks, and how to
+        migrate safely.
+      </p>
+      <p>
+        The useful ones spell out shutdown dates, compatibility windows, and which ownership checks must be
+        updated before the old interface disappears.
+      </p>
+      <div class="related-resources">Related Atlassian docs</div>
+      <div class="feedback-prompt">Was this helpful?</div>
+      <div class="deprecation-banner">Deprecation timeline</div>
+      <div class="page-actions">Edit this page</div>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/extraction/langchain-migration-guide.html
+++ b/tests/fixtures/extraction/langchain-migration-guide.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>LangChain migration guide for AI operations observability</title>
+  </head>
+  <body>
+    <nav class="theme-doc-breadcrumbs">Docs / Migration</nav>
+    <aside class="table-of-contents">Migration guide menu</aside>
+    <section class="theme-doc-markdown">
+      <h1>AI operations observability migration guide</h1>
+      <p>
+        Migration guides are useful only when they explain how operators move production systems without
+        losing observability.
+      </p>
+      <p>
+        The strongest guides document cutover steps, fallback plans, and which dashboards must stay
+        comparable before and after the migration.
+      </p>
+      <div class="related-links">Related migration steps</div>
+      <div class="feedback-widget">Was this page helpful?</div>
+      <div class="pagination-nav">Next section</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/supabase-upgrade-guide.html
+++ b/tests/fixtures/extraction/supabase-upgrade-guide.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Supabase AI operations rollout upgrade guide</title>
+  </head>
+  <body>
+    <section class="prose">
+      <h1>AI operations rollout upgrade guide</h1>
+      <p>
+        Upgrade guides are strongest when they tell teams how to move production traffic without hiding new
+        failure modes.
+      </p>
+      <p>
+        Good upgrade notes include verification steps, rollback handles, and how incident review should
+        change after the cutover.
+      </p>
+      <div class="related-guides">Related upgrade guides</div>
+      <div class="video-callout">Watch the migration walkthrough</div>
+      <div class="cta-panel">Start building</div>
+      <div class="sidebar-toc">Sidebar navigation</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -778,6 +778,56 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related updates", content.text)
         self.assertNotIn("Watch the launch clip", content.text)
 
+    def test_prefers_langchain_migration_guide_body_and_drops_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("langchain-migration-guide.html"),
+            url="https://docs.langchain.com/docs/migration/ai-operations-observability",
+        )
+
+        self.assertIn("Migration guides are useful only when they explain how operators move production systems", content.text)
+        self.assertIn("losing observability", content.text)
+        self.assertIn("cutover steps, fallback plans", content.text)
+        self.assertIn("which dashboards must stay", content.text)
+        self.assertIn("comparable", content.text)
+        self.assertNotIn("Migration guide menu", content.text)
+        self.assertNotIn("Related migration steps", content.text)
+        self.assertNotIn("Was this page helpful?", content.text)
+
+    def test_prefers_atlassian_deprecation_notice_body_and_drops_banner_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("atlassian-deprecation-notice.html"),
+            url="https://developer.atlassian.com/platform/ai/deprecations/incident-response-api",
+        )
+
+        self.assertIn("Deprecation notices matter when they tell operators what breaks", content.text)
+        self.assertIn("how to", content.text)
+        self.assertIn("migrate safely", content.text)
+        self.assertIn("shutdown dates, compatibility windows", content.text)
+        self.assertIn("which ownership checks must be", content.text)
+        self.assertIn("updated", content.text)
+        self.assertNotIn("Deprecation timeline", content.text)
+        self.assertNotIn("Related Atlassian docs", content.text)
+        self.assertNotIn("Was this helpful?", content.text)
+
+    def test_prefers_supabase_upgrade_guide_body_and_drops_cta_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("supabase-upgrade-guide.html"),
+            url="https://supabase.com/docs/guides/upgrade/ai-operations-rollout",
+        )
+
+        self.assertIn("Upgrade guides are strongest when they tell teams how to move production traffic", content.text)
+        self.assertIn("hiding new", content.text)
+        self.assertIn("failure modes", content.text)
+        self.assertIn("verification steps, rollback handles", content.text)
+        self.assertIn("how incident review should", content.text)
+        self.assertIn("change", content.text)
+        self.assertNotIn("Watch the migration walkthrough", content.text)
+        self.assertNotIn("Related upgrade guides", content.text)
+        self.assertNotIn("Start building", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for LangChain Docs, Atlassian Developer, and Supabase Docs
- extend host-specific cleanup for migration-guide, deprecation-notice, and upgrade-guide layouts
- prepare the v1.2.17 version bump, changelog entry, and release notes

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python