### PR TITLE
test: add quota policy extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.23] - 2026-04-09
+
+### Added
+
+- Usage-limit-notice, rate-limit-update, and quota-policy extraction fixtures for `docs.anthropic.com`, `platform.openai.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.23`
+- International extraction coverage now includes usage-limit-notice, rate-limit-update, and quota-policy layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, and SKU-change layouts
+
+### Fixed
+
+- Reduced rate-limit sidebars, tier summaries, limit summaries, quota summaries, and related-guide recirculation noise on developer quota and usage-policy pages
+- Locked another class of quota-policy and rate-limit layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.22] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.22`
+`v1.2.23`
 
 ### Suggested Title
 
-`AI News Open v1.2.22 · Pricing and Service Tier Extraction Coverage`
+`AI News Open v1.2.23 · Rate Limit and Quota Policy Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.22
+## AI News Open v1.2.23
 
-AI News Open `v1.2.22` hardens extraction quality for pricing-update, service-tier-notice, and SKU-change layouts across more international publishers.
+AI News Open `v1.2.23` hardens extraction quality for usage-limit-notice, rate-limit-update, and quota-policy layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.22` hardens extraction quality for pricing-update, service-ti
 
 ### Highlights in this release
 
-- New deterministic commercial-notice fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for pricing sidebars, service-tier grids, plan-comparison modules, and sales CTA recirculation on product pricing and commercial notice pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, and SKU-change layouts
+- New deterministic quota and usage-policy fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for rate-limit navigation, tier summaries, limit summaries, quota summaries, and related-guide recirculation on usage-policy and quota pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, and quota-policy layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.23.md
+++ b/docs/releases/v1.2.23.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.23
+
+AI News Open `v1.2.23` is a content-quality patch release focused on usage-limit notices, rate-limit updates, and quota-policy pages. It extends deterministic extraction coverage for another class of developer policy pages where limit summaries, quota sidebars, and related guides often sit beside the real operator guidance.
+
+### What changed
+
+- Added usage-limit-notice / rate-limit-update / quota-policy extraction fixtures for:
+  - `docs.anthropic.com`
+  - `platform.openai.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for limit summaries, tier summaries, quota summaries, navigation blocks, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of quota and usage-policy pages
+
+### Why this matters
+
+- Usage-policy pages often mix rollout guidance with quota tables, limit sidebars, and related-guide recirculation inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, and quota-policy layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.22"
+version = "1.2.23"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.22"
+__version__ = "1.2.23"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -346,6 +346,7 @@ HOST_SELECTORS = {
     ),
     "docs.anthropic.com": (
         ".security-bulletin",
+        ".usage-limit-notice",
         ".theme-doc-markdown",
         ".docs-content",
         ".article-body",
@@ -406,6 +407,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".rate-limit-update",
         ".docs-body",
         ".prose",
         ".article-body",
@@ -421,6 +423,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".quota-policy",
         ".docs-body",
         ".content-body",
         ".article-body",
@@ -838,10 +841,12 @@ HOST_DROP_SELECTORS = {
     ),
     "docs.anthropic.com": (
         ".severity-badge",
+        ".limit-summary",
         ".table-of-contents",
         ".docs-feedback",
         ".related-links",
         ".related-bulletins",
+        ".related-limit-guides",
         ".contact-security",
         ".callout-banner",
         ".breadcrumbs",
@@ -924,9 +929,12 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".rate-limit-nav",
+        ".tier-summary",
         ".faq-nav",
         ".deprecation-callout",
         ".related-answers",
+        ".related-limit-guides",
         ".feedback-widget",
         ".docs-sidebar",
     ),
@@ -945,9 +953,11 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".quota-summary",
         ".policy-sidebar",
         ".support-banner",
         ".related-articles",
+        ".related-quota-guides",
         ".feedback-widget",
         ".sidebar-toc",
     ),
