### PR TITLE
test: add policy recovery extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.29] - 2026-04-10
+
+### Added
+
+- Burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.29`
+- International extraction coverage now includes burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, and rollover-exception-policy layouts
+
+### Fixed
+
+- Reduced burst-credit recovery summaries, rollback checklist summaries, rollover eligibility summaries, rollover eligibility matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of burst-credit recovery, escalation rollback, and rollover eligibility layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.28] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.28`
+`v1.2.29`
 
 ### Suggested Title
 
-`AI News Open v1.2.28 · Burst Credit FAQ and Rollover Exception Extraction Coverage`
+`AI News Open v1.2.29 · Recovery Note and Eligibility Guide Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.28
+## AI News Open v1.2.29
 
-AI News Open `v1.2.28` hardens extraction quality for burst-credit-faq, priority-escalation-guide, and rollover-exception-policy layouts across more developer-doc publishers.
+AI News Open `v1.2.29` hardens extraction quality for burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.28` hardens extraction quality for burst-credit-faq, priority
 
 ### Highlights in this release
 
-- New deterministic burst-credit-faq, priority-escalation-guide, and rollover-exception-policy fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for burst-credit FAQ summaries, priority escalation summaries, rollover exception summaries, rollover exception matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, and rollover-exception-policy layouts
+- New deterministic burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for burst-credit recovery summaries, rollback checklist summaries, rollover eligibility summaries, rollover eligibility matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, and rollover-eligibility-guide layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.29.md
+++ b/docs/releases/v1.2.29.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.29
+
+AI News Open `v1.2.29` is a content-quality patch release focused on burst-credit recovery notes, escalation rollback checklists, and rollover eligibility guides. It extends deterministic extraction coverage for another class of developer policy pages where recovery guidance shares space with summaries, rollback shortcuts, and eligibility matrices.
+
+### What changed
+
+- Added burst-credit-recovery-note / escalation-rollback-checklist / rollover-eligibility-guide extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for burst-credit recovery summaries, rollback checklist summaries, rollover eligibility summaries, rollover eligibility matrices, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of burst-credit recovery, escalation rollback, and rollover eligibility pages
+
+### Why this matters
+
+- Developer policy pages often mix recovery guidance with summary cards, rollback shortcuts, eligibility matrices, and recirculation modules inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, and rollover-eligibility-guide layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.28"
+version = "1.2.29"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.28"
+__version__ = "1.2.29"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".escalation-rollback-checklist",
         ".priority-escalation-guide",
         ".security-bulletin",
         ".queue-priority-update",
@@ -412,6 +413,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".burst-credit-recovery-note",
         ".burst-credit-faq",
         ".burst-credit-notice",
         ".temporary-overage-notice",
@@ -433,6 +435,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".rollover-eligibility-guide",
         ".rollover-exception-policy",
         ".reservation-rollover-policy",
         ".capacity-reservation-note",
@@ -948,6 +951,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".burst-credit-recovery-summary",
         ".burst-credit-faq-summary",
         ".burst-credit-summary",
         ".overage-summary",
@@ -977,6 +981,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".rollover-eligibility-summary",
+        ".rollover-eligibility-matrix",
         ".rollover-exception-summary",
         ".rollover-exception-matrix",
         ".rollover-summary",
@@ -1317,6 +1323,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Escalation rollback checklist$"),
+        re.compile(r"^Rollback checklist summary$"),
         re.compile(r"^Priority escalation guide$"),
         re.compile(r"^Priority escalation summary$"),
         re.compile(r"^Queue priority update$"),
@@ -1396,6 +1404,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Burst credit recovery note$"),
+        re.compile(r"^Burst credit recovery summary$"),
         re.compile(r"^Burst credit FAQ$"),
         re.compile(r"^Burst credit FAQ summary$"),
         re.compile(r"^Burst credit notice$"),
@@ -1426,6 +1436,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Rollover eligibility guide$"),
+        re.compile(r"^Rollover eligibility summary$"),
+        re.compile(r"^Rollover eligibility matrix$"),
         re.compile(r"^Rollover exception policy$"),
         re.compile(r"^Rollover exception summary$"),
         re.compile(r"^Rollover exception matrix$"),
@@ -1757,6 +1770,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"escalation-rollback-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"priority-escalation-guide"}},
         {"tags": {"div", "section"}, "class_tokens": {"queue-priority-update"}},
         {"tags": {"div", "section"}, "class_tokens": {"fairness-policy-update"}},
