### PR TITLE
test: add status incident extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.20] - 2026-04-09
+
+### Added
+
+- Incident-update, postmortem, and outage-RCA extraction fixtures for `status.openai.com`, `status.pinecone.io`, and `status.together.ai`
+
+### Changed
+
+- Package version is now `1.2.20`
+- International extraction coverage now includes incident-update, postmortem, and outage-RCA layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, and release-channel-note layouts
+
+### Fixed
+
+- Reduced affected-component sidebars, status banners, incident navigation, and related-incident recirculation noise on vendor status and outage-notice pages
+- Locked another class of incident and postmortem layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.19] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.19`
+`v1.2.20`
 
 ### Suggested Title
 
-`AI News Open v1.2.19 · Support Policy and Compatibility Matrix Extraction Coverage`
+`AI News Open v1.2.20 · Incident Update and Postmortem Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.19
+## AI News Open v1.2.20
 
-AI News Open `v1.2.19` hardens extraction quality for support-policy, compatibility-matrix, and release-channel-note layouts across more international publishers.
+AI News Open `v1.2.20` hardens extraction quality for incident-update, postmortem, and outage-RCA layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.19` hardens extraction quality for support-policy, compatibil
 
 ### Highlights in this release
 
-- New deterministic documentation-style fixtures for `LlamaIndex Docs`, `Together Docs`, and `Fireworks Docs`
-- Better cleanup for compatibility sidebars, support banners, release-channel navigation, and related-doc recirculation on AI developer-doc pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, and release-channel-note layouts
+- New deterministic operational-status fixtures for `OpenAI Status`, `Pinecone Status`, and `Together Status`
+- Better cleanup for affected-component sidebars, status banners, incident navigation, and related-incident recirculation on vendor status and outage pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, and outage-RCA layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.20.md
+++ b/docs/releases/v1.2.20.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.20
+
+AI News Open `v1.2.20` is a content-quality patch release focused on incident updates, postmortems, and outage RCA pages. It extends deterministic extraction coverage for another class of operational vendor pages where status banners, component lists, and subscription prompts often sit beside the real guidance operators need.
+
+### What changed
+
+- Added incident-update / postmortem / outage-RCA extraction fixtures for:
+  - `status.openai.com`
+  - `status.pinecone.io`
+  - `status.together.ai`
+- Added host-specific cleanup for affected-component blocks, status banners, incident navigation, and related-incident modules on those layouts
+- Extended the extraction regression suite to cover another class of operational vendor pages
+
+### Why this matters
+
+- Incident and postmortem pages often mix component summaries, subscription prompts, and repeated timeline navigation inside the same content region as the real operational explanation
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, and outage-RCA layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.19"
+version = "1.2.20"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.19"
+__version__ = "1.2.20"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -408,6 +408,21 @@ HOST_SELECTORS = {
         ".content-body",
         ".article-body",
     ),
+    "status.openai.com": (
+        ".incident-updates-container",
+        ".update-body",
+        ".incident-body",
+    ),
+    "status.pinecone.io": (
+        ".postmortem-content",
+        ".incident-body",
+        ".update-body",
+    ),
+    "status.together.ai": (
+        ".incident-detail",
+        ".rca-body",
+        ".update-body",
+    ),
     "docs.vllm.ai": (
         ".md-content",
         ".content-body",
@@ -888,6 +903,27 @@ HOST_DROP_SELECTORS = {
         ".feedback-widget",
         ".sidebar-toc",
     ),
+    "status.openai.com": (
+        ".incident-sidebar",
+        ".affected-components",
+        ".status-banner",
+        ".subscribe-pane",
+        ".incident-timeline-nav",
+    ),
+    "status.pinecone.io": (
+        ".postmortem-meta",
+        ".related-incidents",
+        ".status-banner",
+        ".subscribe-pane",
+        ".component-list",
+    ),
+    "status.together.ai": (
+        ".impact-summary",
+        ".related-incidents",
+        ".status-banner",
+        ".subscribe-pane",
+        ".incident-nav",
+    ),
     "docs.vllm.ai": (
         ".version-warning",
         ".related-pages",
@@ -1243,6 +1279,24 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Related Together docs$"),
         re.compile(r"^Need more help\?$"),
     ),
+    "status.openai.com": (
+        re.compile(r"^Affected components$"),
+        re.compile(r"^Subscribe to updates$"),
+        re.compile(r"^Status update banner$"),
+        re.compile(r"^Incident timeline$"),
+    ),
+    "status.pinecone.io": (
+        re.compile(r"^Postmortem metadata$"),
+        re.compile(r"^Related incidents$"),
+        re.compile(r"^Subscribe to incident updates$"),
+        re.compile(r"^Affected services$"),
+    ),
+    "status.together.ai": (
+        re.compile(r"^Impact summary$"),
+        re.compile(r"^Related incidents$"),
+        re.compile(r"^Subscribe to updates$"),
+        re.compile(r"^Incident navigation$"),
+    ),
     "docs.vllm.ai": (
         re.compile(r"^Version notice$"),
         re.compile(r"^Related versioned pages$"),
@@ -1590,6 +1644,21 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "status.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"incident-updates-container"}},
+        {"tags": {"div", "section"}, "class_tokens": {"update-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"incident-body"}},
+    ),
+    "status.pinecone.io": (
+        {"tags": {"div", "section"}, "class_tokens": {"postmortem-content"}},
+        {"tags": {"div", "section"}, "class_tokens": {"incident-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"update-body"}},
+    ),
+    "status.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"incident-detail"}},
+        {"tags": {"div", "section"}, "class_tokens": {"rca-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"update-body"}},
     ),
     "docs.vllm.ai": (
         {"tags": {"div", "section"}, "class_tokens": {"md-content"}},

--- a/tests/fixtures/extraction/openai-status-incident-update.html
+++ b/tests/fixtures/extraction/openai-status-incident-update.html
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>OpenAI status incident update for inference latency event</title>
+  </head>
+  <body>
+    <section class="incident-updates-container">
+      <h1>Inference latency incident update</h1>
+      <p>
+        Incident updates are useful when they explain which mitigation steps restored service, how traffic
+        was shifted away from the failing path, and what operators should keep monitoring before declaring a
+        system stable again.
+      </p>
+      <p>
+        Strong updates also tell customers what degraded behavior remains, which rollback path is still
+        active, and when the next status checkpoint will be published.
+      </p>
+      <div class="incident-sidebar">Affected components</div>
+      <div class="affected-components">Inference API, Batch API</div>
+      <div class="status-banner">Status update banner</div>
+      <div class="subscribe-pane">Subscribe to updates</div>
+      <div class="incident-timeline-nav">Incident timeline</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/pinecone-postmortem.html
+++ b/tests/fixtures/extraction/pinecone-postmortem.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Pinecone postmortem for vector index write degradation</title>
+  </head>
+  <body>
+    <section class="postmortem-content">
+      <h1>Vector index write degradation postmortem</h1>
+      <p>
+        Postmortems are valuable when they explain the technical trigger, the operational safeguards that
+        failed, and which verification steps must pass before traffic returns to the repaired path.
+      </p>
+      <p>
+        The useful ones also document owner follow-up, rollback boundaries, and the instrumentation changes
+        teams will use to catch the same pattern earlier next time.
+      </p>
+      <div class="postmortem-meta">Postmortem metadata</div>
+      <div class="related-incidents">Related incidents</div>
+      <div class="status-banner">Status update banner</div>
+      <div class="subscribe-pane">Subscribe to incident updates</div>
+      <div class="component-list">Affected services</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-outage-rca.html
+++ b/tests/fixtures/extraction/together-outage-rca.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Together outage RCA for model gateway saturation</title>
+  </head>
+  <body>
+    <section class="incident-detail">
+      <h1>Model gateway saturation RCA</h1>
+      <p>
+        Outage RCAs matter when they show how an overload propagated through the serving stack, which
+        emergency controls reduced customer impact, and what conditions now gate another production rollout.
+      </p>
+      <p>
+        Clear RCAs also describe escalation ownership, instrumentation gaps, and the recovery checks teams
+        must repeat before removing temporary safeguards.
+      </p>
+      <div class="impact-summary">Impact summary</div>
+      <div class="related-incidents">Related incidents</div>
+      <div class="status-banner">Status update banner</div>
+      <div class="subscribe-pane">Subscribe to updates</div>
+      <div class="incident-nav">Incident navigation</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -920,6 +920,52 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related Fireworks guides", content.text)
         self.assertNotIn("Edit this page", content.text)
 
+    def test_prefers_openai_status_incident_update_body_and_drops_status_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-status-incident-update.html"),
+            url="https://status.openai.com/incidents/inference-latency-event",
+        )
+
+        self.assertIn("Incident updates are useful when they explain which mitigation steps restored service", content.text)
+        self.assertIn("shifted away from the failing path", content.text)
+        self.assertIn("rollback path is still", content.text)
+        self.assertIn("active", content.text)
+        self.assertNotIn("Affected components", content.text)
+        self.assertNotIn("Status update banner", content.text)
+        self.assertNotIn("Subscribe to updates", content.text)
+
+    def test_prefers_pinecone_postmortem_body_and_drops_postmortem_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("pinecone-postmortem.html"),
+            url="https://status.pinecone.io/incidents/vector-index-write-degradation-postmortem",
+        )
+
+        self.assertIn("Postmortems are valuable when they explain the technical trigger", content.text)
+        self.assertIn("operational safeguards that", content.text)
+        self.assertIn("failed", content.text)
+        self.assertIn("rollback boundaries", content.text)
+        self.assertIn("instrumentation changes", content.text)
+        self.assertNotIn("Postmortem metadata", content.text)
+        self.assertNotIn("Related incidents", content.text)
+        self.assertNotIn("Subscribe to incident updates", content.text)
+
+    def test_prefers_together_outage_rca_body_and_drops_incident_nav_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-outage-rca.html"),
+            url="https://status.together.ai/incidents/model-gateway-saturation-rca",
+        )
+
+        self.assertIn("Outage RCAs matter when they show how an overload propagated through the serving stack", content.text)
+        self.assertIn("emergency controls reduced customer impact", content.text)
+        self.assertIn("recovery checks teams", content.text)
+        self.assertIn("must repeat before removing temporary safeguards", content.text)
+        self.assertNotIn("Impact summary", content.text)
+        self.assertNotIn("Related incidents", content.text)
+        self.assertNotIn("Incident navigation", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic fixtures for incident-update, postmortem, and outage-RCA vendor status pages
- extend host-specific selector, cleanup, and fallback coverage for status.openai.com, status.pinecone.io, and status.together.ai
- prepare the v1.2.20 changelog, release notes, and launch copy

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
