### PR TITLE
test: add deprecation FAQ and versioned-doc extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.18] - 2026-04-09
+
+### Added
+
+- Deprecation FAQ, migration checklist, and versioned-doc notice extraction fixtures for `platform.openai.com`, `docs.pinecone.io`, and `docs.vllm.ai`
+
+### Changed
+
+- Package version is now `1.2.18`
+- International extraction coverage now includes deprecation-FAQ, migration-checklist, and versioned-doc-notice layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, and migration/deprecation layouts
+
+### Fixed
+
+- Reduced deprecation sidebars, checklist navigation, version banners, and related-doc recirculation noise on AI developer-documentation pages
+- Locked another class of deprecation and versioned-doc layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.17] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.17`
+`v1.2.18`
 
 ### Suggested Title
 
-`AI News Open v1.2.17 · Migration and Deprecation Extraction Coverage`
+`AI News Open v1.2.18 · Deprecation FAQ and Versioned Docs Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.17
+## AI News Open v1.2.18
 
-AI News Open `v1.2.17` hardens extraction quality for migration guides, deprecation notices, and upgrade-guide layouts across more international publishers.
+AI News Open `v1.2.18` hardens extraction quality for deprecation FAQs, migration checklists, and versioned-doc notice layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.17` hardens extraction quality for migration guides, deprecat
 
 ### Highlights in this release
 
-- New deterministic documentation-style fixtures for `LangChain Docs`, `Atlassian Developer`, and `Supabase Docs`
-- Better cleanup for migration navigation, deprecation banners, upgrade CTAs, and related-doc recirculation on change-management-heavy developer pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, and migration/deprecation layouts
+- New deterministic documentation-style fixtures for `OpenAI Platform Docs`, `Pinecone Docs`, and `vLLM Docs`
+- Better cleanup for deprecation sidebars, checklist navigation, version banners, and related-doc recirculation on AI developer-doc pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, and versioned-doc-notice layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.18.md
+++ b/docs/releases/v1.2.18.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.18
+
+AI News Open `v1.2.18` is a content-quality patch release focused on deprecation FAQs, migration checklists, and versioned-doc notice pages. It extends the deterministic extraction suite so deprecation sidebars, checklist navigation, and version warning modules are removed with source-specific cleanup instead of leaking into extracted article text.
+
+### What changed
+
+- Added deprecation-FAQ / migration-checklist / versioned-doc-notice extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.pinecone.io`
+  - `docs.vllm.ai`
+- Added host-specific cleanup for deprecation sidebars, checklist navigation, related-doc blocks, and version warning modules on those layouts
+- Extended the extraction regression suite to cover another class of AI developer-documentation pages
+
+### Why this matters
+
+- Deprecation FAQs and versioned docs frequently mix banners, sidebars, migration prompts, and related-doc modules inside the same container as the real operator guidance
+- Locking those shapes into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, and versioned-doc-notice layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.17"
+version = "1.2.18"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.17"
+__version__ = "1.2.18"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -383,6 +383,21 @@ HOST_SELECTORS = {
         ".content-body",
         ".docs-content",
     ),
+    "platform.openai.com": (
+        ".docs-body",
+        ".prose",
+        ".article-body",
+    ),
+    "docs.pinecone.io": (
+        ".theme-doc-markdown",
+        ".docs-content",
+        ".migration-checklist",
+    ),
+    "docs.vllm.ai": (
+        ".md-content",
+        ".content-body",
+        ".document",
+    ),
     "theguardian.com": (
         ".liveblog__body",
         ".content__article-body",
@@ -823,6 +838,27 @@ HOST_DROP_SELECTORS = {
         ".cta-panel",
         ".sidebar-toc",
     ),
+    "platform.openai.com": (
+        ".faq-nav",
+        ".deprecation-callout",
+        ".related-answers",
+        ".feedback-widget",
+        ".docs-sidebar",
+    ),
+    "docs.pinecone.io": (
+        ".table-of-contents",
+        ".checklist-nav",
+        ".related-guides",
+        ".feedback-widget",
+        ".breadcrumbs",
+    ),
+    "docs.vllm.ai": (
+        ".version-warning",
+        ".related-pages",
+        ".page-nav",
+        ".edit-link",
+        ".sidebar-toc",
+    ),
     "theguardian.com": (
         ".submeta",
         ".email-sign-up",
@@ -1146,6 +1182,21 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Related upgrade guides$"),
         re.compile(r"^Start building$"),
     ),
+    "platform.openai.com": (
+        re.compile(r"^Deprecation FAQ$"),
+        re.compile(r"^Related answers$"),
+        re.compile(r"^Was this helpful\?$"),
+    ),
+    "docs.pinecone.io": (
+        re.compile(r"^Migration checklist$"),
+        re.compile(r"^Related Pinecone guides$"),
+        re.compile(r"^Need more help\?$"),
+    ),
+    "docs.vllm.ai": (
+        re.compile(r"^Version notice$"),
+        re.compile(r"^Related versioned pages$"),
+        re.compile(r"^Edit on GitHub$"),
+    ),
     "theguardian.com": (
         re.compile(r"^Live feed$"),
         re.compile(r"^\d{1,2}\.\d{2}\s*(?:AM|PM)\s*[A-Z]{2,4}$"),
@@ -1463,6 +1514,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+    ),
+    "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "docs.pinecone.io": (
+        {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
+    ),
+    "docs.vllm.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"md-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"document"}},
     ),
     "theguardian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"liveblog__body"}},

