### PR TITLE
test: add eligibility rollover extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.35] - 2026-04-10
+
+### Added
+
+- Eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.35`
+- International extraction coverage now includes eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, and audit-exception-faq layouts
+
+### Fixed
+
+- Reduced eligibility rollover summaries, approval continuity summaries, audit waiver summaries, audit waiver matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of eligibility-rollover, approval-continuity, and audit-waiver layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.34] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.34`
+`v1.2.35`
 
 ### Suggested Title
 
-`AI News Open v1.2.34 · Exception Eligibility and Audit FAQ Coverage`
+`AI News Open v1.2.35 · Eligibility Rollover and Audit Waiver Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.34
+## AI News Open v1.2.35
 
-AI News Open `v1.2.34` hardens extraction quality for exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq layouts across more developer-doc publishers.
+AI News Open `v1.2.35` hardens extraction quality for eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,8 +40,8 @@ AI News Open `v1.2.34` hardens extraction quality for exception-eligibility-matr
 
 ### Highlights in this release
 
-- New deterministic exception-eligibility-matrix, handoff-escalation-checklist, and audit-exception-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for exception eligibility summaries, handoff escalation summaries, audit exception summaries, audit exception matrices, and related-guide recirculation on developer policy pages
+- New deterministic eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for eligibility rollover summaries, approval continuity summaries, audit waiver summaries, audit waiver matrices, and related-guide recirculation on developer policy pages
 - The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 

--- a/docs/releases/v1.2.35.md
+++ b/docs/releases/v1.2.35.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.35
+
+## Highlights
+
+- Added deterministic extraction fixtures for `eligibility-rollover-matrix`, `approval-continuity-faq`, and `audit-waiver-checklist` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.34"
+version = "1.2.35"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.34"
+__version__ = "1.2.35"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".approval-continuity-faq",
         ".handoff-escalation-checklist",
         ".approval-handoff-faq",
         ".approval-escalation-note",
@@ -418,6 +419,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".eligibility-rollover-matrix",
         ".exception-eligibility-matrix",
         ".grace-window-exception-matrix",
         ".grace-window-faq",
@@ -445,6 +447,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-waiver-checklist",
         ".audit-exception-faq",
         ".rollover-audit-checklist",
         ".exception-rollover-checklist",
@@ -873,6 +876,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".approval-continuity-summary",
         ".handoff-escalation-summary",
         ".approval-handoff-summary",
         ".approval-escalation-summary",
@@ -969,6 +973,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".eligibility-rollover-summary",
         ".exception-eligibility-summary",
         ".grace-window-exception-summary",
         ".grace-window-summary",
@@ -1004,6 +1009,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-waiver-summary",
+        ".audit-waiver-matrix",
         ".audit-exception-summary",
         ".audit-exception-matrix",
         ".rollover-audit-summary",
@@ -1356,6 +1363,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Approval continuity FAQ$"),
+        re.compile(r"^Approval continuity summary$"),
         re.compile(r"^Handoff escalation checklist$"),
         re.compile(r"^Handoff escalation summary$"),
         re.compile(r"^Approval handoff FAQ$"),
@@ -1447,6 +1456,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Eligibility rollover matrix$"),
+        re.compile(r"^Eligibility rollover summary$"),
         re.compile(r"^Exception eligibility matrix$"),
         re.compile(r"^Exception eligibility summary$"),
         re.compile(r"^Grace window exception matrix$"),
@@ -1489,6 +1500,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit waiver checklist$"),
+        re.compile(r"^Audit waiver summary$"),
+        re.compile(r"^Audit waiver matrix$"),
         re.compile(r"^Audit exception FAQ$"),
         re.compile(r"^Audit exception summary$"),
         re.compile(r"^Audit exception matrix$"),
@@ -1838,6 +1852,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"approval-continuity-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"handoff-escalation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-handoff-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-escalation-note"}},
@@ -1911,6 +1926,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"eligibility-rollover-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"exception-eligibility-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-window-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-window-faq"}},
@@ -1938,6 +1954,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-waiver-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-exception-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-audit-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"exception-rollover-checklist"}},

--- a/tests/fixtures/extraction/anthropic-approval-continuity-faq.html
+++ b/tests/fixtures/extraction/anthropic-approval-continuity-faq.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="approval-continuity-summary">
+      <h2>Approval continuity FAQ</h2>
+      <p>Approval continuity summary</p>
+    </section>
+    <article class="approval-continuity-faq">
+      <h1>Approval continuity FAQ</h1>
+      <p>Approval continuity FAQs matter when operators need direct answers about how rollback authority stays valid across handoffs, shift changes, and prolonged incidents.</p>
+      <p>The FAQ explains review checkpoints, queue health evidence, and the fallback queues that must remain documented for continuity.</p>
+      <p>It also clarifies which fairness controls stay active while the approval chain remains intact.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-eligibility-rollover-matrix.html
+++ b/tests/fixtures/extraction/openai-eligibility-rollover-matrix.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="eligibility-rollover-summary">
+      <h2>Eligibility rollover matrix</h2>
+      <p>Eligibility rollover summary</p>
+    </section>
+    <article class="eligibility-rollover-matrix">
+      <h1>Eligibility rollover matrix</h1>
+      <p>Eligibility rollover matrices matter when operators need a compact map of which recovery allowances can roll forward after an exception window closes.</p>
+      <p>The matrix ties rollover tiers to grace thresholds, fallback regions, and the dashboard checks required before another cycle is granted.</p>
+      <p>It also makes clear where shared throughput stability overrides local rollover requests.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-waiver-checklist.html
+++ b/tests/fixtures/extraction/together-audit-waiver-checklist.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-waiver-summary">
+      <h2>Audit waiver checklist</h2>
+      <p>Audit waiver summary</p>
+    </section>
+    <section class="audit-waiver-matrix">
+      <h2>Audit waiver matrix</h2>
+      <p>Audit matrix</p>
+    </section>
+    <article class="audit-waiver-checklist">
+      <h1>Audit waiver checklist</h1>
+      <p>Audit waiver checklists matter when operators need a deterministic sequence for documenting why a reservation pool can temporarily skip a normal review step during incident recovery.</p>
+      <p>The checklist calls out exception triggers, dashboard checks, and the reservation guarantees that still have to be preserved.</p>
+      <p>It also links each waiver step back to the regional recovery playbooks used during incident review.</p>
+    </article>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1603,6 +1603,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit exception matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_eligibility_rollover_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-eligibility-rollover-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/eligibility-rollover-matrix",
+        )
+
+        self.assertIn("Eligibility rollover matrices matter when operators need a compact map", content.text)
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Eligibility rollover summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_approval_continuity_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-approval-continuity-faq.html"),
+            url="https://docs.anthropic.com/en/docs/usage/approval-continuity-faq",
+        )
+
+        self.assertIn("Approval continuity FAQs matter when operators need direct answers", content.text)
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Approval continuity summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_waiver_checklist_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-waiver-checklist.html"),
+            url="https://docs.together.ai/docs/inference/audit-waiver-checklist",
+        )
+
+        self.assertIn("Audit waiver checklists matter when operators need a deterministic sequence", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit waiver summary", content.text)
+        self.assertNotIn("Audit waiver matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist extraction fixtures
- expand host-specific cleanup for platform.openai.com, docs.anthropic.com, and docs.together.ai
- bump version, changelog, launch copy, and release notes to v1.2.35

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python