### PR TITLE
test: add policy faq extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.28] - 2026-04-10
+
+### Added
+
+- Burst-credit-faq, priority-escalation-guide, and rollover-exception-policy extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.28`
+- International extraction coverage now includes burst-credit-faq, priority-escalation-guide, and rollover-exception-policy layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, and reservation-rollover-policy layouts
+
+### Fixed
+
+- Reduced burst-credit FAQ summaries, priority escalation summaries, rollover exception summaries, rollover exception matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of burst-credit, priority-escalation, and rollover-exception layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.27] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.27`
+`v1.2.28`
 
 ### Suggested Title
 
-`AI News Open v1.2.27 · Burst Credit and Queue Priority Extraction Coverage`
+`AI News Open v1.2.28 · Burst Credit FAQ and Rollover Exception Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.27
+## AI News Open v1.2.28
 
-AI News Open `v1.2.27` hardens extraction quality for burst-credit-notice, queue-priority-update, and reservation-rollover-policy layouts across more developer-doc publishers.
+AI News Open `v1.2.28` hardens extraction quality for burst-credit-faq, priority-escalation-guide, and rollover-exception-policy layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.27` hardens extraction quality for burst-credit-notice, queue
 
 ### Highlights in this release
 
-- New deterministic burst-credit, queue-priority, and reservation-rollover fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for burst-credit summaries, priority summaries, rollover summaries, rollover matrices, and related-guide recirculation on developer limit and reservation-rollover pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, and reservation-rollover-policy layouts
+- New deterministic burst-credit-faq, priority-escalation-guide, and rollover-exception-policy fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for burst-credit FAQ summaries, priority escalation summaries, rollover exception summaries, rollover exception matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, and rollover-exception-policy layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.28.md
+++ b/docs/releases/v1.2.28.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.28
+
+AI News Open `v1.2.28` is a content-quality patch release focused on burst-credit FAQs, priority escalation guides, and rollover exception policies. It extends deterministic extraction coverage for another class of developer policy pages where operator guidance shares space with FAQ summaries, escalation sidebars, and exception matrices.
+
+### What changed
+
+- Added burst-credit-faq / priority-escalation-guide / rollover-exception-policy extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for burst-credit FAQ summaries, priority escalation summaries, rollover exception summaries, rollover exception matrices, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of burst-credit FAQ, priority escalation, and rollover exception policy pages
+
+### Why this matters
+
+- Developer policy pages often mix operational guidance with FAQ summaries, escalation shortcuts, exception matrices, and recirculation modules inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, and rollover-exception-policy layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.27"
+version = "1.2.28"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.27"
+__version__ = "1.2.28"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".priority-escalation-guide",
         ".security-bulletin",
         ".queue-priority-update",
         ".fairness-policy-update",
@@ -411,6 +412,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".burst-credit-faq",
         ".burst-credit-notice",
         ".temporary-overage-notice",
         ".soft-limit-warning",
@@ -431,6 +433,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".rollover-exception-policy",
         ".reservation-rollover-policy",
         ".capacity-reservation-note",
         ".throughput-exception-policy",
@@ -945,6 +948,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".burst-credit-faq-summary",
         ".burst-credit-summary",
         ".overage-summary",
         ".soft-limit-summary",
@@ -973,6 +977,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".rollover-exception-summary",
+        ".rollover-exception-matrix",
         ".rollover-summary",
         ".rollover-matrix",
         ".reservation-summary",
@@ -1311,6 +1317,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Priority escalation guide$"),
+        re.compile(r"^Priority escalation summary$"),
         re.compile(r"^Queue priority update$"),
         re.compile(r"^Priority summary$"),
         re.compile(r"^Fairness policy update$"),
@@ -1388,6 +1396,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Burst credit FAQ$"),
+        re.compile(r"^Burst credit FAQ summary$"),
         re.compile(r"^Burst credit notice$"),
         re.compile(r"^Burst credit summary$"),
         re.compile(r"^Temporary overage notice$"),
@@ -1416,6 +1426,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Rollover exception policy$"),
+        re.compile(r"^Rollover exception summary$"),
+        re.compile(r"^Rollover exception matrix$"),
         re.compile(r"^Reservation rollover policy$"),
         re.compile(r"^Rollover summary$"),
         re.compile(r"^Rollover matrix$"),