--- a/tests/fixtures/extraction/openai-deprecation-faq.html
+++ b/tests/fixtures/extraction/openai-deprecation-faq.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>OpenAI deprecation FAQ for AI operations endpoint retirement</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs navigation</aside>
+    <section class="docs-body">
+      <h1>AI operations endpoint retirement FAQ</h1>
+      <p>
+        Deprecation FAQs are useful when they answer what changes for operators, which runbooks must
+        change, and how compatibility windows affect production traffic.
+      </p>
+      <p>
+        The best ones explain what to monitor during rollout and what fallback path still exists after the
+        old endpoint is retired.
+      </p>
+      <div class="faq-nav">Deprecation FAQ</div>
+      <div class="related-answers">Related answers</div>
+      <div class="feedback-widget">Was this helpful?</div>
+      <div class="deprecation-callout">Service retirement banner</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/pinecone-migration-checklist.html
+++ b/tests/fixtures/extraction/pinecone-migration-checklist.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Pinecone migration checklist for AI operations</title>
+  </head>
+  <body>
+    <nav class="breadcrumbs">Docs / Guides / Migration</nav>
+    <aside class="table-of-contents">Migration checklist</aside>
+    <section class="theme-doc-markdown">
+      <h1>AI operations migration checklist</h1>
+      <p>
+        Migration checklists are most valuable when they tell teams what must be verified before traffic
+        shifts and which rollback handles stay available during the cutover.
+      </p>
+      <p>
+        Strong checklists also name the incident checkpoints that operators should rehearse before the new
+        stack becomes the default path.
+      </p>
+      <div class="checklist-nav">Step navigation</div>
+      <div class="related-guides">Related Pinecone guides</div>
+      <div class="feedback-widget">Need more help?</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/vllm-version-notice.html
+++ b/tests/fixtures/extraction/vllm-version-notice.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>vLLM versioned docs notice for AI operations upgrade</title>
+  </head>
+  <body>
+    <section class="md-content">
+      <h1>AI operations upgrade notice</h1>
+      <p>
+        Versioned docs notices matter when they explain what changed between supported releases, what
+        operator expectations must change, and which benchmark views remain comparable.
+      </p>
+      <p>
+        The useful ones also document fallback procedures and benchmark comparability so teams can verify an
+        upgrade without losing operational context.
+      </p>
+      <div class="version-warning">Version notice</div>
+      <div class="related-pages">Related versioned pages</div>
+      <div class="edit-link">Edit on GitHub</div>
+      <div class="sidebar-toc">Version sidebar</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -828,6 +828,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related upgrade guides", content.text)
         self.assertNotIn("Start building", content.text)
 
+    def test_prefers_openai_deprecation_faq_body_and_drops_sidebar_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-deprecation-faq.html"),
+            url="https://platform.openai.com/docs/deprecations/faq/ai-operations-endpoint-retirement",
+        )
+
+        self.assertIn("Deprecation FAQs are useful when they answer what changes for operators", content.text)
+        self.assertIn("which runbooks must", content.text)
+        self.assertIn("change", content.text)
+        self.assertIn("how compatibility windows affect production traffic", content.text)
+        self.assertNotIn("Service retirement banner", content.text)
+        self.assertNotIn("Related answers", content.text)
+        self.assertNotIn("Was this helpful?", content.text)
+
+    def test_prefers_pinecone_migration_checklist_body_and_drops_checklist_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("pinecone-migration-checklist.html"),
+            url="https://docs.pinecone.io/guides/migration/ai-operations-checklist",
+        )
+
+        self.assertIn("Migration checklists are most valuable when they tell teams what must be verified", content.text)
+        self.assertIn("before traffic", content.text)
+        self.assertIn("shifts", content.text)
+        self.assertIn("rollback handles stay available", content.text)
+        self.assertIn("incident checkpoints", content.text)
+        self.assertNotIn("Step navigation", content.text)
+        self.assertNotIn("Related Pinecone guides", content.text)
+        self.assertNotIn("Need more help?", content.text)
+
+    def test_prefers_vllm_version_notice_body_and_drops_version_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("vllm-version-notice.html"),
+            url="https://docs.vllm.ai/en/latest/notes/versioned/ai-operations-upgrade-notice.html",
+        )
+
+        self.assertIn("Versioned docs notices matter when they explain what changed between supported releases", content.text)
+        self.assertIn("operator expectations", content.text)
+        self.assertIn("fallback procedures and benchmark comparability", content.text)
+        self.assertNotIn("Version notice", content.text)
+        self.assertNotIn("Related versioned pages", content.text)
+        self.assertNotIn("Edit on GitHub", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic extraction fixtures for OpenAI Platform Docs, Pinecone Docs, and vLLM Docs
- extend host-specific cleanup for deprecation-FAQ, migration-checklist, and versioned-doc notice layouts
- prepare the v1.2.18 version bump, changelog entry, and release notes

## Testing
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python