### PR TITLE
test: add policy notice extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.27] - 2026-04-10
+
+### Added
+
+- Burst-credit-notice, queue-priority-update, and reservation-rollover-policy extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.27`
+- International extraction coverage now includes burst-credit-notice, queue-priority-update, and reservation-rollover-policy layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, and capacity-reservation-note layouts
+
+### Fixed
+
+- Reduced burst-credit summaries, priority summaries, rollover summaries, rollover matrices, and related-guide recirculation noise on developer limit and reservation-rollover pages
+- Locked another class of burst-credit, queue-priority, and reservation-rollover layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.26] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.26`
+`v1.2.27`
 
 ### Suggested Title
 
-`AI News Open v1.2.26 · Overage and Reservation Policy Extraction Coverage`
+`AI News Open v1.2.27 · Burst Credit and Queue Priority Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.26
+## AI News Open v1.2.27
 
-AI News Open `v1.2.26` hardens extraction quality for temporary-overage-notice, fairness-policy-update, and capacity-reservation-note layouts across more developer-doc publishers.
+AI News Open `v1.2.27` hardens extraction quality for burst-credit-notice, queue-priority-update, and reservation-rollover-policy layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.26` hardens extraction quality for temporary-overage-notice, 
 
 ### Highlights in this release
 
-- New deterministic temporary-overage, fairness-policy, and capacity-reservation fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for overage summaries, fairness summaries, reservation summaries, reservation matrices, and related-guide recirculation on developer limit and reservation-policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, and capacity-reservation-note layouts
+- New deterministic burst-credit, queue-priority, and reservation-rollover fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for burst-credit summaries, priority summaries, rollover summaries, rollover matrices, and related-guide recirculation on developer limit and reservation-rollover pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, and reservation-rollover-policy layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.27.md
+++ b/docs/releases/v1.2.27.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.27
+
+AI News Open `v1.2.27` is a content-quality patch release focused on burst-credit notices, queue-priority updates, and reservation-rollover policies. It extends deterministic extraction coverage for another class of developer policy pages where summaries, rollover tables, and related guides often sit beside the real operator guidance.
+
+### What changed
+
+- Added burst-credit-notice / queue-priority-update / reservation-rollover-policy extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for burst-credit summaries, priority summaries, rollover summaries, rollover matrices, navigation blocks, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of burst-credit, queue-priority, and rollover-policy pages
+
+### Why this matters
+
+- Developer policy pages often mix rollout guidance with summaries, rollover tables, and related-guide recirculation inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, and reservation-rollover-policy layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.26"
+version = "1.2.27"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.26"
+__version__ = "1.2.27"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -346,6 +346,7 @@ HOST_SELECTORS = {
     ),
     "docs.anthropic.com": (
         ".security-bulletin",
+        ".queue-priority-update",
         ".fairness-policy-update",
         ".grace-period-notice",
         ".concurrency-cap-update",
@@ -410,6 +411,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".burst-credit-notice",
         ".temporary-overage-notice",
         ".soft-limit-warning",
         ".burst-cap-notice",
@@ -429,6 +431,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".reservation-rollover-policy",
         ".capacity-reservation-note",
         ".throughput-exception-policy",
         ".regional-quota-advisory",
@@ -849,6 +852,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".priority-summary",
         ".fairness-summary",
         ".grace-period-summary",
         ".concurrency-summary",
@@ -941,6 +945,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".burst-credit-summary",
         ".overage-summary",
         ".soft-limit-summary",
         ".burst-cap-summary",
@@ -968,6 +973,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".rollover-summary",
+        ".rollover-matrix",
         ".reservation-summary",
         ".reservation-matrix",
         ".exception-thresholds",
@@ -1304,6 +1311,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Queue priority update$"),
+        re.compile(r"^Priority summary$"),
         re.compile(r"^Fairness policy update$"),
         re.compile(r"^Fairness summary$"),
         re.compile(r"^Grace period notice$"),
@@ -1379,6 +1388,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Burst credit notice$"),
+        re.compile(r"^Burst credit summary$"),
         re.compile(r"^Temporary overage notice$"),
         re.compile(r"^Overage summary$"),
         re.compile(r"^Soft limit warning$"),
@@ -1405,6 +1416,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Reservation rollover policy$"),
+        re.compile(r"^Rollover summary$"),
+        re.compile(r"^Rollover matrix$"),
         re.compile(r"^Capacity reservation note$"),
         re.compile(r"^Reservation summary$"),
         re.compile(r"^Reservation matrix$"),
@@ -1730,6 +1744,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"queue-priority-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"fairness-policy-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-period-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"concurrency-cap-update"}},
@@ -1795,6 +1810,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"burst-credit-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"temporary-overage-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"soft-limit-warning"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-cap-notice"}},
@@ -1814,6 +1830,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"reservation-rollover-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"capacity-reservation-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"throughput-exception-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"regional-quota-advisory"}},