@@ -1744,6 +1757,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"priority-escalation-guide"}},
         {"tags": {"div", "section"}, "class_tokens": {"queue-priority-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"fairness-policy-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-period-notice"}},
@@ -1810,6 +1824,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"burst-credit-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"temporary-overage-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"soft-limit-warning"}},
@@ -1830,6 +1845,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"rollover-exception-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"reservation-rollover-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"capacity-reservation-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"throughput-exception-policy"}},

--- a/tests/fixtures/extraction/anthropic-priority-escalation-guide.html
+++ b/tests/fixtures/extraction/anthropic-priority-escalation-guide.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="priority-escalation-summary">
+      <h2>Priority escalation summary</h2>
+      <p>Short escalation summary.</p>
+    </section>
+    <main class="priority-escalation-guide">
+      <h1>Priority escalation guide</h1>
+      <p>Priority escalation guides matter when they explain which workload classes can request higher scheduling precedence during constrained capacity windows.</p>
+      <p>The guide should define approval checkpoints, incident triggers, and rollback conditions so operators know when temporary escalation is justified.</p>
+      <p>It should also clarify how escalation interacts with queue fairness, dashboard evidence, and fallback queue controls after the elevated window ends.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-burst-credit-faq.html
+++ b/tests/fixtures/extraction/openai-burst-credit-faq.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="burst-credit-faq-summary">
+      <h2>Burst credit FAQ summary</h2>
+      <p>Short summary card.</p>
+    </section>
+    <main class="burst-credit-faq">
+      <h1>Burst credit FAQ</h1>
+      <p>Burst credit FAQs matter when operators need one place that explains how temporary credits interact with steady-state throughput and tenant fairness.</p>
+      <p>The FAQ should spell out when credits refill, how burst windows decay, and which dashboards surface the remaining burst pool before workloads are throttled.</p>
+      <p>It should also explain how exception queues, fallback regions, and pacing controls behave when a tenant spends burst credits faster than expected.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-rollover-exception-policy.html
+++ b/tests/fixtures/extraction/together-rollover-exception-policy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="rollover-exception-summary">
+      <h2>Rollover exception summary</h2>
+      <p>Short exception summary.</p>
+    </section>
+    <section class="rollover-exception-matrix">
+      <h2>Rollover exception matrix</h2>
+      <p>Exception matrix card.</p>
+    </section>
+    <main class="rollover-exception-policy">
+      <h1>Rollover exception policy</h1>
+      <p>Rollover exception policies matter when they explain which reserved capacity can stay active past the normal cutoff during regional failover or emergency backlog relief.</p>
+      <p>The policy should spell out who can grant an exception, how long the temporary rollover remains valid, and which dashboards show exception expiry signals.</p>
+      <p>It should also clarify how rollover exceptions interact with reservation guarantees, queue protection, and regional recovery playbooks once normal capacity returns.</p>
+    </main>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1288,6 +1288,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Rollover matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_burst_credit_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-burst-credit-faq.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/burst-credit-faq",
+        )
+
+        self.assertIn("Burst credit FAQs matter when operators need one place", content.text)
+        self.assertIn("credits refill", content.text)
+        self.assertIn("burst windows decay", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertNotIn("Burst credit FAQ summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_priority_escalation_guide_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-priority-escalation-guide.html"),
+            url="https://docs.anthropic.com/en/docs/usage/priority-escalation-guide",
+        )
+
+        self.assertIn("Priority escalation guides matter when they explain which workload classes", content.text)
+        self.assertIn("higher scheduling precedence", content.text)
+        self.assertIn("approval checkpoints", content.text)
+        self.assertIn("rollback conditions", content.text)
+        self.assertNotIn("Priority escalation summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_rollover_exception_policy_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-rollover-exception-policy.html"),
+            url="https://docs.together.ai/docs/inference/rollover-exception-policy",
+        )
+
+        self.assertIn("Rollover exception policies matter when they explain which reserved capacity can stay active", content.text)
+        self.assertIn("regional failover", content.text)
+        self.assertIn("exception expiry signals", content.text)
+        self.assertIn("reservation guarantees", content.text)
+        self.assertNotIn("Rollover exception summary", content.text)
+        self.assertNotIn("Rollover exception matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add burst-credit-faq, priority-escalation-guide, and rollover-exception-policy extraction fixtures
- extend source-specific cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes to v1.2.28

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python