### PR TITLE
test: add exception eligibility extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.34] - 2026-04-10
+
+### Added
+
+- Exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.34`
+- International extraction coverage now includes exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, and rollover-audit-checklist layouts
+
+### Fixed
+
+- Reduced exception eligibility summaries, handoff escalation summaries, audit exception summaries, audit exception matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of exception-eligibility, handoff-escalation, and audit-exception layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.33] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.33`
+`v1.2.34`
 
 ### Suggested Title
 
-`AI News Open v1.2.33 · Grace Window Exception and Audit Coverage`
+`AI News Open v1.2.34 · Exception Eligibility and Audit FAQ Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.33
+## AI News Open v1.2.34
 
-AI News Open `v1.2.33` hardens extraction quality for grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist layouts across more developer-doc publishers.
+AI News Open `v1.2.34` hardens extraction quality for exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,8 +40,8 @@ AI News Open `v1.2.33` hardens extraction quality for grace-window-exception-mat
 
 ### Highlights in this release
 
-- New deterministic grace-window-exception-matrix, approval-handoff-faq, and rollover-audit-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for grace-window exception summaries, approval handoff summaries, rollover audit summaries, rollover audit matrices, and related-guide recirculation on developer policy pages
+- New deterministic exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for exception eligibility summaries, handoff escalation summaries, audit exception summaries, audit exception matrices, and related-guide recirculation on developer policy pages
 - The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 

--- a/docs/releases/v1.2.34.md
+++ b/docs/releases/v1.2.34.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.34
+
+## Highlights
+
+- Added deterministic extraction fixtures for `exception-eligibility-matrix`, `handoff-escalation-checklist`, and `audit-exception-faq` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.33"
+version = "1.2.34"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.33"
+__version__ = "1.2.34"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".handoff-escalation-checklist",
         ".approval-handoff-faq",
         ".approval-escalation-note",
         ".rollback-approval-matrix",
@@ -417,6 +418,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".exception-eligibility-matrix",
         ".grace-window-exception-matrix",
         ".grace-window-faq",
         ".recovery-grace-period-note",
@@ -443,6 +445,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-exception-faq",
         ".rollover-audit-checklist",
         ".exception-rollover-checklist",
         ".eligibility-exception-faq",
@@ -870,6 +873,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".handoff-escalation-summary",
         ".approval-handoff-summary",
         ".approval-escalation-summary",
         ".priority-summary",
@@ -965,6 +969,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".exception-eligibility-summary",
         ".grace-window-exception-summary",
         ".grace-window-summary",
         ".recovery-grace-summary",
@@ -999,6 +1004,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-exception-summary",
+        ".audit-exception-matrix",
         ".rollover-audit-summary",
         ".rollover-audit-matrix",
         ".exception-rollover-summary",
@@ -1349,6 +1356,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Handoff escalation checklist$"),
+        re.compile(r"^Handoff escalation summary$"),
         re.compile(r"^Approval handoff FAQ$"),
         re.compile(r"^Approval handoff summary$"),
         re.compile(r"^Approval escalation note$"),
@@ -1438,6 +1447,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Exception eligibility matrix$"),
+        re.compile(r"^Exception eligibility summary$"),
         re.compile(r"^Grace window exception matrix$"),
         re.compile(r"^Grace window exception summary$"),
         re.compile(r"^Grace window FAQ$"),
@@ -1478,6 +1489,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit exception FAQ$"),
+        re.compile(r"^Audit exception summary$"),
+        re.compile(r"^Audit exception matrix$"),
         re.compile(r"^Rollover audit checklist$"),
         re.compile(r"^Rollover audit summary$"),
         re.compile(r"^Rollover audit matrix$"),
@@ -1824,6 +1838,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"handoff-escalation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-handoff-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-escalation-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollback-approval-matrix"}},
@@ -1896,6 +1911,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"exception-eligibility-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-window-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-window-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-grace-period-note"}},
@@ -1922,6 +1938,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-exception-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-audit-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"exception-rollover-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-exception-faq"}},

--- a/tests/fixtures/extraction/anthropic-handoff-escalation-checklist.html
+++ b/tests/fixtures/extraction/anthropic-handoff-escalation-checklist.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="handoff-escalation-summary">
+      <h2>Handoff escalation checklist</h2>
+      <p>Handoff escalation summary</p>
+    </section>
+    <article class="handoff-escalation-checklist">
+      <h1>Handoff escalation checklist</h1>
+      <p>Handoff escalation checklists matter when operators need a deterministic sequence for transferring rollback authority between on-call leads and a higher approval tier.</p>
+      <p>The checklist spells out review checkpoints, queue health evidence, and the fallback queues that must be documented before the handoff is approved.</p>
+      <p>It also clarifies which fairness controls remain active while the escalation path stays open.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-exception-eligibility-matrix.html
+++ b/tests/fixtures/extraction/openai-exception-eligibility-matrix.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="exception-eligibility-summary">
+      <h2>Exception eligibility matrix</h2>
+      <p>Exception eligibility summary</p>
+    </section>
+    <article class="exception-eligibility-matrix">
+      <h1>Exception eligibility matrix</h1>
+      <p>Exception eligibility matrices matter when operators need a compact map of which recovery exceptions remain eligible after a burst-credit window tightens.</p>
+      <p>The matrix ties exception tiers to grace thresholds, dashboard checks, and the fallback regions allowed to continue serving traffic.</p>
+      <p>It also makes clear where shared throughput stability overrides local exception relief.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-exception-faq.html
+++ b/tests/fixtures/extraction/together-audit-exception-faq.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-exception-summary">
+      <h2>Audit exception FAQ</h2>
+      <p>Audit exception summary</p>
+    </section>
+    <section class="audit-exception-matrix">
+      <h2>Audit exception matrix</h2>
+      <p>Audit matrix</p>
+    </section>
+    <article class="audit-exception-faq">
+      <h1>Audit exception FAQ</h1>
+      <p>Audit exception FAQs matter when operators need direct answers about how reservation pools stay eligible during failover, replay, and quota exception reviews.</p>
+      <p>The FAQ explains exception triggers, dashboard checks, and the reservation guarantees that auditors expect to see preserved.</p>
+      <p>It also ties each answer back to the regional recovery playbooks used during incident review.</p>
+    </article>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1558,6 +1558,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Rollover audit matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_exception_eligibility_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-exception-eligibility-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/exception-eligibility-matrix",
+        )
+
+        self.assertIn("Exception eligibility matrices matter when operators need a compact map", content.text)
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Exception eligibility summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_handoff_escalation_checklist_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-handoff-escalation-checklist.html"),
+            url="https://docs.anthropic.com/en/docs/usage/handoff-escalation-checklist",
+        )
+
+        self.assertIn("Handoff escalation checklists matter when operators need a deterministic sequence", content.text)
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Handoff escalation summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_exception_faq_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-exception-faq.html"),
+            url="https://docs.together.ai/docs/inference/audit-exception-faq",
+        )
+
+        self.assertIn("Audit exception FAQs matter when operators need direct answers", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit exception summary", content.text)
+        self.assertNotIn("Audit exception matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq extraction fixtures
- expand host-specific cleanup for platform.openai.com, docs.anthropic.com, and docs.together.ai
- bump version, changelog, launch copy, and release notes to v1.2.34

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python