### PR TITLE
test: add recovery exception extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.37] - 2026-04-10
+
+### Added
+
+- Recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.37`
+- International extraction coverage now includes recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, audit-waiver-checklist layouts, rollover-waiver-matrix layouts, continuity-handoff-checklist layouts, and audit-recovery-faq layouts
+
+### Fixed
+
+- Reduced recovery exception summaries, continuity waiver summaries, audit restoration summaries, audit restoration matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of recovery-exception, continuity-waiver, and audit-restoration layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.36] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.36`
+`v1.2.37`
 
 ### Suggested Title
 
-`AI News Open v1.2.36 · Rollover Waiver and Audit Recovery Coverage`
+`AI News Open v1.2.37 · Recovery Exception and Continuity Waiver Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.36
+## AI News Open v1.2.37
 
-AI News Open `v1.2.36` hardens extraction quality for rollover-waiver-matrix, continuity-handoff-checklist, and audit-recovery-faq layouts across more developer-doc publishers.
+AI News Open `v1.2.37` hardens extraction quality for recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.36` hardens extraction quality for rollover-waiver-matrix, co
 
 ### Highlights in this release
 
-- New deterministic rollover-waiver-matrix, continuity-handoff-checklist, and audit-recovery-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for rollover waiver summaries, continuity handoff summaries, audit recovery summaries, audit recovery matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, and eligibility-exception-faq layouts
+- New deterministic recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for recovery exception summaries, continuity waiver summaries, audit restoration summaries, audit restoration matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, and audit-restoration-checklist layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.37.md
+++ b/docs/releases/v1.2.37.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.37
+
+## Highlights
+
+- Added deterministic extraction fixtures for `recovery-exception-matrix`, `continuity-waiver-faq`, and `audit-restoration-checklist` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.36"
+version = "1.2.37"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.36"
+__version__ = "1.2.37"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-waiver-faq",
         ".continuity-handoff-checklist",
         ".approval-continuity-faq",
         ".handoff-escalation-checklist",
@@ -420,6 +421,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".recovery-exception-matrix",
         ".rollover-waiver-matrix",
         ".eligibility-rollover-matrix",
         ".exception-eligibility-matrix",
@@ -449,6 +451,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-restoration-checklist",
         ".audit-recovery-faq",
         ".audit-waiver-checklist",
         ".audit-exception-faq",
@@ -879,6 +882,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-waiver-summary",
         ".continuity-handoff-summary",
         ".approval-continuity-summary",
         ".handoff-escalation-summary",
@@ -977,6 +981,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".recovery-exception-summary",
         ".rollover-waiver-summary",
         ".eligibility-rollover-summary",
         ".exception-eligibility-summary",
@@ -1014,6 +1019,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-restoration-summary",
+        ".audit-restoration-matrix",
         ".audit-recovery-summary",
         ".audit-recovery-matrix",
         ".audit-waiver-summary",
@@ -1370,6 +1377,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity waiver FAQ$"),
+        re.compile(r"^Continuity waiver summary$"),
         re.compile(r"^Continuity handoff checklist$"),
         re.compile(r"^Continuity handoff summary$"),
         re.compile(r"^Approval continuity FAQ$"),
@@ -1465,6 +1474,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Recovery exception matrix$"),
+        re.compile(r"^Recovery exception summary$"),
         re.compile(r"^Rollover waiver matrix$"),
         re.compile(r"^Rollover waiver summary$"),
         re.compile(r"^Eligibility rollover matrix$"),
@@ -1511,6 +1522,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit restoration checklist$"),
+        re.compile(r"^Audit restoration summary$"),
+        re.compile(r"^Audit restoration matrix$"),
         re.compile(r"^Audit recovery FAQ$"),
         re.compile(r"^Audit recovery summary$"),
         re.compile(r"^Audit recovery matrix$"),
@@ -1866,6 +1880,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-waiver-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-handoff-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-continuity-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"handoff-escalation-checklist"}},
@@ -1941,6 +1956,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"recovery-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-waiver-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-rollover-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"exception-eligibility-matrix"}},
@@ -1970,6 +1986,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-restoration-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-recovery-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-waiver-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-exception-faq"}},