@@ -1824,6 +1838,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-notice"}},
         {"tags": {"div", "section"}, "class_tokens": {"temporary-overage-notice"}},
@@ -1845,6 +1860,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"rollover-eligibility-guide"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-exception-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"reservation-rollover-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"capacity-reservation-note"}},

--- a/tests/fixtures/extraction/anthropic-escalation-rollback-checklist.html
+++ b/tests/fixtures/extraction/anthropic-escalation-rollback-checklist.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="rollback-checklist-summary">
+      <h2>Rollback checklist summary</h2>
+      <p>Short rollback card.</p>
+    </section>
+    <main class="escalation-rollback-checklist">
+      <h1>Escalation rollback checklist</h1>
+      <p>Escalation rollback checklists matter when operators need a deterministic sequence for removing temporary scheduling priority after the incident window closes.</p>
+      <p>The checklist should define verification gates, queue health checks, and dashboard evidence that prove the elevated path can be safely withdrawn.</p>
+      <p>It should also explain how rollback interacts with fairness targets, fallback queues, and post-incident review controls once priority escalation ends.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-burst-credit-recovery-note.html
+++ b/tests/fixtures/extraction/openai-burst-credit-recovery-note.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="burst-credit-recovery-summary">
+      <h2>Burst credit recovery summary</h2>
+      <p>Short recovery card.</p>
+    </section>
+    <main class="burst-credit-recovery-note">
+      <h1>Burst credit recovery note</h1>
+      <p>Burst credit recovery notes matter when they explain how tenants return from temporary burst exhaustion without destabilizing their steady-state traffic.</p>
+      <p>The note should spell out replenishment timing, cooldown checkpoints, and the dashboards that show when recovery pacing can safely relax.</p>
+      <p>It should also clarify how exception queues, fallback regions, and retry backoff behave while burst credits recover toward the normal operating baseline.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-rollover-eligibility-guide.html
+++ b/tests/fixtures/extraction/together-rollover-eligibility-guide.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="rollover-eligibility-summary">
+      <h2>Rollover eligibility summary</h2>
+      <p>Short eligibility summary.</p>
+    </section>
+    <section class="rollover-eligibility-matrix">
+      <h2>Rollover eligibility matrix</h2>
+      <p>Eligibility matrix card.</p>
+    </section>
+    <main class="rollover-eligibility-guide">
+      <h1>Rollover eligibility guide</h1>
+      <p>Rollover eligibility guides matter when they explain which reservation pools can carry unused capacity into later windows and which pools expire immediately.</p>
+      <p>The guide should define the eligibility signals, regional failover exceptions, and dashboard checks that confirm whether a reservation remains eligible for rollover.</p>
+      <p>It should also clarify how eligibility interacts with reservation guarantees, queue protection, and recovery playbooks after a constrained capacity window ends.</p>
+    </main>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1333,6 +1333,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Rollover exception matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_burst_credit_recovery_note_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-burst-credit-recovery-note.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/burst-credit-recovery-note",
+        )
+
+        self.assertIn("Burst credit recovery notes matter when they explain how tenants return", content.text)
+        self.assertIn("replenishment timing", content.text)
+        self.assertIn("cooldown checkpoints", content.text)
+        self.assertIn("retry backoff", content.text)
+        self.assertNotIn("Burst credit recovery summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_escalation_rollback_checklist_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-escalation-rollback-checklist.html"),
+            url="https://docs.anthropic.com/en/docs/usage/escalation-rollback-checklist",
+        )
+
+        self.assertIn("Escalation rollback checklists matter when operators need a deterministic sequence", content.text)
+        self.assertIn("verification gates", content.text)
+        self.assertIn("queue health checks", content.text)
+        self.assertIn("fairness targets", content.text)
+        self.assertNotIn("Rollback checklist summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_rollover_eligibility_guide_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-rollover-eligibility-guide.html"),
+            url="https://docs.together.ai/docs/inference/rollover-eligibility-guide",
+        )
+
+        self.assertIn("Rollover eligibility guides matter when they explain which reservation pools can carry", content.text)
+        self.assertIn("regional failover exceptions", content.text)
+        self.assertIn("reservation remains eligible", content.text)
+        self.assertIn("reservation guarantees", content.text)
+        self.assertNotIn("Rollover eligibility summary", content.text)
+        self.assertNotIn("Rollover eligibility matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide extraction fixtures
- extend source-specific cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes to v1.2.29

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python