### PR TITLE
test: add quota advisory extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.24] - 2026-04-09
+
+### Added
+
+- Burst-cap-notice, concurrency-cap-update, and regional-quota-advisory extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.24`
+- International extraction coverage now includes burst-cap-notice, concurrency-cap-update, and regional-quota-advisory layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, and quota-policy layouts
+
+### Fixed
+
+- Reduced burst-cap summaries, concurrency summaries, regional quota summaries, region matrices, and related-guide recirculation noise on developer limit and quota advisory pages
+- Locked another class of burst, concurrency, and regional quota layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.23] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.23`
+`v1.2.24`
 
 ### Suggested Title
 
-`AI News Open v1.2.23 · Rate Limit and Quota Policy Extraction Coverage`
+`AI News Open v1.2.24 · Burst and Regional Quota Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.23
+## AI News Open v1.2.24
 
-AI News Open `v1.2.23` hardens extraction quality for usage-limit-notice, rate-limit-update, and quota-policy layouts across more developer-doc publishers.
+AI News Open `v1.2.24` hardens extraction quality for burst-cap-notice, concurrency-cap-update, and regional-quota-advisory layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.23` hardens extraction quality for usage-limit-notice, rate-l
 
 ### Highlights in this release
 
-- New deterministic quota and usage-policy fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for rate-limit navigation, tier summaries, limit summaries, quota summaries, and related-guide recirculation on usage-policy and quota pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, and quota-policy layouts
+- New deterministic burst, concurrency, and regional-quota fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for burst summaries, concurrency summaries, regional quota summaries, region matrices, and related-guide recirculation on developer limit and quota advisory pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, and regional-quota-advisory layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.24.md
+++ b/docs/releases/v1.2.24.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.24
+
+AI News Open `v1.2.24` is a content-quality patch release focused on burst-cap notices, concurrency-cap updates, and regional-quota advisories. It extends deterministic extraction coverage for another class of developer policy pages where summary panels, region matrices, and related guides often sit beside the real operator guidance.
+
+### What changed
+
+- Added burst-cap-notice / concurrency-cap-update / regional-quota-advisory extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for burst summaries, concurrency summaries, regional quota summaries, region matrices, navigation blocks, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of burst, concurrency, and regional quota policy pages
+
+### Why this matters
+
+- Developer policy pages often mix rollout guidance with summary boxes, region matrices, and related-guide recirculation inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, and regional-quota-advisory layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.23"
+version = "1.2.24"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.23"
+__version__ = "1.2.24"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -346,6 +346,7 @@ HOST_SELECTORS = {
     ),
     "docs.anthropic.com": (
         ".security-bulletin",
+        ".concurrency-cap-update",
         ".usage-limit-notice",
         ".theme-doc-markdown",
         ".docs-content",
@@ -407,6 +408,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".burst-cap-notice",
         ".rate-limit-update",
         ".docs-body",
         ".prose",
@@ -423,6 +425,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".regional-quota-advisory",
         ".quota-policy",
         ".docs-body",
         ".content-body",
@@ -840,6 +843,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".concurrency-summary",
         ".severity-badge",
         ".limit-summary",
         ".table-of-contents",
@@ -929,6 +933,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".burst-cap-summary",
         ".rate-limit-nav",
         ".tier-summary",
         ".faq-nav",
@@ -953,6 +958,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".region-matrix",
+        ".regional-quota-summary",
         ".quota-summary",
         ".policy-sidebar",
         ".support-banner",
@@ -1283,6 +1290,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Concurrency cap update$"),
+        re.compile(r"^Concurrency summary$"),
         re.compile(r"^Security bulletin$"),
         re.compile(r"^Severity level$"),
         re.compile(r"^Usage limit notice$"),
@@ -1352,6 +1361,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Burst cap notice$"),
+        re.compile(r"^Burst cap summary$"),
         re.compile(r"^Rate limit update$"),
         re.compile(r"^Rate limit navigation$"),
         re.compile(r"^Tier summary$"),
@@ -1372,6 +1383,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Regional quota advisory$"),
+        re.compile(r"^Regional quota summary$"),
+        re.compile(r"^Region matrix$"),
         re.compile(r"^Quota policy$"),
         re.compile(r"^Quota summary$"),
         re.compile(r"^Support policy$"),
@@ -1688,6 +1702,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"concurrency-cap-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"usage-limit-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"security-bulletin"}},
         {"tags": {"div", "section"}, "class_tokens": {"theme-doc-markdown"}},
