### PR TITLE
test: add security advisory extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.21] - 2026-04-09
+
+### Added
+
+- Security-bulletin, trust-center-advisory, and compliance-update extraction fixtures for `trust.openai.com`, `docs.anthropic.com`, and `cloud.google.com`
+
+### Changed
+
+- Package version is now `1.2.21`
+- International extraction coverage now includes security-bulletin, trust-center-advisory, and compliance-update layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, and outage-RCA layouts
+
+### Fixed
+
+- Reduced severity banners, trust-center sidebars, compliance navigation, and related-advisory recirculation noise on security and trust vendor pages
+- Locked another class of security and compliance layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.20] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.20`
+`v1.2.21`
 
 ### Suggested Title
 
-`AI News Open v1.2.20 · Incident Update and Postmortem Extraction Coverage`
+`AI News Open v1.2.21 · Security Bulletin and Trust Advisory Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.20
+## AI News Open v1.2.21
 
-AI News Open `v1.2.20` hardens extraction quality for incident-update, postmortem, and outage-RCA layouts across more international publishers.
+AI News Open `v1.2.21` hardens extraction quality for security-bulletin, trust-center-advisory, and compliance-update layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.20` hardens extraction quality for incident-update, postmorte
 
 ### Highlights in this release
 
-- New deterministic operational-status fixtures for `OpenAI Status`, `Pinecone Status`, and `Together Status`
-- Better cleanup for affected-component sidebars, status banners, incident navigation, and related-incident recirculation on vendor status and outage pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, and outage-RCA layouts
+- New deterministic vendor-security fixtures for `OpenAI Trust`, `Anthropic Docs`, and `Google Cloud`
+- Better cleanup for severity banners, trust-center sidebars, compliance navigation, and related-advisory recirculation on vendor trust and security pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, and compliance-update layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.21.md
+++ b/docs/releases/v1.2.21.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.21
+
+AI News Open `v1.2.21` is a content-quality patch release focused on security bulletins, trust center advisories, and compliance update pages. It extends deterministic extraction coverage for another class of vendor trust and security pages where severity banners, side navigation, and subscription prompts often sit beside the real operator guidance.
+
+### What changed
+
+- Added security-bulletin / trust-center-advisory / compliance-update extraction fixtures for:
+  - `trust.openai.com`
+  - `docs.anthropic.com`
+  - `cloud.google.com`
+- Added host-specific cleanup for severity labels, trust sidebars, compliance navigation, and related-advisory modules on those layouts
+- Extended the extraction regression suite to cover another class of vendor trust and security pages
+
+### Why this matters
+
+- Security and compliance pages often mix severity metadata, contact prompts, and side navigation inside the same content region as the real operational guidance
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, and compliance-update layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.20"
+version = "1.2.21"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.20"
+__version__ = "1.2.21"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -314,6 +314,7 @@ HOST_SELECTORS = {
         ".wysiwyg",
     ),
     "cloud.google.com": (
+        ".compliance-update",
         ".devsite-article-body",
         ".article-body",
         ".case-study-body",
@@ -344,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".security-bulletin",
         ".theme-doc-markdown",
         ".docs-content",
         ".article-body",
@@ -397,6 +399,11 @@ HOST_SELECTORS = {
         ".docs-body",
         ".prose",
         ".article-body",
+    ),
+    "trust.openai.com": (
+        ".trust-center-advisory",
+        ".advisory-body",
+        ".content-body",
     ),
     "docs.pinecone.io": (
         ".theme-doc-markdown",
@@ -771,6 +778,8 @@ HOST_DROP_SELECTORS = {
         ".download-prompt",
     ),
     "cloud.google.com": (
+        ".compliance-sidebar",
+        ".security-bulletin-nav",
         ".devsite-page-rating",
         ".newsletter-callout",
         ".benchmark-cta",
@@ -813,9 +822,12 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".severity-badge",
         ".table-of-contents",
         ".docs-feedback",
         ".related-links",
+        ".related-bulletins",
+        ".contact-security",
         ".callout-banner",
         ".breadcrumbs",
     ),
@@ -888,6 +900,13 @@ HOST_DROP_SELECTORS = {
         ".related-answers",
         ".feedback-widget",
         ".docs-sidebar",
+    ),
+    "trust.openai.com": (
+        ".trust-sidebar",
+        ".severity-banner",
+        ".related-advisories",
+        ".subscribe-panel",
+        ".breadcrumbs",
     ),
     "docs.pinecone.io": (
         ".table-of-contents",
@@ -1185,8 +1204,11 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Download the full report$"),
     ),
     "cloud.google.com": (
+        re.compile(r"^Compliance update$"),
+        re.compile(r"^Security bulletin menu$"),
         re.compile(r"^Benchmark methodology$"),
         re.compile(r"^Related products$"),
+        re.compile(r"^Related cloud controls$"),
         re.compile(r"^Listen to this benchmark note$"),
     ),
     "databricks.com": (
@@ -1215,8 +1237,12 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Security bulletin$"),
+        re.compile(r"^Severity level$"),
         re.compile(r"^Troubleshooting menu$"),
         re.compile(r"^Related topics$"),
+        re.compile(r"^Related bulletins$"),
+        re.compile(r"^Contact security$"),
         re.compile(r"^Need more help\?$"),
     ),
     "learn.microsoft.com": (
@@ -1268,6 +1294,12 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Deprecation FAQ$"),
         re.compile(r"^Related answers$"),
         re.compile(r"^Was this helpful\?$"),
+    ),
+    "trust.openai.com": (
+        re.compile(r"^Trust center advisory$"),
+        re.compile(r"^Related advisories$"),
+        re.compile(r"^Subscribe for trust updates$"),
+        re.compile(r"^Severity: .*"),
     ),
     "docs.pinecone.io": (
         re.compile(r"^Migration checklist$"),
@@ -1551,6 +1583,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"wysiwyg"}},
     ),
     "cloud.google.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"compliance-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"devsite-article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"case-study-body"}},
@@ -1581,6 +1614,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"security-bulletin"}},
         {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
@@ -1634,6 +1668,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+    ),
+    "trust.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"trust-center-advisory"}},
+        {"tags": {"div", "section"}, "class_tokens": {"advisory-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
     ),
     "docs.pinecone.io": (
         {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},

--- a/tests/fixtures/extraction/anthropic-security-bulletin.html
+++ b/tests/fixtures/extraction/anthropic-security-bulletin.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Anthropic security bulletin for tool invocation isolation</title>
+  </head>
+  <body>
+    <section class="security-bulletin">
+      <h1>Tool invocation isolation bulletin</h1>
+      <p>
+        Security bulletins are useful when they explain the affected integration surface, what mitigations
+        are already in place, and which customer actions close the remaining exposure.
+      </p>
+      <p>
+        The best bulletins also document patch windows, rollback constraints, and the review steps
+        operators should complete before restoring normal traffic.
+      </p>
+      <div class="severity-badge">Severity level</div>
+      <div class="related-bulletins">Related bulletins</div>
+      <div class="contact-security">Contact security</div>
+      <div class="docs-feedback">Need more help?</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/google-cloud-compliance-update.html
+++ b/tests/fixtures/extraction/google-cloud-compliance-update.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Google Cloud compliance update for AI service evidence retention</title>
+  </head>
+  <body>
+    <section class="compliance-update">
+      <h1>AI service evidence retention update</h1>
+      <p>
+        Compliance updates matter when they explain which controls were re-audited, how evidence collection
+        changes, and what operators must update in deployment records before claiming continued coverage.
+      </p>
+      <p>
+        Useful updates also spell out retention changes, exception handling, and which service
+        configurations need another review cycle before launch gates can close.
+      </p>
+      <div class="compliance-sidebar">Compliance update</div>
+      <div class="security-bulletin-nav">Security bulletin menu</div>
+      <div class="related-products">Related cloud controls</div>
+      <div class="devsite-page-rating">Rate this page</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-trust-advisory.html
+++ b/tests/fixtures/extraction/openai-trust-advisory.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>OpenAI trust center advisory for enterprise access token handling</title>
+  </head>
+  <body>
+    <section class="trust-center-advisory">
+      <h1>Enterprise access token handling advisory</h1>
+      <p>
+        Trust center advisories are useful when they explain which controls changed, how exposure was
+        limited, and what customers should verify before re-enabling the affected workflow.
+      </p>
+      <p>
+        The strongest notices also identify residual risk, rollout sequencing, and the evidence operators
+        should keep for audit follow-up once the immediate mitigation is complete.
+      </p>
+      <div class="trust-sidebar">Trust center advisory</div>
+      <div class="severity-banner">Severity: medium</div>
+      <div class="related-advisories">Related advisories</div>
+      <div class="subscribe-panel">Subscribe for trust updates</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -966,6 +966,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related incidents", content.text)
         self.assertNotIn("Incident navigation", content.text)
 
+    def test_prefers_openai_trust_advisory_body_and_drops_trust_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-trust-advisory.html"),
+            url="https://trust.openai.com/advisories/enterprise-access-token-handling",
+        )
+
+        self.assertIn("Trust center advisories are useful when they explain which controls changed", content.text)
+        self.assertIn("what customers should verify", content.text)
+        self.assertIn("residual risk, rollout sequencing", content.text)
+        self.assertIn("audit follow-up", content.text)
+        self.assertNotIn("Trust center advisory", content.text)
+        self.assertNotIn("Related advisories", content.text)
+        self.assertNotIn("Subscribe for trust updates", content.text)
+
+    def test_prefers_anthropic_security_bulletin_body_and_drops_bulletin_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-security-bulletin.html"),
+            url="https://docs.anthropic.com/en/security/tool-invocation-isolation-bulletin",
+        )
+
+        self.assertIn("Security bulletins are useful when they explain the affected integration surface", content.text)
+        self.assertIn("customer actions close the remaining exposure", content.text)
+        self.assertIn("patch windows, rollback constraints", content.text)
+        self.assertIn("restoring normal traffic", content.text)
+        self.assertNotIn("Severity level", content.text)
+        self.assertNotIn("Related bulletins", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_google_cloud_compliance_update_body_and_drops_compliance_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("google-cloud-compliance-update.html"),
+            url="https://cloud.google.com/security/compliance/ai-service-evidence-retention-update",
+        )
+
+        self.assertIn("Compliance updates matter when they explain which controls were re-audited", content.text)
+        self.assertIn("what operators must update in deployment records", content.text)
+        self.assertIn("retention changes, exception handling", content.text)
+        self.assertIn("review cycle before launch gates can close", content.text)
+        self.assertNotIn("Rate this page", content.text)
+        self.assertNotIn("Security bulletin menu", content.text)
+        self.assertNotIn("Related cloud controls", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic fixtures for security-bulletin, trust-center-advisory, and compliance-update vendor pages
- extend host-specific selector, cleanup, and fallback coverage for trust.openai.com, docs.anthropic.com, and cloud.google.com
- prepare the v1.2.21 changelog, release notes, and launch copy

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
