### PR TITLE
test: add override escalation extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.40] - 2026-04-10
+
+### Added
+
+- Override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.40`
+- International extraction coverage now includes override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, audit-waiver-checklist layouts, rollover-waiver-matrix layouts, continuity-handoff-checklist layouts, audit-recovery-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, and audit-replay-checklist layouts
+
+### Fixed
+
+- Reduced override escalation summaries, continuity revalidation FAQ summaries, audit replay exception summaries, audit replay matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of override-escalation, continuity-revalidation-faq, and audit-replay-exception layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.39] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.39`
+`v1.2.40`
 
 ### Suggested Title
 
-`AI News Open v1.2.39 · Recovery Override FAQ and Revalidation Coverage`
+`AI News Open v1.2.40 · Override Escalation and Replay Exception Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.39
+## AI News Open v1.2.40
 
-AI News Open `v1.2.39` hardens extraction quality for recovery-override-faq, continuity-revalidation-matrix, and audit-replay-checklist layouts across more developer-doc publishers.
+AI News Open `v1.2.40` hardens extraction quality for override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.39` hardens extraction quality for recovery-override-faq, con
 
 ### Highlights in this release
 
-- New deterministic recovery-override-faq, continuity-revalidation-matrix, and audit-replay-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for recovery override FAQ summaries, continuity revalidation summaries, audit replay checklist summaries, audit replay matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, and audit-replay-checklist layouts
+- New deterministic override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for override escalation summaries, continuity revalidation FAQ summaries, audit replay exception summaries, audit replay matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, and audit-replay-exception-matrix layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.40.md
+++ b/docs/releases/v1.2.40.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.40
+
+## Highlights
+
+- Added deterministic extraction fixtures for `override-escalation-checklist`, `continuity-revalidation-faq`, and `audit-replay-exception-matrix` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.39"
+version = "1.2.40"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.39"
+__version__ = "1.2.40"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-faq",
         ".continuity-revalidation-matrix",
         ".continuity-exception-checklist",
         ".continuity-waiver-faq",
@@ -423,6 +424,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".override-escalation-checklist",
         ".recovery-override-faq",
         ".recovery-override-matrix",
         ".recovery-exception-matrix",
@@ -455,6 +457,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-replay-exception-matrix",
         ".audit-replay-checklist",
         ".audit-replay-faq",
         ".audit-restoration-checklist",
@@ -888,6 +891,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-faq-summary",
         ".continuity-revalidation-summary",
         ".continuity-exception-summary",
         ".continuity-waiver-summary",
@@ -989,6 +993,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".override-escalation-summary",
         ".recovery-override-faq-summary",
         ".recovery-override-summary",
         ".recovery-exception-summary",
@@ -1029,6 +1034,7 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-replay-exception-summary",
         ".audit-replay-checklist-summary",
         ".audit-replay-summary",
         ".audit-replay-matrix",
@@ -1390,6 +1396,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity revalidation FAQ$"),
+        re.compile(r"^Continuity revalidation FAQ summary$"),
         re.compile(r"^Continuity revalidation matrix$"),
         re.compile(r"^Continuity revalidation summary$"),
         re.compile(r"^Continuity exception checklist$"),
@@ -1491,6 +1499,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Override escalation checklist$"),
+        re.compile(r"^Override escalation summary$"),
         re.compile(r"^Recovery override FAQ$"),
         re.compile(r"^Recovery override FAQ summary$"),
         re.compile(r"^Recovery override matrix$"),
@@ -1543,6 +1553,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit replay exception matrix$"),
+        re.compile(r"^Audit replay exception summary$"),
         re.compile(r"^Audit replay checklist$"),
         re.compile(r"^Audit replay checklist summary$"),
         re.compile(r"^Audit replay FAQ$"),
@@ -1906,6 +1918,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-exception-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-waiver-faq"}},
@@ -1984,6 +1997,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"override-escalation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-override-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-override-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-exception-matrix"}},
@@ -2016,6 +2030,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-replay-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-restoration-checklist"}},

