### PR TITLE
test: add override approval extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.41] - 2026-04-10
+
+### Added
+
+- Override-approval-matrix, continuity-revalidation-checklist, and audit-replay-waiver-faq extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.41`
+- International extraction coverage now includes override-approval-matrix, continuity-revalidation-checklist, and audit-replay-waiver-faq layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, audit-waiver-checklist layouts, rollover-waiver-matrix layouts, continuity-handoff-checklist layouts, audit-recovery-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, and audit-replay-exception-matrix layouts
+
+### Fixed
+
+- Reduced override approval summaries, continuity revalidation checklist summaries, audit replay waiver summaries, audit replay matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of override-approval, continuity-revalidation-checklist, and audit-replay-waiver layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.40] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.40`
+`v1.2.41`
 
 ### Suggested Title
 
-`AI News Open v1.2.40 · Override Escalation and Replay Exception Coverage`
+`AI News Open v1.2.41 · Override Approval and Replay Waiver Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.40
+## AI News Open v1.2.41
 
-AI News Open `v1.2.40` hardens extraction quality for override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix layouts across more developer-doc publishers.
+AI News Open `v1.2.41` hardens extraction quality for override-approval-matrix, continuity-revalidation-checklist, and audit-replay-waiver-faq layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.40` hardens extraction quality for override-escalation-checkl
 
 ### Highlights in this release
 
-- New deterministic override-escalation-checklist, continuity-revalidation-faq, and audit-replay-exception-matrix fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for override escalation summaries, continuity revalidation FAQ summaries, audit replay exception summaries, audit replay matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, and audit-replay-exception-matrix layouts
+- New deterministic override-approval-matrix, continuity-revalidation-checklist, and audit-replay-waiver-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for override approval summaries, continuity revalidation checklist summaries, audit replay waiver summaries, audit replay matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, and audit-replay-waiver-faq layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.41.md
+++ b/docs/releases/v1.2.41.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.41
+
+## Highlights
+
+- Added deterministic extraction fixtures for `override-approval-matrix`, `continuity-revalidation-checklist`, and `audit-replay-waiver-faq` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.40"
+version = "1.2.41"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.40"
+__version__ = "1.2.41"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-checklist",
         ".continuity-revalidation-faq",
         ".continuity-revalidation-matrix",
         ".continuity-exception-checklist",
@@ -424,6 +425,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".override-approval-matrix",
         ".override-escalation-checklist",
         ".recovery-override-faq",
         ".recovery-override-matrix",
@@ -457,6 +459,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-replay-waiver-faq",
         ".audit-replay-exception-matrix",
         ".audit-replay-checklist",
         ".audit-replay-faq",
@@ -891,6 +894,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-checklist-summary",
         ".continuity-revalidation-faq-summary",
         ".continuity-revalidation-summary",
         ".continuity-exception-summary",
@@ -993,6 +997,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".override-approval-summary",
         ".override-escalation-summary",
         ".recovery-override-faq-summary",
         ".recovery-override-summary",
@@ -1034,6 +1039,7 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-replay-waiver-summary",
         ".audit-replay-exception-summary",
         ".audit-replay-checklist-summary",
         ".audit-replay-summary",
@@ -1396,6 +1402,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity revalidation checklist$"),
+        re.compile(r"^Continuity revalidation checklist summary$"),
         re.compile(r"^Continuity revalidation FAQ$"),
         re.compile(r"^Continuity revalidation FAQ summary$"),
         re.compile(r"^Continuity revalidation matrix$"),
@@ -1499,6 +1507,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Override approval matrix$"),
+        re.compile(r"^Override approval summary$"),
         re.compile(r"^Override escalation checklist$"),
         re.compile(r"^Override escalation summary$"),
         re.compile(r"^Recovery override FAQ$"),
@@ -1553,6 +1563,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit replay waiver FAQ$"),
+        re.compile(r"^Audit replay waiver summary$"),
         re.compile(r"^Audit replay exception matrix$"),
         re.compile(r"^Audit replay exception summary$"),
         re.compile(r"^Audit replay checklist$"),
@@ -1918,6 +1930,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-exception-checklist"}},
@@ -1997,6 +2010,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"override-approval-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"override-escalation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-override-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-override-matrix"}},
@@ -2030,6 +2044,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-replay-waiver-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-faq"}},

