### PR TITLE
test: add policy sibling extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.26] - 2026-04-10
+
+### Added
+
+- Temporary-overage-notice, fairness-policy-update, and capacity-reservation-note extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.26`
+- International extraction coverage now includes temporary-overage-notice, fairness-policy-update, and capacity-reservation-note layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, and throughput-exception-policy layouts
+
+### Fixed
+
+- Reduced overage summaries, fairness summaries, reservation summaries, reservation matrices, and related-guide recirculation noise on developer limit and reservation-policy pages
+- Locked another class of overage, fairness, and capacity-reservation layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.25] - 2026-04-09
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.25`
+`v1.2.26`
 
 ### Suggested Title
 
-`AI News Open v1.2.25 · Soft Limit and Exception Policy Extraction Coverage`
+`AI News Open v1.2.26 · Overage and Reservation Policy Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.25
+## AI News Open v1.2.26
 
-AI News Open `v1.2.25` hardens extraction quality for soft-limit-warning, grace-period-notice, and throughput-exception-policy layouts across more developer-doc publishers.
+AI News Open `v1.2.26` hardens extraction quality for temporary-overage-notice, fairness-policy-update, and capacity-reservation-note layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.25` hardens extraction quality for soft-limit-warning, grace-
 
 ### Highlights in this release
 
-- New deterministic soft-limit, grace-period, and throughput-exception fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for soft-limit summaries, grace-period summaries, exception-threshold panels, and related-guide recirculation on developer limit and exception-policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, and throughput-exception-policy layouts
+- New deterministic temporary-overage, fairness-policy, and capacity-reservation fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for overage summaries, fairness summaries, reservation summaries, reservation matrices, and related-guide recirculation on developer limit and reservation-policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, and capacity-reservation-note layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.26.md
+++ b/docs/releases/v1.2.26.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.26
+
+AI News Open `v1.2.26` is a content-quality patch release focused on temporary-overage notices, fairness-policy updates, and capacity-reservation notes. It extends deterministic extraction coverage for another class of developer policy pages where summaries, reservation tables, and related guides often sit beside the real operator guidance.
+
+### What changed
+
+- Added temporary-overage-notice / fairness-policy-update / capacity-reservation-note extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for overage summaries, fairness summaries, reservation summaries, reservation matrices, navigation blocks, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of overage, fairness, and reservation-policy pages
+
+### Why this matters
+
+- Developer policy pages often mix rollout guidance with summaries, reservation tables, and related-guide recirculation inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, and capacity-reservation-note layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.25"
+version = "1.2.26"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.25"
+__version__ = "1.2.26"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -346,6 +346,7 @@ HOST_SELECTORS = {
     ),
     "docs.anthropic.com": (
         ".security-bulletin",
+        ".fairness-policy-update",
         ".grace-period-notice",
         ".concurrency-cap-update",
         ".usage-limit-notice",
@@ -409,6 +410,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".temporary-overage-notice",
         ".soft-limit-warning",
         ".burst-cap-notice",
         ".rate-limit-update",
@@ -427,6 +429,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".capacity-reservation-note",
         ".throughput-exception-policy",
         ".regional-quota-advisory",
         ".quota-policy",
@@ -846,6 +849,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".fairness-summary",
         ".grace-period-summary",
         ".concurrency-summary",
         ".severity-badge",
@@ -937,6 +941,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".overage-summary",
         ".soft-limit-summary",
         ".burst-cap-summary",
         ".rate-limit-nav",
@@ -963,6 +968,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".reservation-summary",
+        ".reservation-matrix",
         ".exception-thresholds",
         ".exception-policy-summary",
         ".region-matrix",
@@ -1297,6 +1304,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Fairness policy update$"),
+        re.compile(r"^Fairness summary$"),
         re.compile(r"^Grace period notice$"),
         re.compile(r"^Grace period summary$"),
         re.compile(r"^Concurrency cap update$"),
@@ -1370,6 +1379,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Temporary overage notice$"),
+        re.compile(r"^Overage summary$"),
         re.compile(r"^Soft limit warning$"),
         re.compile(r"^Soft limit summary$"),
         re.compile(r"^Burst cap notice$"),
@@ -1394,6 +1405,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Capacity reservation note$"),
+        re.compile(r"^Reservation summary$"),
+        re.compile(r"^Reservation matrix$"),
         re.compile(r"^Throughput exception policy$"),
         re.compile(r"^Exception policy summary$"),
         re.compile(r"^Exception thresholds$"),
@@ -1716,6 +1730,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"fairness-policy-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-period-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"concurrency-cap-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"usage-limit-notice"}},
@@ -1780,6 +1795,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"temporary-overage-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"soft-limit-warning"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-cap-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"rate-limit-update"}},
@@ -1798,6 +1814,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"capacity-reservation-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"throughput-exception-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"regional-quota-advisory"}},
         {"tags": {"div", "section"}, "class_tokens": {"quota-policy"}},

