### PR TITLE
test: add support policy extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.19] - 2026-04-09
+
+### Added
+
+- Support-policy, compatibility-matrix, and release-channel-note extraction fixtures for `docs.llamaindex.ai`, `docs.together.ai`, and `docs.fireworks.ai`
+
+### Changed
+
+- Package version is now `1.2.19`
+- International extraction coverage now includes support-policy, compatibility-matrix, and release-channel-note layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, and versioned-doc-notice layouts
+
+### Fixed
+
+- Reduced compatibility sidebars, support-policy banners, release-channel navigation, and related-doc recirculation noise on AI developer-documentation pages
+- Locked another class of support-policy and compatibility layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.18] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.18`
+`v1.2.19`
 
 ### Suggested Title
 
-`AI News Open v1.2.18 · Deprecation FAQ and Versioned Docs Extraction Coverage`
+`AI News Open v1.2.19 · Support Policy and Compatibility Matrix Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.18
+## AI News Open v1.2.19
 
-AI News Open `v1.2.18` hardens extraction quality for deprecation FAQs, migration checklists, and versioned-doc notice layouts across more international publishers.
+AI News Open `v1.2.19` hardens extraction quality for support-policy, compatibility-matrix, and release-channel-note layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.18` hardens extraction quality for deprecation FAQs, migratio
 
 ### Highlights in this release
 
-- New deterministic documentation-style fixtures for `OpenAI Platform Docs`, `Pinecone Docs`, and `vLLM Docs`
-- Better cleanup for deprecation sidebars, checklist navigation, version banners, and related-doc recirculation on AI developer-doc pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, and versioned-doc-notice layouts
+- New deterministic documentation-style fixtures for `LlamaIndex Docs`, `Together Docs`, and `Fireworks Docs`
+- Better cleanup for compatibility sidebars, support banners, release-channel navigation, and related-doc recirculation on AI developer-doc pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, and release-channel-note layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.19.md
+++ b/docs/releases/v1.2.19.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.19
+
+AI News Open `v1.2.19` is a content-quality patch release focused on support-policy, compatibility-matrix, and release-channel-note pages. It extends deterministic extraction coverage for another class of AI developer-documentation layouts where side navigation and vendor prompts often sit beside the real operator guidance.
+
+### What changed
+
+- Added support-policy / compatibility-matrix / release-channel-note extraction fixtures for:
+  - `docs.llamaindex.ai`
+  - `docs.together.ai`
+  - `docs.fireworks.ai`
+- Added host-specific cleanup for matrix navigation, support banners, related-doc blocks, and release-channel prompts on those layouts
+- Extended the extraction regression suite to cover another class of AI developer-documentation pages
+
+### Why this matters
+
+- Compatibility and support-policy pages often mix sidebar navigation, version banners, and related-doc recirculation inside the same content region as the operational guidance teams actually need
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, and release-channel-note layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.18"
+version = "1.2.19"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.18"
+__version__ = "1.2.19"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -358,6 +358,11 @@ HOST_SELECTORS = {
         ".docs-content",
         ".reference-body",
     ),
+    "docs.fireworks.ai": (
+        ".theme-doc-markdown",
+        ".docs-content",
+        ".release-channel-note",
+    ),
     "developer.nvidia.com": (
         ".article-body",
         ".doc-content",
@@ -372,6 +377,11 @@ HOST_SELECTORS = {
         ".theme-doc-markdown",
         ".docs-content",
         ".migration-guide",
+    ),
+    "docs.llamaindex.ai": (
+        ".theme-doc-markdown",
+        ".docs-content",
+        ".compatibility-matrix",
     ),
     "developer.atlassian.com": (
         ".doc-content",
@@ -392,6 +402,11 @@ HOST_SELECTORS = {
         ".theme-doc-markdown",
         ".docs-content",
         ".migration-checklist",
+    ),
+    "docs.together.ai": (
+        ".docs-body",
+        ".content-body",
+        ".article-body",
     ),
     "docs.vllm.ai": (
         ".md-content",
@@ -803,6 +818,13 @@ HOST_DROP_SELECTORS = {
         ".changelog-banner",
         ".breadcrumbs",
     ),
+    "docs.fireworks.ai": (
+        ".channel-nav",
+        ".version-banner",
+        ".related-guides",
+        ".edit-page-link",
+        ".breadcrumbs",
+    ),
     "developer.nvidia.com": (
         ".sidebar-nav",
         ".related-resources",
@@ -823,6 +845,13 @@ HOST_DROP_SELECTORS = {
         ".related-links",
         ".feedback-widget",
         ".theme-doc-breadcrumbs",
+    ),
+    "docs.llamaindex.ai": (
+        ".table-of-contents",
+        ".matrix-nav",
+        ".related-guides",
+        ".feedback-widget",
+        ".breadcrumbs",
     ),
     "developer.atlassian.com": (
         ".left-nav",
@@ -851,6 +880,13 @@ HOST_DROP_SELECTORS = {
         ".related-guides",
         ".feedback-widget",
         ".breadcrumbs",
+    ),
+    "docs.together.ai": (
+        ".policy-sidebar",
+        ".support-banner",
+        ".related-articles",
+        ".feedback-widget",
+        ".sidebar-toc",
     ),
     "docs.vllm.ai": (
         ".version-warning",
@@ -1157,6 +1193,11 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Related endpoints$"),
         re.compile(r"^Need help with integration\?$"),
     ),
+    "docs.fireworks.ai": (
+        re.compile(r"^Release channels$"),
+        re.compile(r"^Related Fireworks guides$"),
+        re.compile(r"^Edit this page$"),
+    ),
     "developer.nvidia.com": (
         re.compile(r"^Performance checklist$"),
         re.compile(r"^Related NVIDIA guides$"),
@@ -1170,6 +1211,11 @@ HOST_NOISE_LINE_PATTERNS = {
     "docs.langchain.com": (
         re.compile(r"^Migration guide menu$"),
         re.compile(r"^Related migration steps$"),
+        re.compile(r"^Was this page helpful\?$"),
+    ),
+    "docs.llamaindex.ai": (
+        re.compile(r"^Compatibility matrix$"),
+        re.compile(r"^Related LlamaIndex docs$"),
         re.compile(r"^Was this page helpful\?$"),
     ),
     "developer.atlassian.com": (
@@ -1190,6 +1236,11 @@ HOST_NOISE_LINE_PATTERNS = {
     "docs.pinecone.io": (
         re.compile(r"^Migration checklist$"),
         re.compile(r"^Related Pinecone guides$"),
+        re.compile(r"^Need more help\?$"),
+    ),
+    "docs.together.ai": (
+        re.compile(r"^Support policy$"),
+        re.compile(r"^Related Together docs$"),
         re.compile(r"^Need more help\?$"),
     ),
     "docs.vllm.ai": (
@@ -1490,6 +1541,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"reference-body"}},
     ),
+    "docs.fireworks.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"release-channel-note"}},
+    ),
     "developer.nvidia.com": (
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
@@ -1504,6 +1560,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"migration-guide"}},
+    ),
+    "docs.llamaindex.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
+        {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"compatibility-matrix"}},
     ),
     "developer.atlassian.com": (
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
@@ -1524,6 +1585,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
+    ),
+    "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
     ),
     "docs.vllm.ai": (
         {"tags": {"div", "section"}, "class_tokens": {"md-content"}},

--- a/tests/fixtures/extraction/fireworks-release-channel-note.html
+++ b/tests/fixtures/extraction/fireworks-release-channel-note.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Fireworks release channel note for enterprise AI operations</title>
+  </head>
+  <body>
+    <section class="theme-doc-markdown">
+      <h1>Enterprise release channel guidance</h1>
+      <p>
+        Release-channel notes matter when they explain which preview and stable tracks carry operational
+        risk, how rollout timing affects benchmark parity, and when teams should promote a new serving stack
+        into production.
+      </p>
+      <p>
+        Useful channel docs also call out rollback triggers, incident ownership, and observability checks
+        that must pass before the stable channel changes.
+      </p>
+      <div class="channel-nav">Release channels</div>
+      <div class="version-banner">Preview channel banner</div>
+      <div class="related-guides">Related Fireworks guides</div>
+      <div class="edit-page-link">Edit this page</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/llamaindex-compatibility-matrix.html
+++ b/tests/fixtures/extraction/llamaindex-compatibility-matrix.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>LlamaIndex compatibility matrix for AI operations stacks</title>
+  </head>
+  <body>
+    <section class="theme-doc-markdown">
+      <h1>AI operations compatibility matrix</h1>
+      <p>
+        Compatibility matrices are useful when they tell operators which model providers, vector stores,
+        and orchestration layers are supported together in production, where fallback behavior changes, and
+        what upgrade combinations remain safe during staged rollout.
+      </p>
+      <p>
+        Strong matrices also explain how deprecation windows, testing scope, and rollback limits should
+        influence release planning for AI teams.
+      </p>
+      <div class="table-of-contents">Compatibility matrix</div>
+      <div class="matrix-nav">Matrix navigation</div>
+      <div class="related-guides">Related LlamaIndex docs</div>
+      <div class="feedback-widget">Was this page helpful?</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-support-policy.html
+++ b/tests/fixtures/extraction/together-support-policy.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Together support policy for production inference operations</title>
+  </head>
+  <body>
+    <section class="docs-body">
+      <h1>Production inference support policy</h1>
+      <p>
+        Support policies are useful when they spell out what service levels apply to inference workloads,
+        which model versions receive security fixes, and how customers should plan migrations before support
+        windows close.
+      </p>
+      <p>
+        Good policies also define escalation paths, maintenance exceptions, and rollback expectations for
+        teams running production AI traffic.
+      </p>
+      <div class="policy-sidebar">Support policy</div>
+      <div class="support-banner">Enterprise support banner</div>
+      <div class="related-articles">Related Together docs</div>
+      <div class="feedback-widget">Need more help?</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -873,6 +873,53 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related versioned pages", content.text)
         self.assertNotIn("Edit on GitHub", content.text)
 
+    def test_prefers_llamaindex_compatibility_matrix_body_and_drops_matrix_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("llamaindex-compatibility-matrix.html"),
+            url="https://docs.llamaindex.ai/en/stable/getting_started/compatibility/ai-operations-matrix",
+        )
+
+        self.assertIn("Compatibility matrices are useful when they tell operators which model providers", content.text)
+        self.assertIn("fallback behavior changes", content.text)
+        self.assertIn("upgrade combinations remain safe", content.text)
+        self.assertIn("rollback limits should", content.text)
+        self.assertIn("influence release planning", content.text)
+        self.assertNotIn("Compatibility matrix", content.text)
+        self.assertNotIn("Matrix navigation", content.text)
+        self.assertNotIn("Related LlamaIndex docs", content.text)
+
+    def test_prefers_together_support_policy_body_and_drops_support_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-support-policy.html"),
+            url="https://docs.together.ai/docs/support-policy/ai-inference-ops",
+        )
+
+        self.assertIn("Support policies are useful when they spell out what service levels apply", content.text)
+        self.assertIn("which model versions receive security fixes", content.text)
+        self.assertIn("migrations before support", content.text)
+        self.assertIn("windows close", content.text)
+        self.assertIn("rollback expectations", content.text)
+        self.assertNotIn("Support policy", content.text)
+        self.assertNotIn("Related Together docs", content.text)
+        self.assertNotIn("Need more help?", content.text)
+
+    def test_prefers_fireworks_release_channel_note_body_and_drops_channel_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("fireworks-release-channel-note.html"),
+            url="https://docs.fireworks.ai/guides/release-channels/enterprise-ai-ops",
+        )
+
+        self.assertIn("Release-channel notes matter when they explain which preview and stable tracks", content.text)
+        self.assertIn("rollout timing affects benchmark parity", content.text)
+        self.assertIn("rollback triggers, incident ownership", content.text)
+        self.assertIn("stable channel changes", content.text)
+        self.assertNotIn("Release channels", content.text)
+        self.assertNotIn("Related Fireworks guides", content.text)
+        self.assertNotIn("Edit this page", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic fixtures for support-policy, compatibility-matrix, and release-channel-note AI developer-doc layouts
- extend host-specific selector, cleanup, and fallback coverage for docs.llamaindex.ai, docs.together.ai, and docs.fireworks.ai
- prepare the v1.2.19 changelog, release notes, and launch copy

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