--- a/tests/fixtures/extraction/anthropic-queue-priority-update.html
+++ b/tests/fixtures/extraction/anthropic-queue-priority-update.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Queue priority update</title>
+  </head>
+  <body>
+    <main>
+      <div class="priority-summary">Priority summary</div>
+      <section class="queue-priority-update">
+        <h1>Queue priority update</h1>
+        <p>
+          Queue priority updates are useful when they explain which workload classes now receive
+          elevated scheduling precedence, how exception requests are reviewed, and what operators
+          should adjust in queuing policy before the priority rules go live.
+        </p>
+        <p>
+          Clear updates also describe dashboard checkpoints, escalation contacts, and the fallback
+          queue controls teams should keep ready while priority enforcement stabilizes.
+        </p>
+      </section>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="contact-security">Contact security</div>
+      <div class="docs-feedback">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-burst-credit-notice.html
+++ b/tests/fixtures/extraction/openai-burst-credit-notice.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Burst credit notice</title>
+  </head>
+  <body>
+    <main>
+      <div class="burst-credit-summary">Burst credit summary</div>
+      <section class="burst-credit-notice">
+        <h1>Burst credit notice</h1>
+        <p>
+          Burst credit notices matter when they explain which workloads can spend temporary credit
+          pools above baseline throughput, how credits are replenished, and what operators should
+          change in pacing policy before the new burst-credit window opens.
+        </p>
+        <p>
+          Useful notices also document burn-rate dashboards, retry smoothing, and the fallback
+          routing controls teams should keep enabled while burst-credit behavior is monitored.
+        </p>
+      </section>
+      <div class="rate-limit-nav">Rate limit navigation</div>
+      <div class="related-limit-guides">Related limit guides</div>
+      <div class="feedback-widget">Was this helpful?</div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-reservation-rollover-policy.html
+++ b/tests/fixtures/extraction/together-reservation-rollover-policy.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Reservation rollover policy</title>
+  </head>
+  <body>
+    <main>
+      <div class="rollover-summary">Rollover summary</div>
+      <div class="rollover-matrix">Rollover matrix</div>
+      <section class="reservation-rollover-policy">
+        <h1>Reservation rollover policy</h1>
+        <p>
+          Reservation rollover policies matter when they explain which reserved capacity can carry
+          forward into later windows, how rollover interacts with regional failover, and what
+          operators should verify before production traffic depends on rollover capacity.
+        </p>
+        <p>
+          Useful policies also spell out rollover expiry signals, dashboard markers, and the retry
+          controls teams should apply while rollover reservations remain active.
+        </p>
+      </section>
+      <div class="related-quota-guides">Related quota guides</div>
+      <div class="policy-sidebar">Quota policy</div>
+      <div class="feedback-widget">Need more help?</div>
+    </main>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1242,6 +1242,52 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Reservation matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_burst_credit_notice_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-burst-credit-notice.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/burst-credit-notice",
+        )
+
+        self.assertIn("Burst credit notices matter when they explain which workloads can spend temporary credit", content.text)
+        self.assertIn("credits are replenished", content.text)
+        self.assertIn("pacing policy", content.text)
+        self.assertIn("burn-rate dashboards", content.text)
+        self.assertNotIn("Burst credit summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_queue_priority_update_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-queue-priority-update.html"),
+            url="https://docs.anthropic.com/en/docs/usage/queue-priority-update",
+        )
+
+        self.assertIn("Queue priority updates are useful when they explain which workload classes now receive", content.text)
+        self.assertIn("elevated scheduling precedence", content.text)
+        self.assertIn("queuing policy", content.text)
+        self.assertIn("fallback", content.text)
+        self.assertIn("queue controls", content.text)
+        self.assertNotIn("Priority summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_reservation_rollover_policy_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-reservation-rollover-policy.html"),
+            url="https://docs.together.ai/docs/inference/reservation-rollover-policy",
+        )
+
+        self.assertIn("Reservation rollover policies matter when they explain which reserved capacity can carry", content.text)
+        self.assertIn("rollover interacts with regional failover", content.text)
+        self.assertIn("rollover expiry signals", content.text)
+        self.assertIn("rollover reservations remain active", content.text)
+        self.assertNotIn("Rollover summary", content.text)
+        self.assertNotIn("Rollover matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add burst-credit-notice, queue-priority-update, and reservation-rollover-policy extraction fixtures
- extend source-specific cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes to v1.2.27

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python