--- a/tests/fixtures/extraction/anthropic-fairness-policy-update.html
+++ b/tests/fixtures/extraction/anthropic-fairness-policy-update.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Fairness policy update</title>
+  </head>
+  <body>
+    <main>
+      <div class="fairness-summary">Fairness summary</div>
+      <section class="fairness-policy-update">
+        <h1>Fairness policy update</h1>
+        <p>
+          Fairness policy updates are useful when they explain which workload classes now share
+          queue fairness guarantees, how exception requests are reviewed, and what operators should
+          adjust in scheduling before the policy takes effect.
+        </p>
+        <p>
+          Clear updates also describe dashboard checkpoints, escalation contacts, and the fallback
+          queue controls teams should keep ready while fairness enforcement stabilizes.
+        </p>
+      </section>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="contact-security">Contact security</div>
+      <div class="docs-feedback">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-temporary-overage-notice.html
+++ b/tests/fixtures/extraction/openai-temporary-overage-notice.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Temporary overage notice</title>
+  </head>
+  <body>
+    <main>
+      <div class="overage-summary">Overage summary</div>
+      <section class="temporary-overage-notice">
+        <h1>Temporary overage notice</h1>
+        <p>
+          Temporary overage notices matter when they explain which workloads can briefly exceed
+          normal spend or token envelopes, how temporary relief is approved, and what operators
+          should change in admission control before the overage window closes.
+        </p>
+        <p>
+          Useful notices also document burn-rate alerts, retry smoothing, and the fallback routing
+          controls teams should keep enabled while temporary overage handling is active.
+        </p>
+      </section>
+      <div class="rate-limit-nav">Rate limit navigation</div>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="feedback-widget">Was this helpful?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-capacity-reservation-note.html
+++ b/tests/fixtures/extraction/together-capacity-reservation-note.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Capacity reservation note</title>
+  </head>
+  <body>
+    <main>
+      <div class="reservation-summary">Reservation summary</div>
+      <div class="reservation-matrix">Reservation matrix</div>
+      <section class="capacity-reservation-note">
+        <h1>Capacity reservation note</h1>
+        <p>
+          Capacity reservation notes matter when they explain which workloads can claim reserved
+          throughput pools, how reservation windows interact with failover routing, and what
+          operators should verify before production traffic depends on reserved capacity.
+        </p>
+        <p>
+          Useful notes also spell out reservation expiry signals, dashboard markers, and the retry
+          controls teams should apply while reserved-capacity policies remain active.
+        </p>
+      </section>
+      <div class="related-quota-guides">Related quota guides</div>
+      <div class="policy-sidebar">Quota policy</div>
+      <div class="feedback-widget">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1195,6 +1195,53 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Exception thresholds", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_temporary_overage_notice_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-temporary-overage-notice.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/temporary-overage-notice",
+        )
+
+        self.assertIn("Temporary overage notices matter when they explain which workloads can briefly exceed", content.text)
+        self.assertIn("temporary relief is approved", content.text)
+        self.assertIn("burn-rate alerts", content.text)
+        self.assertIn("fallback routing", content.text)
+        self.assertNotIn("Overage summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_fairness_policy_update_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-fairness-policy-update.html"),
+            url="https://docs.anthropic.com/en/docs/usage/fairness-policy-update",
+        )
+
+        self.assertIn("Fairness policy updates are useful when they explain which workload classes now share", content.text)
+        self.assertIn("queue fairness guarantees", content.text)
+        self.assertIn("scheduling", content.text)
+        self.assertIn("fallback", content.text)
+        self.assertIn("queue controls", content.text)
+        self.assertNotIn("Fairness summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_capacity_reservation_note_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-capacity-reservation-note.html"),
+            url="https://docs.together.ai/docs/inference/capacity-reservation-note",
+        )
+
+        self.assertIn("Capacity reservation notes matter when they explain which workloads can claim reserved", content.text)
+        self.assertIn("reserved", content.text)
+        self.assertIn("throughput pools", content.text)
+        self.assertIn("failover routing", content.text)
+        self.assertIn("reservation expiry signals", content.text)
+        self.assertNotIn("Reservation summary", content.text)
+        self.assertNotIn("Reservation matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add deterministic temporary-overage, fairness-policy, and capacity-reservation extraction fixtures for OpenAI, Anthropic, and Together docs
- extend source-specific cleanup rules for summary panels, reservation tables, and related-guide noise on developer policy pages
- bump the patch line to v1.2.26 and add release notes

## Verification
- make check PYTHON=./.venv-dev/bin/python