@@ -1750,6 +1765,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"burst-cap-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"rate-limit-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
@@ -1766,6 +1782,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"regional-quota-advisory"}},
         {"tags": {"div", "section"}, "class_tokens": {"quota-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
         {"tags": {"div", "section"}, "class_tokens": {"content-body"}},

--- a/tests/fixtures/extraction/anthropic-concurrency-cap-update.html
+++ b/tests/fixtures/extraction/anthropic-concurrency-cap-update.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Model concurrency cap update</title>
+  </head>
+  <body>
+    <main>
+      <div class="concurrency-summary">Concurrency summary</div>
+      <section class="concurrency-cap-update">
+        <h1>Model concurrency cap update</h1>
+        <p>
+          Concurrency cap updates are useful when they explain which workload pools now share
+          parallel request slots, how burst exceptions are reviewed, and what operators should
+          adjust in admission control before the new cap is enforced.
+        </p>
+        <p>
+          Clear notices also describe dashboard thresholds, escalation paths, and the fallback
+          queue controls teams should keep ready while concurrency enforcement stabilizes.
+        </p>
+      </section>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="contact-security">Contact security</div>
+      <div class="docs-feedback">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-burst-cap-notice.html
+++ b/tests/fixtures/extraction/openai-burst-cap-notice.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Enterprise burst cap notice</title>
+  </head>
+  <body>
+    <main>
+      <div class="burst-cap-summary">Burst cap summary</div>
+      <section class="burst-cap-notice">
+        <h1>Enterprise burst cap notice</h1>
+        <p>
+          Burst cap notices matter when they explain which traffic classes can spike above baseline
+          throughput, how temporary surge windows are approved, and what operators should change in
+          queueing policy before the new ceiling takes effect.
+        </p>
+        <p>
+          Strong notices also document retry jitter expectations, dashboard counters, and the
+          fallback routing controls teams should keep enabled while burst enforcement settles.
+        </p>
+      </section>
+      <div class="rate-limit-nav">Rate limit navigation</div>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="feedback-widget">Was this helpful?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-regional-quota-advisory.html
+++ b/tests/fixtures/extraction/together-regional-quota-advisory.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Regional quota advisory</title>
+  </head>
+  <body>
+    <main>
+      <div class="regional-quota-summary">Regional quota summary</div>
+      <div class="region-matrix">Region matrix</div>
+      <section class="regional-quota-advisory">
+        <h1>Regional quota advisory</h1>
+        <p>
+          Regional quota advisories matter when they explain which inference regions now draw from
+          separate throughput pools, how spillover is handled during failover, and what operators
+          should verify before latency-sensitive traffic depends on the new regional limits.
+        </p>
+        <p>
+          Useful advisories also spell out region health signals, escalation triggers, and the retry
+          routing teams should apply while the regional quota rollout stabilizes.
+        </p>
+      </section>
+      <div class="related-quota-guides">Related quota guides</div>
+      <div class="policy-sidebar">Quota policy</div>
+      <div class="feedback-widget">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1104,6 +1104,52 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Related quota guides", content.text)
         self.assertNotIn("Need more help?", content.text)
 
+    def test_prefers_openai_burst_cap_notice_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-burst-cap-notice.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/burst-cap-notice",
+        )
+
+        self.assertIn("Burst cap notices matter when they explain which traffic classes can spike", content.text)
+        self.assertIn("temporary surge windows", content.text)
+        self.assertIn("queueing policy", content.text)
+        self.assertIn("retry jitter expectations, dashboard counters", content.text)
+        self.assertNotIn("Burst cap summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_concurrency_cap_update_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-concurrency-cap-update.html"),
+            url="https://docs.anthropic.com/en/docs/usage/model-concurrency-cap-update",
+        )
+
+        self.assertIn("Concurrency cap updates are useful when they explain which workload pools", content.text)
+        self.assertIn("parallel request slots", content.text)
+        self.assertIn("admission control", content.text)
+        self.assertIn("fallback", content.text)
+        self.assertIn("queue controls", content.text)
+        self.assertNotIn("Concurrency summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_regional_quota_advisory_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-regional-quota-advisory.html"),
+            url="https://docs.together.ai/docs/inference/regional-quota-advisory",
+        )
+
+        self.assertIn("Regional quota advisories matter when they explain which inference regions", content.text)
+        self.assertIn("spillover is handled", content.text)
+        self.assertIn("latency-sensitive traffic", content.text)
+        self.assertIn("region health signals, escalation triggers", content.text)
+        self.assertNotIn("Regional quota summary", content.text)
+        self.assertNotIn("Region matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic burst-cap, concurrency-cap, and regional-quota extraction fixtures for OpenAI, Anthropic, and Together docs
- extend source-specific cleanup rules for summary panels, region matrices, and related-guide noise on developer policy pages
- bump the patch line to v1.2.24 and add release notes

## Verification
- make check PYTHON=./.venv-dev/bin/python
