### PR TITLE
test: add policy grace window extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.32] - 2026-04-10
+
+### Added
+
+- Grace-window-faq, approval-escalation-note, and exception-rollover-checklist extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.32`
+- International extraction coverage now includes grace-window-faq, approval-escalation-note, and exception-rollover-checklist layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
+
+### Fixed
+
+- Reduced grace-window summaries, approval escalation summaries, exception rollover summaries, exception rollover matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of grace-window, approval-escalation, and exception-rollover layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.31] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.31`
+`v1.2.32`
 
 ### Suggested Title
 
-`AI News Open v1.2.31 · Grace Period and Approval Matrix Extraction Coverage`
+`AI News Open v1.2.32 · Grace Window and Exception Checklist Extraction Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.31
+## AI News Open v1.2.32
 
-AI News Open `v1.2.31` hardens extraction quality for recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq layouts across more developer-doc publishers.
+AI News Open `v1.2.32` hardens extraction quality for grace-window-faq, approval-escalation-note, and exception-rollover-checklist layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,8 +40,8 @@ AI News Open `v1.2.31` hardens extraction quality for recovery-grace-period-note
 
 ### Highlights in this release
 
-- New deterministic recovery-grace-period-note, rollback-approval-matrix, and eligibility-exception-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for recovery grace summaries, rollback approval matrix summaries, eligibility exception summaries, eligibility exception matrices, and related-guide recirculation on developer policy pages
+- New deterministic grace-window-faq, approval-escalation-note, and exception-rollover-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for grace-window summaries, approval escalation summaries, exception rollover summaries, exception rollover matrices, and related-guide recirculation on developer policy pages
 - The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 

--- a/docs/releases/v1.2.32.md
+++ b/docs/releases/v1.2.32.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.32
+
+## Highlights
+
+- Added deterministic extraction fixtures for `grace-window-faq`, `approval-escalation-note`, and `exception-rollover-checklist` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.31"
+version = "1.2.32"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.31"
+__version__ = "1.2.32"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".approval-escalation-note",
         ".rollback-approval-matrix",
         ".rollback-exception-note",
         ".escalation-rollback-checklist",
@@ -415,6 +416,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".grace-window-faq",
         ".recovery-grace-period-note",
         ".burst-credit-recovery-faq",
         ".burst-credit-recovery-note",
@@ -439,6 +441,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".exception-rollover-checklist",
         ".eligibility-exception-faq",
         ".eligibility-edge-case-advisory",
         ".rollover-eligibility-guide",
@@ -864,6 +867,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".approval-escalation-summary",
         ".priority-summary",
         ".fairness-summary",
         ".grace-period-summary",
@@ -957,6 +961,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".grace-window-summary",
         ".recovery-grace-summary",
         ".burst-credit-recovery-faq-summary",
         ".burst-credit-recovery-summary",
@@ -989,6 +994,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".exception-rollover-summary",
+        ".exception-rollover-matrix",
         ".eligibility-exception-summary",
         ".eligibility-exception-matrix",
         ".eligibility-edge-case-summary",
@@ -1335,6 +1342,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Approval escalation note$"),
+        re.compile(r"^Approval escalation summary$"),
         re.compile(r"^Rollback approval matrix$"),
         re.compile(r"^Approval matrix summary$"),
         re.compile(r"^Rollback exception note$"),
@@ -1420,6 +1429,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Grace window FAQ$"),
+        re.compile(r"^Grace window summary$"),
         re.compile(r"^Recovery grace-period note$"),
         re.compile(r"^Recovery grace summary$"),
         re.compile(r"^Burst credit recovery FAQ$"),
@@ -1456,6 +1467,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Exception rollover checklist$"),
+        re.compile(r"^Exception rollover summary$"),
+        re.compile(r"^Exception rollover matrix$"),
         re.compile(r"^Eligibility exception FAQ$"),
         re.compile(r"^Eligibility exception summary$"),
         re.compile(r"^Eligibility exception matrix$"),
@@ -1796,6 +1810,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"approval-escalation-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollback-approval-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollback-exception-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"escalation-rollback-checklist"}},
@@ -1866,6 +1881,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"grace-window-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-grace-period-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-note"}},
@@ -1890,6 +1906,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"exception-rollover-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-exception-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-edge-case-advisory"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-eligibility-guide"}},

--- a/tests/fixtures/extraction/anthropic-approval-escalation-note.html
+++ b/tests/fixtures/extraction/anthropic-approval-escalation-note.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="approval-escalation-summary">
+      <h2>Approval escalation note</h2>
+      <p>Approval escalation summary</p>
+    </section>
+    <article class="approval-escalation-note">
+      <h1>Approval escalation note</h1>
+      <p>Approval escalation notes matter when operators need to document why rollback authority must move to a higher review tier during an ongoing incident.</p>
+      <p>The note should capture review checkpoints, queue health evidence, and the exact fallback queues that justified the escalation.</p>
+      <p>It should also explain which fairness controls stay in force while the higher approval path remains active.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-grace-window-faq.html
+++ b/tests/fixtures/extraction/openai-grace-window-faq.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="grace-window-summary">
+      <h2>Grace window FAQ</h2>
+      <p>Grace window summary</p>
+    </section>
+    <article class="grace-window-faq">
+      <h1>Grace window FAQ</h1>
+      <p>Grace window FAQs matter when operators need direct answers about how long softened recovery pacing can remain active after a burst-credit event.</p>
+      <p>These notes explain how grace thresholds should be measured across recovery dashboards before normal pacing resumes.</p>
+      <p>They also explain when fallback regions can continue serving traffic without breaking shared throughput stability.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-exception-rollover-checklist.html
+++ b/tests/fixtures/extraction/together-exception-rollover-checklist.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="exception-rollover-summary">
+      <h2>Exception rollover checklist</h2>
+      <p>Exception rollover summary</p>
+    </section>
+    <section class="exception-rollover-matrix">
+      <h2>Exception rollover matrix</h2>
+      <p>Eligibility matrix</p>
+    </section>
+    <article class="exception-rollover-checklist">
+      <h1>Exception rollover checklist</h1>
+      <p>Exception rollover checklists matter when operators need a deterministic sequence for keeping reservation pools eligible during unusual failover or replay conditions.</p>
+      <p>The checklist spells out exception triggers, dashboard checks, and the reservation guarantees that must still be honored.</p>
+      <p>It also points teams to the regional recovery playbooks that govern how rollover exceptions are documented.</p>
+    </article>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1468,6 +1468,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Eligibility exception matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_grace_window_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-grace-window-faq.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/grace-window-faq",
+        )
+
+        self.assertIn("Grace window FAQs matter when operators need direct answers", content.text)
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("recovery dashboards", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Grace window summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_approval_escalation_note_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-approval-escalation-note.html"),
+            url="https://docs.anthropic.com/en/docs/usage/approval-escalation-note",
+        )
+
+        self.assertIn("Approval escalation notes matter when operators need to document why rollback authority", content.text)
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Approval escalation summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_exception_rollover_checklist_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-exception-rollover-checklist.html"),
+            url="https://docs.together.ai/docs/inference/exception-rollover-checklist",
+        )
+
+        self.assertIn("Exception rollover checklists matter when operators need a deterministic sequence", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Exception rollover summary", content.text)
+        self.assertNotIn("Exception rollover matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add grace-window-faq, approval-escalation-note, and exception-rollover-checklist extraction fixtures
- expand host-specific cleanup for platform.openai.com, docs.anthropic.com, and docs.together.ai
- bump version, changelog, launch copy, and release notes to v1.2.32

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python