### PR TITLE
test: add rollover waiver extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.36] - 2026-04-10
+
+### Added
+
+- Rollover-waiver-matrix, continuity-handoff-checklist, and audit-recovery-faq extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.36`
+- International extraction coverage now includes rollover-waiver-matrix, continuity-handoff-checklist, and audit-recovery-faq layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, and audit-waiver-checklist layouts
+
+### Fixed
+
+- Reduced rollover waiver summaries, continuity handoff summaries, audit recovery summaries, audit recovery matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of rollover-waiver, continuity-handoff, and audit-recovery layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.35] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.35`
+`v1.2.36`
 
 ### Suggested Title
 
-`AI News Open v1.2.35 · Eligibility Rollover and Audit Waiver Coverage`
+`AI News Open v1.2.36 · Rollover Waiver and Audit Recovery Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.35
+## AI News Open v1.2.36
 
-AI News Open `v1.2.35` hardens extraction quality for eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist layouts across more developer-doc publishers.
+AI News Open `v1.2.36` hardens extraction quality for rollover-waiver-matrix, continuity-handoff-checklist, and audit-recovery-faq layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,8 +40,8 @@ AI News Open `v1.2.35` hardens extraction quality for eligibility-rollover-matri
 
 ### Highlights in this release
 
-- New deterministic eligibility-rollover-matrix, approval-continuity-faq, and audit-waiver-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for eligibility rollover summaries, approval continuity summaries, audit waiver summaries, audit waiver matrices, and related-guide recirculation on developer policy pages
+- New deterministic rollover-waiver-matrix, continuity-handoff-checklist, and audit-recovery-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for rollover waiver summaries, continuity handoff summaries, audit recovery summaries, audit recovery matrices, and related-guide recirculation on developer policy pages
 - The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 

--- a/docs/releases/v1.2.36.md
+++ b/docs/releases/v1.2.36.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.36
+
+## Highlights
+
+- Added deterministic extraction fixtures for `rollover-waiver-matrix`, `continuity-handoff-checklist`, and `audit-recovery-faq` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.35"
+version = "1.2.36"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.35"
+__version__ = "1.2.36"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-handoff-checklist",
         ".approval-continuity-faq",
         ".handoff-escalation-checklist",
         ".approval-handoff-faq",
@@ -419,6 +420,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".rollover-waiver-matrix",
         ".eligibility-rollover-matrix",
         ".exception-eligibility-matrix",
         ".grace-window-exception-matrix",
@@ -447,6 +449,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-recovery-faq",
         ".audit-waiver-checklist",
         ".audit-exception-faq",
         ".rollover-audit-checklist",
@@ -876,6 +879,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-handoff-summary",
         ".approval-continuity-summary",
         ".handoff-escalation-summary",
         ".approval-handoff-summary",
@@ -973,6 +977,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".rollover-waiver-summary",
         ".eligibility-rollover-summary",
         ".exception-eligibility-summary",
         ".grace-window-exception-summary",
@@ -1009,6 +1014,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-recovery-summary",
+        ".audit-recovery-matrix",
         ".audit-waiver-summary",
         ".audit-waiver-matrix",
         ".audit-exception-summary",
@@ -1363,6 +1370,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity handoff checklist$"),
+        re.compile(r"^Continuity handoff summary$"),
         re.compile(r"^Approval continuity FAQ$"),
         re.compile(r"^Approval continuity summary$"),
         re.compile(r"^Handoff escalation checklist$"),
@@ -1456,6 +1465,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Rollover waiver matrix$"),
+        re.compile(r"^Rollover waiver summary$"),
         re.compile(r"^Eligibility rollover matrix$"),
         re.compile(r"^Eligibility rollover summary$"),
         re.compile(r"^Exception eligibility matrix$"),
@@ -1500,6 +1511,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit recovery FAQ$"),
+        re.compile(r"^Audit recovery summary$"),
+        re.compile(r"^Audit recovery matrix$"),
         re.compile(r"^Audit waiver checklist$"),
         re.compile(r"^Audit waiver summary$"),
         re.compile(r"^Audit waiver matrix$"),
@@ -1852,6 +1866,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-handoff-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-continuity-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"handoff-escalation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-handoff-faq"}},
@@ -1926,6 +1941,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"rollover-waiver-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-rollover-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"exception-eligibility-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"grace-window-exception-matrix"}},
@@ -1954,6 +1970,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-recovery-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-waiver-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-exception-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-audit-checklist"}},

--- a/tests/fixtures/extraction/anthropic-continuity-handoff-checklist.html
+++ b/tests/fixtures/extraction/anthropic-continuity-handoff-checklist.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-handoff-summary">
+      <h2>Continuity handoff checklist</h2>
+      <p>Continuity handoff summary</p>
+    </section>
+    <article class="continuity-handoff-checklist">
+      <h1>Continuity handoff checklist</h1>
+      <p>Continuity handoff checklists matter when operators need a deterministic sequence for keeping rollback authority valid across shift changes and prolonged incidents.</p>
+      <p>The checklist spells out review checkpoints, queue health evidence, and the fallback queues that must stay documented before the chain of approval moves.</p>
+      <p>It also clarifies which fairness controls remain active while the continuity path stays open.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-rollover-waiver-matrix.html
+++ b/tests/fixtures/extraction/openai-rollover-waiver-matrix.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="rollover-waiver-summary">
+      <h2>Rollover waiver matrix</h2>
+      <p>Rollover waiver summary</p>
+    </section>
+    <article class="rollover-waiver-matrix">
+      <h1>Rollover waiver matrix</h1>
+      <p>Rollover waiver matrices matter when operators need a compact map of which rollover requests can bypass a normal eligibility gate during constrained recovery windows.</p>
+      <p>The matrix ties waiver tiers to grace thresholds, fallback regions, and the dashboard checks required before another rollover cycle is granted.</p>
+      <p>It also makes clear where shared throughput stability overrides local waiver requests.</p>
+    </article>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-recovery-faq.html
+++ b/tests/fixtures/extraction/together-audit-recovery-faq.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-recovery-summary">
+      <h2>Audit recovery FAQ</h2>
+      <p>Audit recovery summary</p>
+    </section>
+    <section class="audit-recovery-matrix">
+      <h2>Audit recovery matrix</h2>
+      <p>Audit matrix</p>
+    </section>
+    <article class="audit-recovery-faq">
+      <h1>Audit recovery FAQ</h1>
+      <p>Audit recovery FAQs matter when operators need direct answers about how reservation evidence and waiver records should be restored after an incident stabilizes.</p>
+      <p>The FAQ explains exception triggers, dashboard checks, and the reservation guarantees that auditors expect to see preserved during recovery.</p>
+      <p>It also links each answer back to the regional recovery playbooks used during incident review.</p>
+    </article>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Need more help?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1648,6 +1648,51 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit waiver matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_rollover_waiver_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-rollover-waiver-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/rollover-waiver-matrix",
+        )
+
+        self.assertIn("Rollover waiver matrices matter when operators need a compact map", content.text)
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Rollover waiver summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_handoff_checklist_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-handoff-checklist.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-handoff-checklist",
+        )
+
+        self.assertIn("Continuity handoff checklists matter when operators need a deterministic sequence", content.text)
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity handoff summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_recovery_faq_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-recovery-faq.html"),
+            url="https://docs.together.ai/docs/inference/audit-recovery-faq",
+        )
+
+        self.assertIn("Audit recovery FAQs matter when operators need direct answers", content.text)
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit recovery summary", content.text)
+        self.assertNotIn("Audit recovery matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_prefers_theguardian_liveblog_and_drops_live_feed_noise(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
         content = extractor.extract_from_html(


### PR DESCRIPTION
## Summary
- add rollover waiver, continuity handoff, and audit recovery extraction fixtures
- extend source-specific extraction cleanup for OpenAI, Anthropic, and Together docs policy pages
- bump release metadata and notes for v1.2.36

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python