--- a/tests/fixtures/extraction/anthropic-continuity-revalidation-checklist.html
+++ b/tests/fixtures/extraction/anthropic-continuity-revalidation-checklist.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Continuity revalidation checklist</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-revalidation-checklist-summary">
+      <h2>Continuity revalidation checklist summary</h2>
+      <p>Summary card that should be dropped.</p>
+    </section>
+    <section class="continuity-revalidation-checklist">
+      <h1>Continuity revalidation checklist</h1>
+      <p>
+        Continuity revalidation checklists matter when operators need a deterministic
+        sequence for renewing approval authority through prolonged incidents.
+      </p>
+      <p>
+        The document explains how review checkpoints, queue health evidence, and fallback
+        queues should be refreshed before any revalidation window is extended.
+      </p>
+      <p>
+        Teams are expected to preserve fairness controls, handoff records, and recovery
+        evidence so revalidation remains traceable across shifts.
+      </p>
+      <p>
+        Longer incidents also require explicit rollback ownership and a fresh validation
+        window before authority is passed to the next operator.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-override-approval-matrix.html
+++ b/tests/fixtures/extraction/openai-override-approval-matrix.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Override approval matrix</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="override-approval-summary">
+      <h2>Override approval summary</h2>
+      <p>Summary card that should not be part of the extracted body.</p>
+    </section>
+    <section class="override-approval-matrix">
+      <h1>Override approval matrix</h1>
+      <p>
+        Override approval matrices matter when operators need a precise map of who can
+        authorize temporary overrides while core traffic is stabilized.
+      </p>
+      <p>
+        The guidance ties approval paths to queue pressure, audit checkpoints,
+        fallback regions, and rollback ownership rather than ad hoc approvals.
+      </p>
+      <p>
+        In practice, operators still need to verify grace thresholds, regional failover
+        evidence, and escalation logs before any override is extended.
+      </p>
+      <p>
+        The matrix stresses that approvals should preserve shared throughput stability
+        and leave a durable trail for post-incident review.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-replay-waiver-faq.html
+++ b/tests/fixtures/extraction/together-audit-replay-waiver-faq.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Audit replay waiver FAQ</title>
+  </head>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-replay-waiver-summary">
+      <h2>Audit replay waiver summary</h2>
+      <p>Summary card that should not survive extraction.</p>
+    </section>
+    <section class="audit-replay-matrix">
+      <h2>Audit replay matrix</h2>
+      <p>Matrix helper that should not be included in the body.</p>
+    </section>
+    <section class="audit-replay-waiver-faq">
+      <h1>Audit replay waiver FAQ</h1>
+      <p>
+        Audit replay waiver FAQs matter when operators need direct answers about replaying
+        reservation evidence and waiver records after an incident has stabilized.
+      </p>
+      <p>
+        The guidance covers exception triggers, dashboard checks, and reservation
+        guarantees that should be revalidated before replayed records are accepted.
+      </p>
+      <p>
+        Teams are expected to compare regional recovery playbooks, reconcile missing
+        snapshots, and confirm queue exports before replaying eligibility decisions.
+      </p>
+      <p>
+        The FAQ also emphasizes attaching replayed audit artifacts to the same
+        recovery record used for incident review and follow-up.
+      </p>
+    </section>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Was this page helpful?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -2003,6 +2003,60 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit replay matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_override_approval_matrix_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-override-approval-matrix.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/override-approval-matrix",
+        )
+
+        self.assertIn(
+            "Override approval matrices matter when operators need a precise map",
+            content.text,
+        )
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput stability", content.text)
+        self.assertNotIn("Override approval summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_revalidation_checklist_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-revalidation-checklist.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-revalidation-checklist",
+        )
+
+        self.assertIn(
+            "Continuity revalidation checklists matter when operators need a deterministic",
+            content.text,
+        )
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity revalidation checklist summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_replay_waiver_faq_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-replay-waiver-faq.html"),
+            url="https://docs.together.ai/docs/inference/audit-replay-waiver-faq",
+        )
+
+        self.assertIn(
+            "Audit replay waiver FAQs matter when operators need direct answers",
+            content.text,
+        )
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit replay waiver summary", content.text)
+        self.assertNotIn("Audit replay matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_skips_google_news_aggregate_fixture(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
 


### PR DESCRIPTION
## Summary
- add extraction fixtures for override approval matrix, continuity revalidation checklist, and audit replay waiver FAQ pages
- extend source-specific cleanup rules for OpenAI, Anthropic, and Together developer policy docs
- bump release metadata to v1.2.41 and update launch/release docs

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python