### PR TITLE
test: add override approval faq extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.42] - 2026-04-10
+
+### Added
+
+- Override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.42`
+- International extraction coverage now includes override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, audit-waiver-checklist layouts, rollover-waiver-matrix layouts, continuity-handoff-checklist layouts, audit-recovery-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, and audit-replay-waiver-faq layouts
+
+### Fixed
+
+- Reduced override approval FAQ summaries, continuity revalidation exception summaries, audit replay waiver checklist summaries, audit replay matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.41] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.41`
+`v1.2.42`
 
 ### Suggested Title
 
-`AI News Open v1.2.41 · Override Approval and Replay Waiver Coverage`
+`AI News Open v1.2.42 · Override Approval FAQ and Revalidation Exception Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.41
+## AI News Open v1.2.42
 
-AI News Open `v1.2.41` hardens extraction quality for override-approval-matrix, continuity-revalidation-checklist, and audit-replay-waiver-faq layouts across more developer-doc publishers.
+AI News Open `v1.2.42` hardens extraction quality for override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.41` hardens extraction quality for override-approval-matrix, 
 
 ### Highlights in this release
 
-- New deterministic override-approval-matrix, continuity-revalidation-checklist, and audit-replay-waiver-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for override approval summaries, continuity revalidation checklist summaries, audit replay waiver summaries, audit replay matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, and audit-replay-waiver-faq layouts
+- New deterministic override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for override approval FAQ summaries, continuity revalidation exception summaries, audit replay waiver checklist summaries, audit replay matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, audit-replay-waiver-faq layouts, override-approval-faq layouts, continuity-revalidation-exception-matrix layouts, and audit-replay-waiver-checklist layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.42.md
+++ b/docs/releases/v1.2.42.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.42
+
+## Highlights
+
+- Added deterministic extraction fixtures for `override-approval-faq`, `continuity-revalidation-exception-matrix`, and `audit-replay-waiver-checklist` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.41"
+version = "1.2.42"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.41"
+__version__ = "1.2.42"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-exception-matrix",
         ".continuity-revalidation-checklist",
         ".continuity-revalidation-faq",
         ".continuity-revalidation-matrix",
@@ -425,6 +426,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".override-approval-faq",
         ".override-approval-matrix",
         ".override-escalation-checklist",
         ".recovery-override-faq",
@@ -459,6 +461,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-replay-waiver-checklist",
         ".audit-replay-waiver-faq",
         ".audit-replay-exception-matrix",
         ".audit-replay-checklist",
@@ -894,6 +897,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-exception-summary",
         ".continuity-revalidation-checklist-summary",
         ".continuity-revalidation-faq-summary",
         ".continuity-revalidation-summary",
@@ -997,6 +1001,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".override-approval-faq-summary",
         ".override-approval-summary",
         ".override-escalation-summary",
         ".recovery-override-faq-summary",
@@ -1039,6 +1044,7 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-replay-waiver-checklist-summary",
         ".audit-replay-waiver-summary",
         ".audit-replay-exception-summary",
         ".audit-replay-checklist-summary",
@@ -1402,6 +1408,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity revalidation exception matrix$"),
+        re.compile(r"^Continuity revalidation exception summary$"),
         re.compile(r"^Continuity revalidation checklist$"),
         re.compile(r"^Continuity revalidation checklist summary$"),
         re.compile(r"^Continuity revalidation FAQ$"),
@@ -1507,6 +1515,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Override approval FAQ$"),
+        re.compile(r"^Override approval FAQ summary$"),
         re.compile(r"^Override approval matrix$"),
         re.compile(r"^Override approval summary$"),
         re.compile(r"^Override escalation checklist$"),
@@ -1563,6 +1573,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit replay waiver checklist$"),
+        re.compile(r"^Audit replay waiver checklist summary$"),
         re.compile(r"^Audit replay waiver FAQ$"),
         re.compile(r"^Audit replay waiver summary$"),
         re.compile(r"^Audit replay exception matrix$"),
@@ -1930,6 +1942,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-matrix"}},
@@ -2010,6 +2023,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"override-approval-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"override-approval-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"override-escalation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"recovery-override-faq"}},
@@ -2044,6 +2058,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-replay-waiver-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-waiver-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-checklist"}},

