### PR TITLE
test: add policy edge-case extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.30] - 2026-04-10
+
+### Added
+
+- Burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.30`
+- International extraction coverage now includes burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, and rollover-eligibility-guide layouts
+
+### Fixed
+
+- Reduced burst-credit recovery FAQ summaries, rollback exception summaries, eligibility edge-case summaries, eligibility edge-case matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of burst-credit recovery FAQ, rollback exception, and eligibility edge-case layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.29] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.29`
+`v1.2.30`
 
 ### Suggested Title
 
-`AI News Open v1.2.29 · Recovery Note and Eligibility Guide Extraction Coverage`
+`AI News Open v1.2.30 · Recovery FAQ and Edge-Case Advisory Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.29
+## AI News Open v1.2.30
 
-AI News Open `v1.2.29` hardens extraction quality for burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide layouts across more developer-doc publishers.
+AI News Open `v1.2.30` hardens extraction quality for burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.29` hardens extraction quality for burst-credit-recovery-note
 
 ### Highlights in this release
 
-- New deterministic burst-credit-recovery-note, escalation-rollback-checklist, and rollover-eligibility-guide fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for burst-credit recovery summaries, rollback checklist summaries, rollover eligibility summaries, rollover eligibility matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, and rollover-eligibility-guide layouts
+- New deterministic burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for burst-credit recovery FAQ summaries, rollback exception summaries, eligibility edge-case summaries, eligibility edge-case matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, and eligibility-edge-case-advisory layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.30.md
+++ b/docs/releases/v1.2.30.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.30
+
+AI News Open `v1.2.30` is a content-quality patch release focused on burst-credit recovery FAQs, rollback exception notes, and eligibility edge-case advisories. It extends deterministic extraction coverage for another class of developer policy pages where recovery guidance shares space with FAQ cards, exception summaries, and edge-case matrices.
+
+### What changed
+
+- Added burst-credit-recovery-faq / rollback-exception-note / eligibility-edge-case-advisory extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for burst-credit recovery FAQ summaries, rollback exception summaries, eligibility edge-case summaries, eligibility edge-case matrices, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of burst-credit recovery FAQ, rollback exception, and eligibility edge-case pages
+
+### Why this matters
+
+- Developer policy pages often mix recovery guidance with FAQ cards, exception summaries, edge-case matrices, and recirculation modules inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, and eligibility-edge-case-advisory layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.29"
+version = "1.2.30"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.29"
+__version__ = "1.2.30"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".rollback-exception-note",
         ".escalation-rollback-checklist",
         ".priority-escalation-guide",
         ".security-bulletin",
@@ -413,6 +414,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".burst-credit-recovery-faq",
         ".burst-credit-recovery-note",
         ".burst-credit-faq",
         ".burst-credit-notice",
@@ -435,6 +437,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".eligibility-edge-case-advisory",
         ".rollover-eligibility-guide",
         ".rollover-exception-policy",
         ".reservation-rollover-policy",
@@ -951,6 +954,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".burst-credit-recovery-faq-summary",
         ".burst-credit-recovery-summary",
         ".burst-credit-faq-summary",
         ".burst-credit-summary",
@@ -981,6 +985,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".eligibility-edge-case-summary",
+        ".eligibility-edge-case-matrix",
         ".rollover-eligibility-summary",
         ".rollover-eligibility-matrix",
         ".rollover-exception-summary",
@@ -1323,6 +1329,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Rollback exception note$"),
+        re.compile(r"^Rollback exception summary$"),
         re.compile(r"^Escalation rollback checklist$"),
         re.compile(r"^Rollback checklist summary$"),
         re.compile(r"^Priority escalation guide$"),
@@ -1404,6 +1412,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Burst credit recovery FAQ$"),
+        re.compile(r"^Burst credit recovery FAQ summary$"),
         re.compile(r"^Burst credit recovery note$"),
         re.compile(r"^Burst credit recovery summary$"),
         re.compile(r"^Burst credit FAQ$"),
@@ -1436,6 +1446,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Eligibility edge-case advisory$"),
+        re.compile(r"^Eligibility edge-case summary$"),
+        re.compile(r"^Eligibility edge-case matrix$"),
         re.compile(r"^Rollover eligibility guide$"),
         re.compile(r"^Rollover eligibility summary$"),
         re.compile(r"^Rollover eligibility matrix$"),
@@ -1770,6 +1783,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"rollback-exception-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"escalation-rollback-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"priority-escalation-guide"}},
         {"tags": {"div", "section"}, "class_tokens": {"queue-priority-update"}},