--- a/tests/fixtures/extraction/anthropic-continuity-revalidation-faq.html
+++ b/tests/fixtures/extraction/anthropic-continuity-revalidation-faq.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Continuity revalidation FAQ</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-revalidation-faq-summary">
+      <h2>Continuity revalidation FAQ summary</h2>
+      <p>Summary card that should be dropped.</p>
+    </section>
+    <section class="continuity-revalidation-faq">
+      <h1>Continuity revalidation FAQ</h1>
+      <p>
+        Continuity revalidation FAQs matter when operators need direct answers about how
+        approval authority should be renewed through prolonged incidents without losing auditability.
+      </p>
+      <p>
+        The document explains how review checkpoints, queue health evidence, and fallback
+        queues should be refreshed before any revalidation window is extended.
+      </p>
+      <p>
+        Teams are expected to preserve fairness controls, handoff records, and recovery
+        evidence so revalidation remains traceable across shifts.
+      </p>
+      <p>
+        Longer incidents also require explicit rollback ownership and a fresh validation
+        window before authority is passed to the next operator.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-override-escalation-checklist.html
+++ b/tests/fixtures/extraction/openai-override-escalation-checklist.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Override escalation checklist</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="override-escalation-summary">
+      <h2>Override escalation summary</h2>
+      <p>Summary card that should not be part of the extracted body.</p>
+    </section>
+    <section class="override-escalation-checklist">
+      <h1>Override escalation checklist</h1>
+      <p>
+        Override escalation checklists matter when operators need a deterministic sequence
+        for escalating override authority while core traffic is stabilized.
+      </p>
+      <p>
+        The guidance ties escalation steps to queue pressure, audit checkpoints,
+        fallback regions, and rollback ownership rather than ad hoc approvals.
+      </p>
+      <p>
+        In practice, operators still need to verify grace thresholds, regional failover
+        evidence, and escalation logs before any override is extended.
+      </p>
+      <p>
+        The checklist stresses that escalation should preserve shared throughput stability
+        and leave a durable trail for post-incident review.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-replay-exception-matrix.html
+++ b/tests/fixtures/extraction/together-audit-replay-exception-matrix.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Audit replay exception matrix</title>
+  </head>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-replay-exception-summary">
+      <h2>Audit replay exception summary</h2>
+      <p>Summary card that should not survive extraction.</p>
+    </section>
+    <section class="audit-replay-matrix">
+      <h2>Audit replay matrix</h2>
+      <p>Matrix helper that should not be included in the body.</p>
+    </section>
+    <section class="audit-replay-exception-matrix">
+      <h1>Audit replay exception matrix</h1>
+      <p>
+        Audit replay exception matrices matter when operators need a precise map for
+        replaying reservation evidence and waiver records after an incident has stabilized.
+      </p>
+      <p>
+        The guidance covers exception triggers, dashboard checks, and reservation
+        guarantees that should be revalidated before replayed records are accepted.
+      </p>
+      <p>
+        Teams are expected to compare regional recovery playbooks, reconcile missing
+        snapshots, and confirm queue exports before replaying eligibility decisions.
+      </p>
+      <p>
+        The matrix also emphasizes attaching replayed audit artifacts to the same
+        recovery record used for incident review and follow-up.
+      </p>
+    </section>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Was this page helpful?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1949,6 +1949,60 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit replay matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_override_escalation_checklist_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-override-escalation-checklist.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/override-escalation-checklist",
+        )
+
+        self.assertIn(
+            "Override escalation checklists matter when operators need a deterministic sequence",
+            content.text,
+        )
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Override escalation summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_revalidation_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-revalidation-faq.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-revalidation-faq",
+        )
+
+        self.assertIn(
+            "Continuity revalidation FAQs matter when operators need direct answers",
+            content.text,
+        )
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity revalidation FAQ summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_replay_exception_matrix_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-replay-exception-matrix.html"),
+            url="https://docs.together.ai/docs/inference/audit-replay-exception-matrix",
+        )
+
+        self.assertIn(
+            "Audit replay exception matrices matter when operators need a precise map",
+            content.text,
+        )
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit replay exception summary", content.text)
+        self.assertNotIn("Audit replay matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_skips_google_news_aggregate_fixture(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
 


### PR DESCRIPTION
## Summary
- add override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix extraction fixtures
- extend source-specific extraction cleanup for OpenAI, Anthropic, and Together developer policy pages
- bump release metadata and notes for v1.2.40

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python