### PR TITLE
test: add recovery override extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.38] - 2026-04-10
+
+### Added
+
+- Recovery-override-matrix, continuity-exception-checklist, and audit-replay-faq extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.38`
+- International extraction coverage now includes recovery-override-matrix, continuity-exception-checklist, and audit-replay-faq layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, audit-waiver-checklist layouts, rollover-waiver-matrix layouts, continuity-handoff-checklist layouts, audit-recovery-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, and audit-restoration-checklist layouts
+
+### Fixed
+
+- Reduced recovery override summaries, continuity exception summaries, audit replay summaries, audit replay matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of recovery-override, continuity-exception, and audit-replay layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.37] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.37`
+`v1.2.38`
 
 ### Suggested Title
 
-`AI News Open v1.2.37 · Recovery Exception and Continuity Waiver Coverage`
+`AI News Open v1.2.38 · Recovery Override and Audit Replay Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.37
+## AI News Open v1.2.38
 
-AI News Open `v1.2.37` hardens extraction quality for recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist layouts across more developer-doc publishers.
+AI News Open `v1.2.38` hardens extraction quality for recovery-override-matrix, continuity-exception-checklist, and audit-replay-faq layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.37` hardens extraction quality for recovery-exception-matrix,
 
 ### Highlights in this release
 
-- New deterministic recovery-exception-matrix, continuity-waiver-faq, and audit-restoration-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for recovery exception summaries, continuity waiver summaries, audit restoration summaries, audit restoration matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, and audit-restoration-checklist layouts
+- New deterministic recovery-override-matrix, continuity-exception-checklist, and audit-replay-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for recovery override summaries, continuity exception summaries, audit replay summaries, audit replay matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, and audit-replay-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.38.md
+++ b/docs/releases/v1.2.38.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.38
+
+## Highlights
+
+- Added deterministic extraction fixtures for `recovery-override-matrix`, `continuity-exception-checklist`, and `audit-replay-faq` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.37"
+version = "1.2.38"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.37"
+__version__ = "1.2.38"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-exception-checklist",
         ".continuity-waiver-faq",
         ".continuity-handoff-checklist",
         ".approval-continuity-faq",
@@ -421,6 +422,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".recovery-override-matrix",
         ".recovery-exception-matrix",
         ".rollover-waiver-matrix",
         ".eligibility-rollover-matrix",
@@ -451,6 +453,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-replay-faq",
         ".audit-restoration-checklist",
         ".audit-recovery-faq",
         ".audit-waiver-checklist",
@@ -882,6 +885,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-exception-summary",
         ".continuity-waiver-summary",
         ".continuity-handoff-summary",
         ".approval-continuity-summary",
@@ -981,6 +985,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".recovery-override-summary",
         ".recovery-exception-summary",
         ".rollover-waiver-summary",
         ".eligibility-rollover-summary",
@@ -1019,6 +1024,8 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-replay-summary",
+        ".audit-replay-matrix",
         ".audit-restoration-summary",
         ".audit-restoration-matrix",
         ".audit-recovery-summary",
@@ -1377,6 +1384,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity exception checklist$"),
+        re.compile(r"^Continuity exception summary$"),
         re.compile(r"^Continuity waiver FAQ$"),
         re.compile(r"^Continuity waiver summary$"),
         re.compile(r"^Continuity handoff checklist$"),
@@ -1474,6 +1483,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Recovery override matrix$"),
+        re.compile(r"^Recovery override summary$"),
         re.compile(r"^Recovery exception matrix$"),
         re.compile(r"^Recovery exception summary$"),
         re.compile(r"^Rollover waiver matrix$"),
@@ -1522,6 +1533,9 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit replay FAQ$"),
+        re.compile(r"^Audit replay summary$"),
+        re.compile(r"^Audit replay matrix$"),
         re.compile(r"^Audit restoration checklist$"),
         re.compile(r"^Audit restoration summary$"),
         re.compile(r"^Audit restoration matrix$"),
@@ -1880,6 +1894,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-exception-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-waiver-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-handoff-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"approval-continuity-faq"}},
@@ -1956,6 +1971,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"recovery-override-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"rollover-waiver-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"eligibility-rollover-matrix"}},
@@ -1986,6 +2002,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-replay-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-restoration-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-recovery-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-waiver-checklist"}},

