### PR TITLE
test: add policy grace window exception fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.33] - 2026-04-10
+
+### Added
+
+- Grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.33`
+- International extraction coverage now includes grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, and exception-rollover-checklist layouts
+
+### Fixed
+
+- Reduced grace-window exception summaries, approval handoff summaries, rollover audit summaries, rollover audit matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of grace-window exception, approval handoff, and rollover audit layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.32] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.32`
+`v1.2.33`
 
 ### Suggested Title
 
-`AI News Open v1.2.32 · Grace Window and Exception Checklist Extraction Coverage`
+`AI News Open v1.2.33 · Grace Window Exception and Audit Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.32
+## AI News Open v1.2.33
 
-AI News Open `v1.2.32` hardens extraction quality for grace-window-faq, approval-escalation-note, and exception-rollover-checklist layouts across more developer-doc publishers.
+AI News Open `v1.2.33` hardens extraction quality for grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,8 +40,8 @@ AI News Open `v1.2.32` hardens extraction quality for grace-window-faq, approval
 
 ### Highlights in this release
 
-- New deterministic grace-window-faq, approval-escalation-note, and exception-rollover-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for grace-window summaries, approval escalation summaries, exception rollover summaries, exception rollover matrices, and related-guide recirculation on developer policy pages
+- New deterministic grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for grace-window exception summaries, approval handoff summaries, rollover audit summaries, rollover audit matrices, and related-guide recirculation on developer policy pages
 - The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 

--- a/docs/releases/v1.2.33.md
+++ b/docs/releases/v1.2.33.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.33
+
+## Highlights
+
+- Added deterministic extraction fixtures for `grace-window-exception-matrix`, `approval-handoff-faq`, and `rollover-audit-checklist` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.32"
+version = "1.2.33"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.32"
+__version__ = "1.2.33"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".approval-handoff-faq",
         ".approval-escalation-note",
         ".rollback-approval-matrix",
         ".rollback-exception-note",
@@ -416,6 +417,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".grace-window-exception-matrix",
         ".grace-window-faq",
         ".recovery-grace-period-note",
         ".burst-credit-recovery-faq",
@@ -441,6 +443,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".rollover-audit-checklist",
         ".exception-rollover-checklist",
         ".eligibility-exception-faq",
         ".eligibility-edge-case-advisory",
@@ -867,6 +870,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".approval-handoff-summary",
         ".approval-escalation-summary",
         ".priority-summary",
         ".fairness-summary",
@@ -961,6 +965,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".grace-window-exception-summary",
         ".grace-window-summary",
         ".recovery-grace-summary",
         ".burst-credit-recovery-faq-summary",
@@ -994,6 +999,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".rollover-audit-summary",
+        ".rollover-audit-matrix",
         ".exception-rollover-summary",
         ".exception-rollover-matrix",
         ".eligibility-exception-summary",
@@ -1342,6 +1349,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Approval handoff FAQ$"),
+        re.compile(r"^Approval handoff summary$"),
         re.compile(r"^Approval escalation note$"),
         re.compile(r"^Approval escalation summary$"),
         re.compile(r"^Rollback approval matrix$"),
@@ -1429,6 +1438,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Grace window exception matrix$"),
+        re.compile(r"^Grace window exception summary$"),
         re.compile(r"^Grace window FAQ$"),
         re.compile(r"^Grace window summary$"),
         re.compile(r"^Recovery grace-period note$"),
@@ -1467,6 +1478,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Rollover audit checklist$"),
+        re.compile(r"^Rollover audit summary$"),
+        re.compile(r"^Rollover audit matrix$"),
         re.compile(r"^Exception rollover checklist$"),
         re.compile(r"^Exception rollover summary$"),
         re.compile(r"^Exception rollover matrix$"),
@@ -1810,6 +1824,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"approval-handoff-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-escalation-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollback-approval-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollback-exception-note"}},
@@ -1881,6 +1896,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"grace-window-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-window-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-grace-period-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"burst-credit-recovery-faq"}},
@@ -1906,6 +1922,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"rollover-audit-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"exception-rollover-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-exception-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-edge-case-advisory"}},

--- a/tests/fixtures/extraction/anthropic-approval-handoff-faq.html
+++ b/tests/fixtures/extraction/anthropic-approval-handoff-faq.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="approval-handoff-summary">
+      <h2>Approval handoff FAQ</h2>
+      <p>Approval handoff summary</p>
+    </section>
+    <article class="approval-handoff-faq">
+      <h1>Approval handoff FAQ</h1>
+      <p>Approval handoff FAQs matter when operators need direct answers about how rollback authority transfers between on-call leads and higher review tiers.</p>
+      <p>The FAQ explains review checkpoints, queue health evidence, and the fallback queues that must be documented before a handoff is accepted.</p>
+      <p>It also clarifies which fairness controls continue to apply while the handoff remains open.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-grace-window-exception-matrix.html
+++ b/tests/fixtures/extraction/openai-grace-window-exception-matrix.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="grace-window-exception-summary">
+      <h2>Grace window exception matrix</h2>
+      <p>Grace window exception summary</p>
+    </section>
+    <article class="grace-window-exception-matrix">
+      <h1>Grace window exception matrix</h1>
+      <p>Grace window exception matrices matter when operators need a compact map of which recovery exceptions can stay active during a softened throughput window.</p>
+      <p>The matrix ties grace thresholds to recovery dashboards, fallback regions, and the exact escalation tier required for each exception path.</p>
+      <p>It also makes clear when shared throughput stability takes precedence over local burst relief.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-rollover-audit-checklist.html
+++ b/tests/fixtures/extraction/together-rollover-audit-checklist.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="rollover-audit-summary">
+      <h2>Rollover audit checklist</h2>
+      <p>Rollover audit summary</p>
+    </section>
+    <section class="rollover-audit-matrix">
+      <h2>Rollover audit matrix</h2>
+      <p>Audit matrix</p>
+    </section>
+    <article class="rollover-audit-checklist">
+      <h1>Rollover audit checklist</h1>
+      <p>Rollover audit checklists matter when operators need a deterministic sequence for proving that reservation pools stayed eligible across failover, replay, and quota exception events.</p>
+      <p>The checklist calls out exception triggers, dashboard checks, and the reservation guarantees that auditors expect to see preserved.</p>
+      <p>It also links each audit step to the regional recovery playbooks used during incident review.</p>
+    </article>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1513,6 +1513,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Exception rollover matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_grace_window_exception_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-grace-window-exception-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/grace-window-exception-matrix",
+        )
+
+        self.assertIn("Grace window exception matrices matter when operators need a compact map", content.text)
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Grace window exception summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_approval_handoff_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-approval-handoff-faq.html"),
+            url="https://docs.anthropic.com/en/docs/usage/approval-handoff-faq",
+        )
+
+        self.assertIn("Approval handoff FAQs matter when operators need direct answers", content.text)
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Approval handoff summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_rollover_audit_checklist_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-rollover-audit-checklist.html"),
+            url="https://docs.together.ai/docs/inference/rollover-audit-checklist",
+        )
+
+        self.assertIn("Rollover audit checklists matter when operators need a deterministic sequence", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Rollover audit summary", content.text)
+        self.assertNotIn("Rollover audit matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist extraction fixtures
- expand host-specific cleanup for platform.openai.com, docs.anthropic.com, and docs.together.ai
- bump version, changelog, launch copy, and release notes to v1.2.33

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python