--- a/tests/fixtures/extraction/anthropic-continuity-waiver-faq.html
+++ b/tests/fixtures/extraction/anthropic-continuity-waiver-faq.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Continuity waiver FAQ</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-waiver-summary">
+      <h2>Continuity waiver summary</h2>
+      <p>Summary card that should be dropped.</p>
+    </section>
+    <section class="continuity-waiver-faq">
+      <h1>Continuity waiver FAQ</h1>
+      <p>
+        Continuity waiver FAQs matter when operators need direct answers about keeping
+        approval authority valid while incidents span multiple shifts and escalation paths.
+      </p>
+      <p>
+        The guidance explains how review checkpoints, queue health evidence, and fallback
+        queues should be documented before any continuity waiver is renewed.
+      </p>
+      <p>
+        Teams are also expected to preserve fairness controls, incident notes, and
+        cross-functional handoff evidence so recovery decisions remain auditable.
+      </p>
+      <p>
+        In longer incidents, waiver decisions should be tied to clear revalidation windows
+        and explicit rollback ownership.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-recovery-exception-matrix.html
+++ b/tests/fixtures/extraction/openai-recovery-exception-matrix.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Recovery exception matrix</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="recovery-exception-summary">
+      <h2>Recovery exception summary</h2>
+      <p>Summary card that should not be part of the extracted body.</p>
+    </section>
+    <section class="recovery-exception-matrix">
+      <h1>Recovery exception matrix</h1>
+      <p>
+        Recovery exception matrices matter when operators need a compact map of which
+        safeguards can be temporarily relaxed while core service health is restored.
+      </p>
+      <p>
+        The most reliable teams pair exception windows with audit checkpoints,
+        throughput safeguards, and region-specific rollback triggers.
+      </p>
+      <p>
+        In practice, recovery owners still need to verify queue depth, grace thresholds,
+        fallback regions, and approval evidence before any exception is extended.
+      </p>
+      <p>
+        The document emphasizes that recovery decisions should preserve shared throughput
+        stability even when temporary credits or waivers are granted.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-restoration-checklist.html
+++ b/tests/fixtures/extraction/together-audit-restoration-checklist.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Audit restoration checklist</title>
+  </head>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-restoration-summary">
+      <h2>Audit restoration summary</h2>
+      <p>Summary card that should not survive extraction.</p>
+    </section>
+    <section class="audit-restoration-matrix">
+      <h2>Audit restoration matrix</h2>
+      <p>Matrix helper that should not be included in the body.</p>
+    </section>
+    <section class="audit-restoration-checklist">
+      <h1>Audit restoration checklist</h1>
+      <p>
+        Audit restoration checklists matter when operators need a deterministic sequence
+        for rebuilding reservation evidence and waiver records after an incident stabilizes.
+      </p>
+      <p>
+        The checklist walks through exception triggers, dashboard checks, and reservation
+        guarantees that should be validated before restored records are marked complete.
+      </p>
+      <p>
+        Teams are expected to compare regional recovery playbooks, reconcile missing
+        reservation snapshots, and verify queue exports before reopening eligibility flows.
+      </p>
+      <p>
+        The guidance also emphasizes attaching restored audit artifacts to the same
+        recovery record used for incident review and follow-up.
+      </p>
+    </section>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Was this page helpful?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1786,6 +1786,61 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertIn("dashboards for latency, refusals, retrieval quality", content.text)
         self.assertNotIn("Related stories", content.text)
 
+    def test_prefers_openai_recovery_exception_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-recovery-exception-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/recovery-exception-matrix",
+        )
+
+        self.assertIn(
+            "Recovery exception matrices matter when operators need a compact map",
+            content.text,
+        )
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput", content.text)
+        self.assertIn("stability even when temporary credits", content.text)
+        self.assertNotIn("Recovery exception summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_waiver_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-waiver-faq.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-waiver-faq",
+        )
+
+        self.assertIn(
+            "Continuity waiver FAQs matter when operators need direct answers",
+            content.text,
+        )
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity waiver summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_restoration_checklist_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-restoration-checklist.html"),
+            url="https://docs.together.ai/docs/inference/audit-restoration-checklist",
+        )
+
+        self.assertIn(
+            "Audit restoration checklists matter when operators need a deterministic sequence",
+            content.text,
+        )
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit restoration summary", content.text)
+        self.assertNotIn("Audit restoration matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_skips_google_news_aggregate_fixture(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
 


### PR DESCRIPTION
## Summary
- add recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist extraction fixtures
- extend source-specific extraction cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes for v1.2.37

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python