--- a/tests/fixtures/extraction/anthropic-continuity-exception-checklist.html
+++ b/tests/fixtures/extraction/anthropic-continuity-exception-checklist.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Continuity exception checklist</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-exception-summary">
+      <h2>Continuity exception summary</h2>
+      <p>Summary card that should be dropped.</p>
+    </section>
+    <section class="continuity-exception-checklist">
+      <h1>Continuity exception checklist</h1>
+      <p>
+        Continuity exception checklists matter when operators need a deterministic sequence
+        for carrying approval authority through prolonged incidents without losing auditability.
+      </p>
+      <p>
+        The document explains how review checkpoints, queue health evidence, and fallback
+        queues should be refreshed before any continuity exception is renewed.
+      </p>
+      <p>
+        Teams are expected to preserve fairness controls, handoff records, and recovery
+        evidence so exception handling remains traceable across shifts.
+      </p>
+      <p>
+        Longer incidents also require explicit rollback ownership and a fresh validation
+        window before authority is passed to the next operator.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-recovery-override-matrix.html
+++ b/tests/fixtures/extraction/openai-recovery-override-matrix.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Recovery override matrix</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="recovery-override-summary">
+      <h2>Recovery override summary</h2>
+      <p>Summary card that should not be part of the extracted body.</p>
+    </section>
+    <section class="recovery-override-matrix">
+      <h1>Recovery override matrix</h1>
+      <p>
+        Recovery override matrices matter when operators need a precise map of which
+        safeguards can be temporarily overridden while core traffic is stabilized.
+      </p>
+      <p>
+        The guidance ties override windows to queue pressure, audit checkpoints,
+        fallback regions, and rollback ownership rather than ad hoc approvals.
+      </p>
+      <p>
+        In practice, operators still need to verify grace thresholds, regional failover
+        evidence, and escalation logs before any override is extended.
+      </p>
+      <p>
+        The matrix stresses that overrides should preserve shared throughput stability
+        and leave a durable trail for post-incident review.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-replay-faq.html
+++ b/tests/fixtures/extraction/together-audit-replay-faq.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Audit replay FAQ</title>
+  </head>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-replay-summary">
+      <h2>Audit replay summary</h2>
+      <p>Summary card that should not survive extraction.</p>
+    </section>
+    <section class="audit-replay-matrix">
+      <h2>Audit replay matrix</h2>
+      <p>Matrix helper that should not be included in the body.</p>
+    </section>
+    <section class="audit-replay-faq">
+      <h1>Audit replay FAQ</h1>
+      <p>
+        Audit replay FAQs matter when operators need direct answers about replaying
+        reservation evidence and waiver records after an incident has stabilized.
+      </p>
+      <p>
+        The guidance covers exception triggers, dashboard checks, and reservation
+        guarantees that should be revalidated before replayed records are accepted.
+      </p>
+      <p>
+        Teams are expected to compare regional recovery playbooks, reconcile missing
+        snapshots, and confirm queue exports before replaying eligibility decisions.
+      </p>
+      <p>
+        The FAQ also emphasizes attaching replayed audit artifacts to the same recovery
+        record used for incident review and follow-up.
+      </p>
+    </section>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Was this page helpful?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1841,6 +1841,60 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit restoration matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_recovery_override_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-recovery-override-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/recovery-override-matrix",
+        )
+
+        self.assertIn(
+            "Recovery override matrices matter when operators need a precise map",
+            content.text,
+        )
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Recovery override summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_exception_checklist_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-exception-checklist.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-exception-checklist",
+        )
+
+        self.assertIn(
+            "Continuity exception checklists matter when operators need a deterministic sequence",
+            content.text,
+        )
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity exception summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_replay_faq_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-replay-faq.html"),
+            url="https://docs.together.ai/docs/inference/audit-replay-faq",
+        )
+
+        self.assertIn(
+            "Audit replay FAQs matter when operators need direct answers",
+            content.text,
+        )
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit replay summary", content.text)
+        self.assertNotIn("Audit replay matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_skips_google_news_aggregate_fixture(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
 


### PR DESCRIPTION
## Summary
- add recovery-override-matrix, continuity-exception-checklist, and audit-replay-faq extraction fixtures
- extend source-specific extraction cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes for v1.2.38

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python