### PR TITLE
test: add policy grace extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.31] - 2026-04-10
+
+### Added
+
+- Recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.31`
+- International extraction coverage now includes recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, and eligibility-edge-case-advisory layouts
+
+### Fixed
+
+- Reduced recovery grace summaries, rollback approval matrix summaries, eligibility exception summaries, eligibility exception matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of recovery-grace, rollback-approval, and eligibility-exception layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.30] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.30`
+`v1.2.31`
 
 ### Suggested Title
 
-`AI News Open v1.2.30 · Recovery FAQ and Edge-Case Advisory Extraction Coverage`
+`AI News Open v1.2.31 · Grace Period and Approval Matrix Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.30
+## AI News Open v1.2.31
 
-AI News Open `v1.2.30` hardens extraction quality for burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory layouts across more developer-doc publishers.
+AI News Open `v1.2.31` hardens extraction quality for recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.30` hardens extraction quality for burst-credit-recovery-faq,
 
 ### Highlights in this release
 
-- New deterministic burst-credit-recovery-faq, rollback-exception-note, and eligibility-edge-case-advisory fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for burst-credit recovery FAQ summaries, rollback exception summaries, eligibility edge-case summaries, eligibility edge-case matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, and eligibility-edge-case-advisory layouts
+- New deterministic recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for recovery grace summaries, rollback approval matrix summaries, eligibility exception summaries, eligibility exception matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.31.md
+++ b/docs/releases/v1.2.31.md
@@ -1,0 +1,24 @@
+## AI News Open v1.2.31
+
+AI News Open `v1.2.31` is a content-quality patch release focused on recovery grace-period notes, rollback approval matrices, and eligibility exception FAQs. It extends deterministic extraction coverage for another class of developer policy pages where recovery guidance shares space with grace summaries, approval shortcuts, and FAQ-style exception cards.
+
+### What changed
+
+- Added recovery-grace-period-note / rollback-approval-matrix / eligibility-exception-faq extraction fixtures for:
+  - `platform.openai.com`
+  - `docs.anthropic.com`
+  - `docs.together.ai`
+- Added host-specific cleanup for recovery grace summaries, rollback approval matrix summaries, eligibility exception summaries, eligibility exception matrices, and related-guide modules on those layouts
+- Extended the extraction regression suite to cover another class of recovery-grace, rollback-approval, and eligibility-exception pages
+
+### Why this matters
+
+- Developer policy pages often mix recovery guidance with summary cards, approval shortcuts, FAQ answers, and recirculation modules inside the same visible content region
+- Locking those layouts into fixtures reduces the chance that cleanup changes silently pollute extracted text and downstream digest summaries
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts together
+
+### Operator notes
+
+- This is a patch release with no new runtime configuration requirements
+- Existing deployments do not need schema or environment changes
+- `Release Artifact Smoke` still runs automatically after tag publication

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.30"
+version = "1.2.31"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.30"
+__version__ = "1.2.31"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".rollback-approval-matrix",
         ".rollback-exception-note",
         ".escalation-rollback-checklist",
         ".priority-escalation-guide",
@@ -414,6 +415,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".recovery-grace-period-note",
         ".burst-credit-recovery-faq",
         ".burst-credit-recovery-note",
         ".burst-credit-faq",
@@ -437,6 +439,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".eligibility-exception-faq",
         ".eligibility-edge-case-advisory",
         ".rollover-eligibility-guide",
         ".rollover-exception-policy",
@@ -954,6 +957,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".recovery-grace-summary",
         ".burst-credit-recovery-faq-summary",
         ".burst-credit-recovery-summary",
         ".burst-credit-faq-summary",
@@ -985,6 +989,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".eligibility-exception-summary",
+        ".eligibility-exception-matrix",
         ".eligibility-edge-case-summary",
         ".eligibility-edge-case-matrix",
         ".rollover-eligibility-summary",
@@ -1329,6 +1335,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Rollback approval matrix$"),
+        re.compile(r"^Approval matrix summary$"),
         re.compile(r"^Rollback exception note$"),
         re.compile(r"^Rollback exception summary$"),
         re.compile(r"^Escalation rollback checklist$"),
@@ -1412,6 +1420,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Recovery grace-period note$"),
+        re.compile(r"^Recovery grace summary$"),
         re.compile(r"^Burst credit recovery FAQ$"),
         re.compile(r"^Burst credit recovery FAQ summary$"),
         re.compile(r"^Burst credit recovery note$"),