@@ -1838,6 +1852,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-notice"}},
@@ -1860,6 +1875,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"eligibility-edge-case-advisory"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-eligibility-guide"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-exception-policy"}},
         {"tags": {"div", "section"}, "class_tokens": {"reservation-rollover-policy"}},

--- a/tests/fixtures/extraction/anthropic-rollback-exception-note.html
+++ b/tests/fixtures/extraction/anthropic-rollback-exception-note.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="rollback-exception-summary">
+      <h2>Rollback exception summary</h2>
+      <p>Short exception card.</p>
+    </section>
+    <main class="rollback-exception-note">
+      <h1>Rollback exception note</h1>
+      <p>Rollback exception notes matter when operators need to document why a temporary priority path cannot be removed on the normal timeline after an incident.</p>
+      <p>The note should define exception triggers, review checkpoints, and dashboard evidence showing why rollback must be delayed for a specific workload class.</p>
+      <p>It should also explain how rollback exceptions interact with fairness targets, fallback queues, and post-incident approvals once the elevated path is finally retired.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-burst-credit-recovery-faq.html
+++ b/tests/fixtures/extraction/openai-burst-credit-recovery-faq.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="burst-credit-recovery-faq-summary">
+      <h2>Burst credit recovery FAQ summary</h2>
+      <p>Short recovery FAQ card.</p>
+    </section>
+    <main class="burst-credit-recovery-faq">
+      <h1>Burst credit recovery FAQ</h1>
+      <p>Burst credit recovery FAQs matter when operators need direct answers about how exhausted burst pools return to normal without destabilizing steady-state traffic.</p>
+      <p>The FAQ should explain replenishment timing, cooldown checkpoints, and which dashboards confirm that recovery pacing can safely relax after a burst event.</p>
+      <p>It should also clarify how fallback regions, retry backoff, and exception queues behave while workloads recover toward the baseline throughput envelope.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-eligibility-edge-case-advisory.html
+++ b/tests/fixtures/extraction/together-eligibility-edge-case-advisory.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="eligibility-edge-case-summary">
+      <h2>Eligibility edge-case summary</h2>
+      <p>Short edge-case summary.</p>
+    </section>
+    <section class="eligibility-edge-case-matrix">
+      <h2>Eligibility edge-case matrix</h2>
+      <p>Edge-case matrix card.</p>
+    </section>
+    <main class="eligibility-edge-case-advisory">
+      <h1>Eligibility edge-case advisory</h1>
+      <p>Eligibility edge-case advisories matter when they explain which reservation pools lose rollover eligibility under unusual failover, replay, or regional saturation conditions.</p>
+      <p>The advisory should define the signals, exception thresholds, and dashboard checks that reveal when a pool drops out of the normal eligibility path.</p>
+      <p>It should also clarify how these edge cases interact with reservation guarantees, queue protection, and recovery playbooks after the constrained window ends.</p>
+    </main>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1378,6 +1378,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Rollover eligibility matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_burst_credit_recovery_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-burst-credit-recovery-faq.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/burst-credit-recovery-faq",
+        )
+
+        self.assertIn("Burst credit recovery FAQs matter when operators need direct answers", content.text)
+        self.assertIn("replenishment timing", content.text)
+        self.assertIn("recovery pacing", content.text)
+        self.assertIn("baseline throughput envelope", content.text)
+        self.assertNotIn("Burst credit recovery FAQ summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_rollback_exception_note_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-rollback-exception-note.html"),
+            url="https://docs.anthropic.com/en/docs/usage/rollback-exception-note",
+        )
+
+        self.assertIn("Rollback exception notes matter when operators need to document why a temporary priority path", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("fallback queues", content.text)
+        self.assertNotIn("Rollback exception summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_eligibility_edge_case_advisory_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-eligibility-edge-case-advisory.html"),
+            url="https://docs.together.ai/docs/inference/eligibility-edge-case-advisory",
+        )
+
+        self.assertIn("Eligibility edge-case advisories matter when they explain which reservation pools lose rollover eligibility", content.text)
+        self.assertIn("exception thresholds", content.text)
+        self.assertIn("drops out of the normal eligibility path", content.text)
+        self.assertIn("queue protection", content.text)
+        self.assertNotIn("Eligibility edge-case summary", content.text)
+        self.assertNotIn("Eligibility edge-case matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory extraction fixtures
- extend source-specific cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes to v1.2.30

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python