@@ -1275,9 +1285,12 @@ HOST_NOISE_LINE_PATTERNS = {
     "docs.anthropic.com": (
         re.compile(r"^Security bulletin$"),
         re.compile(r"^Severity level$"),
+        re.compile(r"^Usage limit notice$"),
+        re.compile(r"^Limit summary$"),
         re.compile(r"^Troubleshooting menu$"),
         re.compile(r"^Related topics$"),
         re.compile(r"^Related bulletins$"),
+        re.compile(r"^Related limit guides$"),
         re.compile(r"^Contact security$"),
         re.compile(r"^Need more help\?$"),
     ),
@@ -1339,8 +1352,12 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Rate limit update$"),
+        re.compile(r"^Rate limit navigation$"),
+        re.compile(r"^Tier summary$"),
         re.compile(r"^Deprecation FAQ$"),
         re.compile(r"^Related answers$"),
+        re.compile(r"^Related limit guides$"),
         re.compile(r"^Was this helpful\?$"),
     ),
     "trust.openai.com": (
@@ -1355,8 +1372,11 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Quota policy$"),
+        re.compile(r"^Quota summary$"),
         re.compile(r"^Support policy$"),
         re.compile(r"^Related Together docs$"),
+        re.compile(r"^Related quota guides$"),
         re.compile(r"^Need more help\?$"),
     ),
     "status.openai.com": (
@@ -1668,6 +1688,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"usage-limit-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"security-bulletin"}},
         {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-content"}},
@@ -1729,6 +1750,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"rate-limit-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},
@@ -1744,6 +1766,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"quota-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"article-body"}},

--- a/tests/fixtures/extraction/anthropic-usage-limit-notice.html
+++ b/tests/fixtures/extraction/anthropic-usage-limit-notice.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Anthropic usage limit notice for enterprise workload classes</title>
+  </head>
+  <body>
+    <section class="usage-limit-notice">
+      <h1>Enterprise workload usage limit notice</h1>
+      <p>
+        Usage limit notices are useful when they explain which workload classes are capped, how temporary
+        exceptions are handled, and what operators should change in client behavior before the new limits go
+        live.
+      </p>
+      <p>
+        Clear notices also describe escalation paths, reporting expectations, and the fallback controls
+        teams should keep available while the new policy is phased in.
+      </p>
+      <div class="limit-summary">Limit summary</div>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="contact-security">Contact security</div>
+      <div class="docs-feedback">Need more help?</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-rate-limit-update.html
+++ b/tests/fixtures/extraction/openai-rate-limit-update.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>OpenAI rate limit update for enterprise batch and realtime traffic</title>
+  </head>
+  <body>
+    <section class="rate-limit-update">
+      <h1>Enterprise rate limit update</h1>
+      <p>
+        Rate limit updates are useful when they explain which traffic classes are changing, how burst and
+        sustained limits will be enforced, and what operators should validate before moving production
+        workloads onto the new thresholds.
+      </p>
+      <p>
+        The strongest notices also document fallback queues, retry guidance, and the monitoring fields
+        teams should watch while the new ceilings roll out.
+      </p>
+      <div class="rate-limit-nav">Rate limit navigation</div>
+      <div class="tier-summary">Tier summary</div>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="feedback-widget">Was this helpful?</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-quota-policy.html
+++ b/tests/fixtures/extraction/together-quota-policy.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Together quota policy for hosted inference programs</title>
+  </head>
+  <body>
+    <section class="quota-policy">
+      <h1>Hosted inference quota policy</h1>
+      <p>
+        Quota policies matter when they explain which credits and throughput pools are shared, how rollover
+        is handled, and what operators should verify before high-priority traffic depends on the new quota
+        model.
+      </p>
+      <p>
+        Useful quota notices also spell out exception handling, dashboard fields, and the retry behavior
+        teams should use while the new quota rules stabilize.
+      </p>
+      <div class="quota-summary">Quota summary</div>
+      <div class="related-quota-guides">Related quota guides</div>
+      <div class="policy-sidebar">Quota policy</div>
+      <div class="feedback-widget">Need more help?</div>
+    </section>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1057,6 +1057,53 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Plan comparison", content.text)
         self.assertNotIn("Related product updates", content.text)
 
+    def test_prefers_openai_rate_limit_update_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-rate-limit-update.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/enterprise-update",
+        )
+
+        self.assertIn("Rate limit updates are useful when they explain which traffic classes are changing", content.text)
+        self.assertIn("burst and", content.text)
+        self.assertIn("sustained limits will be enforced", content.text)
+        self.assertIn("fallback queues, retry guidance", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Tier summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_usage_limit_notice_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-usage-limit-notice.html"),
+            url="https://docs.anthropic.com/en/docs/usage/enterprise-limit-notice",
+        )
+
+        self.assertIn("Usage limit notices are useful when they explain which workload classes are capped", content.text)
+        self.assertIn("temporary", content.text)
+        self.assertIn("exceptions are handled", content.text)
+        self.assertIn("change in client behavior", content.text)
+        self.assertIn("fallback controls", content.text)
+        self.assertNotIn("Limit summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_quota_policy_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-quota-policy.html"),
+            url="https://docs.together.ai/docs/inference/quota-policy",
+        )
+
+        self.assertIn("Quota policies matter when they explain which credits and throughput pools are shared", content.text)
+        self.assertIn("how rollover", content.text)
+        self.assertIn("is handled", content.text)
+        self.assertIn("exception handling, dashboard fields", content.text)
+        self.assertIn("new quota rules stabilize", content.text)
+        self.assertNotIn("Quota summary", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+        self.assertNotIn("Need more help?", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic usage-limit, rate-limit, and quota-policy extraction fixtures for Anthropic, OpenAI, and Together docs
- extend source-specific cleanup rules for quota sidebars, limit summaries, tier summaries, and related-guide noise
- bump the patch line to v1.2.23 and add release notes

## Verification
- make check PYTHON=./.venv-dev/bin/python
