### PR TITLE
test: add limit policy extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.25] - 2026-04-09
+
+### Added
+
+- Soft-limit-warning, grace-period-notice, and throughput-exception-policy extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.25`
+- International extraction coverage now includes soft-limit-warning, grace-period-notice, and throughput-exception-policy layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, and regional-quota-advisory layouts
+
+### Fixed
+
+- Reduced soft-limit summaries, grace-period summaries, exception-threshold panels, and related-guide recirculation noise on developer limit and exception-policy pages
+- Locked another class of soft-limit, grace-period, and throughput-exception layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.24] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.24`
+`v1.2.25`
 
 ### Suggested Title
 
-`AI News Open v1.2.24 · Burst and Regional Quota Extraction Coverage`
+`AI News Open v1.2.25 · Soft Limit and Exception Policy Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.24
+## AI News Open v1.2.25
 
-AI News Open `v1.2.24` hardens extraction quality for burst-cap-notice, concurrency-cap-update, and regional-quota-advisory layouts across more developer-doc publishers.
+AI News Open `v1.2.25` hardens extraction quality for soft-limit-warning, grace-period-notice, and throughput-exception-policy layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.24` hardens extraction quality for burst-cap-notice, concurre
 
 ### Highlights in this release
 
-- New deterministic burst, concurrency, and regional-quota fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for burst summaries, concurrency summaries, regional quota summaries, region matrices, and related-guide recirculation on developer limit and quota advisory pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, and regional-quota-advisory layouts
+- New deterministic soft-limit, grace-period, and throughput-exception fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for soft-limit summaries, grace-period summaries, exception-threshold panels, and related-guide recirculation on developer limit and exception-policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, and throughput-exception-policy layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.25.md
+++ b/docs/releases/v1.2.25.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.25
+
+AI News Open `v1.2.25` is a content-quality patch release focused on soft-limit warnings, grace-period notices, and throughput-exception policies. It extends deterministic extraction coverage for another class of developer policy pages where summary panels, exception thresholds, and related guides often sit beside the real operator guidance.
+
+### What changed
+
+- Added soft-limit-warning / grace-period-notice / throughput-exception-policy extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for soft-limit summaries, grace-period summaries, exception-threshold panels, navigation blocks, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of soft-limit and exception-policy pages
+
+### Why this matters
+
+- Developer policy pages often mix rollout guidance with summaries, threshold tables, and related-guide recirculation inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, and throughput-exception-policy layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.24"
+version = "1.2.25"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.24"
+__version__ = "1.2.25"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -346,6 +346,7 @@ HOST_SELECTORS = {
     ),
     "docs.anthropic.com": (
         ".security-bulletin",
+        ".grace-period-notice",
         ".concurrency-cap-update",
         ".usage-limit-notice",
         ".theme-doc-markdown",
@@ -408,6 +409,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".soft-limit-warning",
         ".burst-cap-notice",
         ".rate-limit-update",
         ".docs-body",
@@ -425,6 +427,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".throughput-exception-policy",
         ".regional-quota-advisory",
         ".quota-policy",
         ".docs-body",
@@ -843,6 +846,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".grace-period-summary",
         ".concurrency-summary",
         ".severity-badge",
         ".limit-summary",
@@ -933,6 +937,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".soft-limit-summary",
         ".burst-cap-summary",
         ".rate-limit-nav",
         ".tier-summary",
@@ -958,6 +963,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".exception-thresholds",
+        ".exception-policy-summary",
         ".region-matrix",
         ".regional-quota-summary",
         ".quota-summary",
@@ -1290,6 +1297,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Grace period notice$"),
+        re.compile(r"^Grace period summary$"),
         re.compile(r"^Concurrency cap update$"),
         re.compile(r"^Concurrency summary$"),
         re.compile(r"^Security bulletin$"),
@@ -1361,6 +1370,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Soft limit warning$"),
+        re.compile(r"^Soft limit summary$"),
         re.compile(r"^Burst cap notice$"),
         re.compile(r"^Burst cap summary$"),
         re.compile(r"^Rate limit update$"),
@@ -1383,6 +1394,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Throughput exception policy$"),
+        re.compile(r"^Exception policy summary$"),
+        re.compile(r"^Exception thresholds$"),
         re.compile(r"^Regional quota advisory$"),
         re.compile(r"^Regional quota summary$"),
         re.compile(r"^Region matrix$"),
@@ -1702,6 +1716,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"grace-period-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"concurrency-cap-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"usage-limit-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"security-bulletin"}},
@@ -1765,6 +1780,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"soft-limit-warning"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-cap-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"rate-limit-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},
@@ -1782,6 +1798,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"throughput-exception-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"regional-quota-advisory"}},
         {"tags": {"div", "section"}, "class_tokens": {"quota-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"docs-body"}},

--- a/tests/fixtures/extraction/anthropic-grace-period-notice.html
+++ b/tests/fixtures/extraction/anthropic-grace-period-notice.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Grace period notice</title>
+  </head>
+  <body>
+    <main>
+      <div class="grace-period-summary">Grace period summary</div>
+      <section class="grace-period-notice">
+        <h1>Grace period notice</h1>
+        <p>
+          Grace period notices are useful when they explain which customers retain temporary access
+          to prior limits, how exemption windows are reviewed, and what operators should change in
+          traffic shaping before the grace period expires.
+        </p>
+        <p>
+          Clear notices also describe escalation contacts, dashboard checkpoints, and the fallback
+          queueing controls teams should keep available while the transition window remains open.
+        </p>
+      </section>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="contact-security">Contact security</div>
+      <div class="docs-feedback">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-soft-limit-warning.html
+++ b/tests/fixtures/extraction/openai-soft-limit-warning.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Soft limit warning</title>
+  </head>
+  <body>
+    <main>
+      <div class="soft-limit-summary">Soft limit summary</div>
+      <section class="soft-limit-warning">
+        <h1>Soft limit warning</h1>
+        <p>
+          Soft limit warnings matter when they explain which workload classes may temporarily cross
+          advisory thresholds, how operators should stage backpressure before hard enforcement, and
+          what client-side pacing changes should land before the warning window closes.
+        </p>
+        <p>
+          Useful warnings also document alert thresholds, retry smoothing, and the fallback routing
+          controls teams should keep enabled while soft-limit behavior is monitored.
+        </p>
+      </section>
+      <div class="rate-limit-nav">Rate limit navigation</div>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="feedback-widget">Was this helpful?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-throughput-exception-policy.html
+++ b/tests/fixtures/extraction/together-throughput-exception-policy.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Throughput exception policy</title>
+  </head>
+  <body>
+    <main>
+      <div class="exception-policy-summary">Exception policy summary</div>
+      <div class="exception-thresholds">Exception thresholds</div>
+      <section class="throughput-exception-policy">
+        <h1>Throughput exception policy</h1>
+        <p>
+          Throughput exception policies matter when they explain which workloads qualify for
+          temporary throughput relief, how approval queues interact with regional routing, and what
+          operators should verify before production traffic depends on exception handling.
+        </p>
+        <p>
+          Useful policies also spell out expiry signals, dashboard markers, and the retry controls
+          teams should apply while throughput exceptions remain active.
+        </p>
+      </section>
+      <div class="related-quota-guides">Related quota guides</div>
+      <div class="policy-sidebar">Quota policy</div>
+      <div class="feedback-widget">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1150,6 +1150,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Region matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_soft_limit_warning_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-soft-limit-warning.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/soft-limit-warning",
+        )
+
+        self.assertIn("Soft limit warnings matter when they explain which workload classes", content.text)
+        self.assertIn("advisory thresholds", content.text)
+        self.assertIn("backpressure", content.text)
+        self.assertIn("retry smoothing", content.text)
+        self.assertNotIn("Soft limit summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_grace_period_notice_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-grace-period-notice.html"),
+            url="https://docs.anthropic.com/en/docs/usage/grace-period-notice",
+        )
+
+        self.assertIn("Grace period notices are useful when they explain which customers retain temporary access", content.text)
+        self.assertIn("exemption windows", content.text)
+        self.assertIn("traffic shaping", content.text)
+        self.assertIn("queueing controls", content.text)
+        self.assertNotIn("Grace period summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_throughput_exception_policy_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-throughput-exception-policy.html"),
+            url="https://docs.together.ai/docs/inference/throughput-exception-policy",
+        )
+
+        self.assertIn("Throughput exception policies matter when they explain which workloads qualify", content.text)
+        self.assertIn("regional routing", content.text)
+        self.assertIn("production traffic", content.text)
+        self.assertIn("expiry signals, dashboard markers", content.text)
+        self.assertNotIn("Exception policy summary", content.text)
+        self.assertNotIn("Exception thresholds", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic soft-limit, grace-period, and throughput-exception extraction fixtures for OpenAI, Anthropic, and Together docs
- extend source-specific cleanup rules for summary panels, exception thresholds, and related-guide noise on developer policy pages
- bump the patch line to v1.2.25 and add release notes

## Verification
- make check PYTHON=./.venv-dev/bin/python