@@ -1446,6 +1456,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Eligibility exception FAQ$"),
+        re.compile(r"^Eligibility exception summary$"),
+        re.compile(r"^Eligibility exception matrix$"),
         re.compile(r"^Eligibility edge-case advisory$"),
         re.compile(r"^Eligibility edge-case summary$"),
         re.compile(r"^Eligibility edge-case matrix$"),
@@ -1783,6 +1796,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"rollback-approval-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollback-exception-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"escalation-rollback-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"priority-escalation-guide"}},
@@ -1852,6 +1866,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"recovery-grace-period-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-faq"}},
@@ -1875,6 +1890,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"eligibility-exception-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-edge-case-advisory"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-eligibility-guide"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-exception-policy"}},

--- a/tests/fixtures/extraction/anthropic-rollback-approval-matrix.html
+++ b/tests/fixtures/extraction/anthropic-rollback-approval-matrix.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="approval-matrix-summary">
+      <h2>Approval matrix summary</h2>
+      <p>Short approval matrix card.</p>
+    </section>
+    <main class="rollback-approval-matrix">
+      <h1>Rollback approval matrix</h1>
+      <p>Rollback approval matrices matter when operators need a clear map of who can approve the removal of temporary priority paths across different incident severities.</p>
+      <p>The matrix should define approval owners, evidence requirements, and queue health checks that must be satisfied before rollback authority is granted.</p>
+      <p>It should also explain how matrix exceptions interact with fairness controls, fallback queues, and post-incident review expectations.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-recovery-grace-period-note.html
+++ b/tests/fixtures/extraction/openai-recovery-grace-period-note.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="recovery-grace-summary">
+      <h2>Recovery grace summary</h2>
+      <p>Short grace summary.</p>
+    </section>
+    <main class="recovery-grace-period-note">
+      <h1>Recovery grace-period note</h1>
+      <p>Recovery grace-period notes matter when operators need to understand how long a workload can remain on softened recovery pacing after a burst-credit incident.</p>
+      <p>The note should define grace thresholds, dashboard checkpoints, and the signals that show when normal pacing can resume without renewed pressure on shared throughput.</p>
+      <p>It should also explain how fallback regions, retry controls, and exception queues behave while the grace window is still active.</p>
+    </main>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-eligibility-exception-faq.html
+++ b/tests/fixtures/extraction/together-eligibility-exception-faq.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="eligibility-exception-summary">
+      <h2>Eligibility exception summary</h2>
+      <p>Short exception summary.</p>
+    </section>
+    <section class="eligibility-exception-matrix">
+      <h2>Eligibility exception matrix</h2>
+      <p>Exception matrix card.</p>
+    </section>
+    <main class="eligibility-exception-faq">
+      <h1>Eligibility exception FAQ</h1>
+      <p>Eligibility exception FAQs matter when operators need direct answers about which reservation pools can keep rollover status under unusual failover or replay conditions.</p>
+      <p>The FAQ should define exception triggers, dashboard checks, and threshold signals that explain when a pool remains eligible outside the normal policy path.</p>
+      <p>It should also clarify how exception handling interacts with reservation guarantees, queue protection, and regional recovery playbooks after the constrained window ends.</p>
+    </main>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1423,6 +1423,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Eligibility edge-case matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_recovery_grace_period_note_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-recovery-grace-period-note.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/recovery-grace-period-note",
+        )
+
+        self.assertIn("Recovery grace-period notes matter when operators need to understand how long", content.text)
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("normal pacing can resume", content.text)
+        self.assertIn("exception queues", content.text)
+        self.assertNotIn("Recovery grace summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_rollback_approval_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-rollback-approval-matrix.html"),
+            url="https://docs.anthropic.com/en/docs/usage/rollback-approval-matrix",
+        )
+
+        self.assertIn("Rollback approval matrices matter when operators need a clear map", content.text)
+        self.assertIn("approval owners", content.text)
+        self.assertIn("evidence requirements", content.text)
+        self.assertIn("fallback queues", content.text)
+        self.assertNotIn("Approval matrix summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_eligibility_exception_faq_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-eligibility-exception-faq.html"),
+            url="https://docs.together.ai/docs/inference/eligibility-exception-faq",
+        )
+
+        self.assertIn("Eligibility exception FAQs matter when operators need direct answers", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("remains eligible outside the normal policy path", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Eligibility exception summary", content.text)
+        self.assertNotIn("Eligibility exception matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq extraction fixtures
- extend source-specific cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes to v1.2.31

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python