--- a/tests/fixtures/extraction/anthropic-continuity-revalidation-exception-matrix.html
+++ b/tests/fixtures/extraction/anthropic-continuity-revalidation-exception-matrix.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Continuity revalidation exception matrix</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-revalidation-exception-summary">
+      <h2>Continuity revalidation exception summary</h2>
+      <p>Summary card that should be dropped.</p>
+    </section>
+    <section class="continuity-revalidation-exception-matrix">
+      <h1>Continuity revalidation exception matrix</h1>
+      <p>
+        Continuity revalidation exception matrices matter when operators need a precise
+        map of which incident conditions justify bypassing the default revalidation flow.
+      </p>
+      <p>
+        The matrix ties exception paths to review checkpoints, queue health evidence,
+        fallback queues, and incident severity rather than informal judgement.
+      </p>
+      <p>
+        Teams are expected to preserve fairness controls, handoff records, and recovery
+        evidence so exception handling remains auditable across shifts.
+      </p>
+      <p>
+        Longer incidents still require explicit rollback ownership and a fresh approval
+        check before an exception path is extended.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-override-approval-faq.html
+++ b/tests/fixtures/extraction/openai-override-approval-faq.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Override approval FAQ</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="override-approval-faq-summary">
+      <h2>Override approval FAQ summary</h2>
+      <p>Summary card that should not be part of the extracted body.</p>
+    </section>
+    <section class="override-approval-faq">
+      <h1>Override approval FAQ</h1>
+      <p>
+        Override approval FAQs matter when operators need direct answers about when a
+        temporary approval path can stay active without undermining core safety controls.
+      </p>
+      <p>
+        The guidance explains how queue evidence, failover checkpoints, and approver
+        rotation should be reviewed before an override answer is reused.
+      </p>
+      <p>
+        In practice, operators still need to confirm grace thresholds, fallback regions,
+        and change logs before any answer is treated as an active approval.
+      </p>
+      <p>
+        The FAQ emphasizes that every approval answer should preserve shared throughput
+        stability and leave a durable incident-review trail.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-replay-waiver-checklist.html
+++ b/tests/fixtures/extraction/together-audit-replay-waiver-checklist.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Audit replay waiver checklist</title>
+  </head>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-replay-waiver-checklist-summary">
+      <h2>Audit replay waiver checklist summary</h2>
+      <p>Summary card that should not survive extraction.</p>
+    </section>
+    <section class="audit-replay-matrix">
+      <h2>Audit replay matrix</h2>
+      <p>Matrix helper that should not be included in the body.</p>
+    </section>
+    <section class="audit-replay-waiver-checklist">
+      <h1>Audit replay waiver checklist</h1>
+      <p>
+        Audit replay waiver checklists matter when operators need a deterministic
+        sequence for validating waiver records before replaying them into the incident log.
+      </p>
+      <p>
+        The checklist covers exception triggers, dashboard checks, reservation exports,
+        and replay prerequisites that must be confirmed in order.
+      </p>
+      <p>
+        Teams are expected to compare regional recovery playbooks, reconcile missing
+        snapshots, and verify queue exports before replaying any waiver decision.
+      </p>
+      <p>
+        The checklist also stresses attaching replayed waiver evidence to the same
+        recovery record used for follow-up review and escalation.
+      </p>
+    </section>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Was this page helpful?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -2057,6 +2057,63 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit replay matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_override_approval_faq_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-override-approval-faq.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/override-approval-faq",
+        )
+
+        self.assertIn(
+            "Override approval FAQs matter when operators need direct answers",
+            content.text,
+        )
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput", content.text)
+        self.assertIn("incident-review trail", content.text)
+        self.assertNotIn("Override approval FAQ summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_revalidation_exception_matrix_body_and_drops_limit_noise(
+        self,
+    ) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-revalidation-exception-matrix.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-revalidation-exception-matrix",
+        )
+
+        self.assertIn(
+            "Continuity revalidation exception matrices matter when operators need a precise",
+            content.text,
+        )
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity revalidation exception summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_replay_waiver_checklist_body_and_drops_quota_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-replay-waiver-checklist.html"),
+            url="https://docs.together.ai/docs/inference/audit-replay-waiver-checklist",
+        )
+
+        self.assertIn(
+            "Audit replay waiver checklists matter when operators need a deterministic",
+            content.text,
+        )
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit replay waiver checklist summary", content.text)
+        self.assertNotIn("Audit replay matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_skips_google_news_aggregate_fixture(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
 


### PR DESCRIPTION
## Summary
- add extraction fixtures for override approval FAQ, continuity revalidation exception matrix, and audit replay waiver checklist pages
- extend source-specific cleanup rules for OpenAI, Anthropic, and Together developer policy docs
- bump release metadata to v1.2.42 and update launch/release docs

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python