### PR TITLE
test: add pricing notice extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.22] - 2026-04-09
+
+### Added
+
+- Pricing-update, service-tier-notice, and SKU-change extraction fixtures for `openai.com`, `anthropic.com`, and `together.ai`
+
+### Changed
+
+- Package version is now `1.2.22`
+- International extraction coverage now includes pricing-update, service-tier-notice, and SKU-change layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, and compliance-update layouts
+
+### Fixed
+
+- Reduced pricing sidebars, service-tier grids, plan-comparison modules, and related-update recirculation noise on product pricing and commercial notice pages
+- Locked another class of pricing and commercial-notice layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.21] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.21`
+`v1.2.22`
 
 ### Suggested Title
 
-`AI News Open v1.2.21 · Security Bulletin and Trust Advisory Extraction Coverage`
+`AI News Open v1.2.22 · Pricing and Service Tier Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.21
+## AI News Open v1.2.22
 
-AI News Open `v1.2.21` hardens extraction quality for security-bulletin, trust-center-advisory, and compliance-update layouts across more international publishers.
+AI News Open `v1.2.22` hardens extraction quality for pricing-update, service-tier-notice, and SKU-change layouts across more international publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.21` hardens extraction quality for security-bulletin, trust-c
 
 ### Highlights in this release
 
-- New deterministic vendor-security fixtures for `OpenAI Trust`, `Anthropic Docs`, and `Google Cloud`
-- Better cleanup for severity banners, trust-center sidebars, compliance navigation, and related-advisory recirculation on vendor trust and security pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, and compliance-update layouts
+- New deterministic commercial-notice fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for pricing sidebars, service-tier grids, plan-comparison modules, and sales CTA recirculation on product pricing and commercial notice pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, and SKU-change layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.22.md
+++ b/docs/releases/v1.2.22.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.22
+
+AI News Open `v1.2.22` is a content-quality patch release focused on pricing updates, service tier notices, and SKU change pages. It extends deterministic extraction coverage for another class of commercial product pages where pricing navigation, comparison grids, and sales prompts often sit beside the real operator guidance.
+
+### What changed
+
+- Added pricing-update / service-tier-notice / SKU-change extraction fixtures for:
+  - `openai.com`
+  - `anthropic.com`
+  - `together.ai`
+- Added host-specific cleanup for pricing sidebars, comparison grids, sales prompts, and related-update modules on those layouts
+- Extended the extraction regression suite to cover another class of commercial product pages
+
+### Why this matters
+
+- Pricing and service-tier pages often mix product comparison modules, pricing navigation, and sales CTAs inside the same content region as the rollout and operational guidance teams actually need
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, and SKU-change layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.21"
+version = "1.2.22"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.21"
+__version__ = "1.2.22"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -395,6 +395,16 @@ HOST_SELECTORS = {
         ".content-body",
         ".docs-content",
     ),
+    "openai.com": (
+        ".content-body",
+        ".article-body",
+        ".prose",
+    ),
+    "anthropic.com": (
+        ".content-body",
+        ".article-body",
+        ".prose",
+    ),
     "platform.openai.com": (
         ".docs-body",
         ".prose",
@@ -429,6 +439,11 @@ HOST_SELECTORS = {
         ".incident-detail",
         ".rca-body",
         ".update-body",
+    ),
+    "together.ai": (
+        ".content-body",
+        ".article-body",
+        ".prose",
     ),
     "docs.vllm.ai": (
         ".md-content",
@@ -894,6 +909,20 @@ HOST_DROP_SELECTORS = {
         ".cta-panel",
         ".sidebar-toc",
     ),
+    "openai.com": (
+        ".pricing-sidebar",
+        ".tier-card-grid",
+        ".related-updates",
+        ".contact-sales-banner",
+        ".pricing-nav",
+    ),
+    "anthropic.com": (
+        ".service-tier-sidebar",
+        ".tier-comparison-grid",
+        ".related-announcements",
+        ".contact-sales-banner",
+        ".page-nav",
+    ),
     "platform.openai.com": (
         ".faq-nav",
         ".deprecation-callout",
@@ -942,6 +971,13 @@ HOST_DROP_SELECTORS = {
         ".status-banner",
         ".subscribe-pane",
         ".incident-nav",
+    ),
+    "together.ai": (
+        ".sku-sidebar",
+        ".plan-comparison-grid",
+        ".related-updates",
+        ".contact-sales-banner",
+        ".page-nav",
     ),
     "docs.vllm.ai": (
         ".version-warning",
@@ -1290,6 +1326,18 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Related upgrade guides$"),
         re.compile(r"^Start building$"),
     ),
+    "openai.com": (
+        re.compile(r"^Pricing update navigation$"),
+        re.compile(r"^Service tier grid$"),
+        re.compile(r"^Related pricing updates$"),
+        re.compile(r"^Talk to sales$"),
+    ),
+    "anthropic.com": (
+        re.compile(r"^Service tier notice$"),
+        re.compile(r"^Tier comparison$"),
+        re.compile(r"^Related product announcements$"),
+        re.compile(r"^Contact sales$"),
+    ),
     "platform.openai.com": (
         re.compile(r"^Deprecation FAQ$"),
         re.compile(r"^Related answers$"),
@@ -1328,6 +1376,12 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Related incidents$"),
         re.compile(r"^Subscribe to updates$"),
         re.compile(r"^Incident navigation$"),
+    ),
+    "together.ai": (
+        re.compile(r"^SKU change overview$"),
+        re.compile(r"^Plan comparison$"),
+        re.compile(r"^Related product updates$"),
+        re.compile(r"^Talk to sales$"),
     ),
     "docs.vllm.ai": (
         re.compile(r"^Version notice$"),
@@ -1664,6 +1718,16 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
     ),
+    "openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
+    ),
+    "anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
+    ),
     "platform.openai.com": (
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
@@ -1698,6 +1762,11 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"incident-detail"}},
         {"tags": {"div", "section"}, "class_tokens": {"rca-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"update-body"}},
+    ),
+    "together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
+        {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "docs.vllm.ai": (
         {"tags": {"div", "section"}, "class_tokens": {"md-content"}},

--- a/tests/fixtures/extraction/anthropic-service-tier-notice.html
+++ b/tests/fixtures/extraction/anthropic-service-tier-notice.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Anthropic service tier notice for enterprise throughput lanes</title>
+  </head>
+  <body>
+    <section class="content-body">
+      <h1>Enterprise throughput tier notice</h1>
+      <p>
+        Service tier notices are useful when they explain which latency and throughput guarantees changed,
+        what customer traffic is eligible for the new lane, and how rollout sequencing affects existing
+        production commitments.
+      </p>
+      <p>
+        Clear notices also document downgrade behavior, billing reconciliation points, and the review steps
+        operators should finish before moving regulated workloads onto the new tier.
+      </p>
+      <div class="service-tier-sidebar">Service tier notice</div>
+      <div class="tier-comparison-grid">Tier comparison</div>
+      <div class="related-announcements">Related product announcements</div>
+      <div class="contact-sales-banner">Contact sales</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-pricing-update.html
+++ b/tests/fixtures/extraction/openai-pricing-update.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>OpenAI pricing update for enterprise inference tiers</title>
+  </head>
+  <body>
+    <section class="content-body">
+      <h1>Enterprise inference pricing update</h1>
+      <p>
+        Pricing updates are useful when they explain which workloads move to a new billing tier, how
+        reservation and overage behavior changes, and what operators should verify before shifting
+        production traffic to the new pricing path.
+      </p>
+      <p>
+        The strongest notices also spell out migration timing, fallback options, and the reporting fields
+        finance and engineering teams should reconcile after the change takes effect.
+      </p>
+      <div class="pricing-sidebar">Pricing update navigation</div>
+      <div class="tier-card-grid">Service tier grid</div>
+      <div class="related-updates">Related pricing updates</div>
+      <div class="contact-sales-banner">Talk to sales</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-sku-change.html
+++ b/tests/fixtures/extraction/together-sku-change.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Together SKU change notice for hosted model bundles</title>
+  </head>
+  <body>
+    <section class="content-body">
+      <h1>Hosted model bundle SKU change</h1>
+      <p>
+        SKU change notices matter when they explain which bundled capabilities are moving, how entitlements
+        map from old plans to new ones, and what operators should confirm before contract-bound workloads
+        inherit the updated SKU.
+      </p>
+      <p>
+        Useful notices also describe fallback purchase paths, invoice mapping, and the support checkpoints
+        customers should keep during the transition window.
+      </p>
+      <div class="sku-sidebar">SKU change overview</div>
+      <div class="plan-comparison-grid">Plan comparison</div>
+      <div class="related-updates">Related product updates</div>
+      <div class="contact-sales-banner">Talk to sales</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1011,6 +1011,52 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Security bulletin menu", content.text)
         self.assertNotIn("Related cloud controls", content.text)
 
+    def test_prefers_openai_pricing_update_body_and_drops_pricing_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-pricing-update.html"),
+            url="https://openai.com/pricing/enterprise-inference-update",
+        )
+
+        self.assertIn("Pricing updates are useful when they explain which workloads move to a new billing tier", content.text)
+        self.assertIn("reservation and overage behavior changes", content.text)
+        self.assertIn("fallback options", content.text)
+        self.assertIn("reporting fields", content.text)
+        self.assertNotIn("Pricing update navigation", content.text)
+        self.assertNotIn("Service tier grid", content.text)
+        self.assertNotIn("Related pricing updates", content.text)
+
+    def test_prefers_anthropic_service_tier_notice_body_and_drops_tier_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-service-tier-notice.html"),
+            url="https://www.anthropic.com/news/enterprise-throughput-tier-notice",
+        )
+
+        self.assertIn("Service tier notices are useful when they explain which latency and throughput guarantees changed", content.text)
+        self.assertIn("rollout sequencing affects existing", content.text)
+        self.assertIn("production commitments", content.text)
+        self.assertIn("downgrade behavior, billing reconciliation points", content.text)
+        self.assertNotIn("Contact sales", content.text)
+        self.assertNotIn("Tier comparison", content.text)
+        self.assertNotIn("Related product announcements", content.text)
+
+    def test_prefers_together_sku_change_body_and_drops_plan_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-sku-change.html"),
+            url="https://www.together.ai/pricing/hosted-model-bundle-sku-change",
+        )
+
+        self.assertIn("SKU change notices matter when they explain which bundled capabilities are moving", content.text)
+        self.assertIn("entitlements", content.text)
+        self.assertIn("map from old plans to new ones", content.text)
+        self.assertIn("fallback purchase paths, invoice mapping", content.text)
+        self.assertIn("transition window", content.text)
+        self.assertNotIn("SKU change overview", content.text)
+        self.assertNotIn("Plan comparison", content.text)
+        self.assertNotIn("Related product updates", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic fixtures for pricing-update, service-tier-notice, and SKU-change product pages
- extend host-specific selector, cleanup, and fallback coverage for openai.com, anthropic.com, and together.ai
- prepare the v1.2.22 changelog, release notes, and launch copy

## Verification
- make check PYTHON=./.venv-dev/bin/python
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
