### PR TITLE
test: add override approval incident extraction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.43] - 2026-04-10
+
+### Added
+
+- Override-approval-incident-note, continuity-revalidation-waiver-faq, and audit-replay-waiver-exception-matrix extraction fixtures for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`
+
+### Changed
+
+- Package version is now `1.2.43`
+- International extraction coverage now includes override-approval-incident-note, continuity-revalidation-waiver-faq, and audit-replay-waiver-exception-matrix layouts in addition to standard articles, live updates, briefing pages, multimedia-heavy pages, opinion/column layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy-feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, grace-window-faq layouts, approval-escalation-note layouts, exception-rollover-checklist layouts, grace-window-exception-matrix layouts, approval-handoff-faq layouts, rollover-audit-checklist layouts, exception-eligibility-matrix layouts, handoff-escalation-checklist layouts, audit-exception-faq layouts, eligibility-rollover-matrix layouts, approval-continuity-faq layouts, audit-waiver-checklist layouts, rollover-waiver-matrix layouts, continuity-handoff-checklist layouts, audit-recovery-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, audit-replay-waiver-faq layouts, override-approval-faq layouts, continuity-revalidation-exception-matrix layouts, and audit-replay-waiver-checklist layouts
+
+### Fixed
+
+- Reduced override approval incident summaries, continuity revalidation waiver summaries, audit replay waiver exception summaries, audit replay matrices, and related-guide recirculation noise on developer policy pages
+- Locked another class of override-approval-incident-note, continuity-revalidation-waiver-faq, and audit-replay-waiver-exception-matrix layouts into deterministic fixture coverage so extraction regressions are caught in CI
+
 ## [1.2.42] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.42`
+`v1.2.43`
 
 ### Suggested Title
 
-`AI News Open v1.2.42 · Override Approval FAQ and Revalidation Exception Coverage`
+`AI News Open v1.2.43 · Incident Note and Waiver Exception Coverage`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.42
+## AI News Open v1.2.43
 
-AI News Open `v1.2.42` hardens extraction quality for override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist layouts across more developer-doc publishers.
+AI News Open `v1.2.43` hardens extraction quality for override-approval-incident-note, continuity-revalidation-waiver-faq, and audit-replay-waiver-exception-matrix layouts across more developer-doc publishers.
 
 ### What it does
 
@@ -40,9 +40,9 @@ AI News Open `v1.2.42` hardens extraction quality for override-approval-faq, con
 
 ### Highlights in this release
 
-- New deterministic override-approval-faq, continuity-revalidation-exception-matrix, and audit-replay-waiver-checklist fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for override approval FAQ summaries, continuity revalidation exception summaries, audit replay waiver checklist summaries, audit replay matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, audit-replay-waiver-faq layouts, override-approval-faq layouts, continuity-revalidation-exception-matrix layouts, and audit-replay-waiver-checklist layouts
+- New deterministic override-approval-incident-note, continuity-revalidation-waiver-faq, and audit-replay-waiver-exception-matrix fixtures for `OpenAI`, `Anthropic`, and `Together`
+- Better cleanup for override approval incident summaries, continuity revalidation waiver summaries, audit replay waiver exception summaries, audit replay matrices, and related-guide recirculation on developer policy pages
+- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, audit-replay-waiver-faq layouts, override-approval-faq layouts, continuity-revalidation-exception-matrix layouts, audit-replay-waiver-checklist layouts, override-approval-incident-note layouts, continuity-revalidation-waiver-faq layouts, and audit-replay-waiver-exception-matrix layouts
 - Published-artifact smoke validation still runs automatically after release publication
 
 ### Quick start

--- a/docs/releases/v1.2.43.md
+++ b/docs/releases/v1.2.43.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.43
+
+## Highlights
+
+- Added deterministic extraction fixtures for `override-approval-incident-note`, `continuity-revalidation-waiver-faq`, and `audit-replay-waiver-exception-matrix` policy layouts.
+- Expanded host-specific cleanup for `platform.openai.com`, `docs.anthropic.com`, and `docs.together.ai`.
+- Reduced summary-card, matrix, and related-guide noise on developer policy pages.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.42"
+version = "1.2.43"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.42"
+__version__ = "1.2.43"

--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -345,6 +345,7 @@ HOST_SELECTORS = {
         ".doc-content",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-waiver-faq",
         ".continuity-revalidation-exception-matrix",
         ".continuity-revalidation-checklist",
         ".continuity-revalidation-faq",
@@ -426,6 +427,7 @@ HOST_SELECTORS = {
         ".prose",
     ),
     "platform.openai.com": (
+        ".override-approval-incident-note",
         ".override-approval-faq",
         ".override-approval-matrix",
         ".override-escalation-checklist",
@@ -461,6 +463,7 @@ HOST_SELECTORS = {
         ".migration-checklist",
     ),
     "docs.together.ai": (
+        ".audit-replay-waiver-exception-matrix",
         ".audit-replay-waiver-checklist",
         ".audit-replay-waiver-faq",
         ".audit-replay-exception-matrix",
@@ -897,6 +900,7 @@ HOST_DROP_SELECTORS = {
         ".sidebar-nav",
     ),
     "docs.anthropic.com": (
+        ".continuity-revalidation-waiver-summary",
         ".continuity-revalidation-exception-summary",
         ".continuity-revalidation-checklist-summary",
         ".continuity-revalidation-faq-summary",
@@ -1001,6 +1005,7 @@ HOST_DROP_SELECTORS = {
         ".page-nav",
     ),
     "platform.openai.com": (
+        ".override-approval-incident-summary",
         ".override-approval-faq-summary",
         ".override-approval-summary",
         ".override-escalation-summary",
@@ -1044,6 +1049,7 @@ HOST_DROP_SELECTORS = {
         ".breadcrumbs",
     ),
     "docs.together.ai": (
+        ".audit-replay-waiver-exception-summary",
         ".audit-replay-waiver-checklist-summary",
         ".audit-replay-waiver-summary",
         ".audit-replay-exception-summary",
@@ -1408,6 +1414,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Watch the walkthrough$"),
     ),
     "docs.anthropic.com": (
+        re.compile(r"^Continuity revalidation waiver FAQ$"),
+        re.compile(r"^Continuity revalidation waiver summary$"),
         re.compile(r"^Continuity revalidation exception matrix$"),
         re.compile(r"^Continuity revalidation exception summary$"),
         re.compile(r"^Continuity revalidation checklist$"),
@@ -1515,6 +1523,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Contact sales$"),
     ),
     "platform.openai.com": (
+        re.compile(r"^Override approval incident note$"),
+        re.compile(r"^Override approval incident summary$"),
         re.compile(r"^Override approval FAQ$"),
         re.compile(r"^Override approval FAQ summary$"),
         re.compile(r"^Override approval matrix$"),
@@ -1573,6 +1583,8 @@ HOST_NOISE_LINE_PATTERNS = {
         re.compile(r"^Need more help\?$"),
     ),
     "docs.together.ai": (
+        re.compile(r"^Audit replay waiver exception matrix$"),
+        re.compile(r"^Audit replay waiver exception summary$"),
         re.compile(r"^Audit replay waiver checklist$"),
         re.compile(r"^Audit replay waiver checklist summary$"),
         re.compile(r"^Audit replay waiver FAQ$"),
@@ -1942,6 +1954,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"doc-content"}},
     ),
     "docs.anthropic.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-waiver-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"continuity-revalidation-faq"}},
@@ -2023,6 +2036,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"prose"}},
     ),
     "platform.openai.com": (
+        {"tags": {"div", "section"}, "class_tokens": {"override-approval-incident-note"}},
         {"tags": {"div", "section"}, "class_tokens": {"override-approval-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"override-approval-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"override-escalation-checklist"}},
@@ -2058,6 +2072,7 @@ FALLBACK_HOST_RULES = {
         {"tags": {"div", "section"}, "class_tokens": {"migration-checklist"}},
     ),
     "docs.together.ai": (
+        {"tags": {"div", "section"}, "class_tokens": {"audit-replay-waiver-exception-matrix"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-waiver-checklist"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-waiver-faq"}},
         {"tags": {"div", "section"}, "class_tokens": {"audit-replay-exception-matrix"}},

--- a/tests/fixtures/extraction/anthropic-continuity-revalidation-waiver-faq.html
+++ b/tests/fixtures/extraction/anthropic-continuity-revalidation-waiver-faq.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Continuity revalidation waiver FAQ</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <section class="continuity-revalidation-waiver-summary">
+      <h2>Continuity revalidation waiver summary</h2>
+      <p>Summary card that should be dropped.</p>
+    </section>
+    <section class="continuity-revalidation-waiver-faq">
+      <h1>Continuity revalidation waiver FAQ</h1>
+      <p>
+        Continuity revalidation waiver FAQs matter when operators need direct answers
+        about when the default revalidation sequence can be safely bypassed.
+      </p>
+      <p>
+        The guidance explains how review checkpoints, queue health evidence, and fallback
+        queues should be checked before a waiver answer is reused.
+      </p>
+      <p>
+        Teams are expected to preserve fairness controls, handoff records, and recovery
+        evidence so waiver decisions remain traceable across shifts.
+      </p>
+      <p>
+        Longer incidents still require explicit rollback ownership and a fresh approval
+        window before a waiver path is extended.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="contact-security">Contact security</div>
+    <div class="docs-feedback">Need more help?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/openai-override-approval-incident-note.html
+++ b/tests/fixtures/extraction/openai-override-approval-incident-note.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Override approval incident note</title>
+  </head>
+  <body>
+    <aside class="docs-sidebar">Docs sidebar</aside>
+    <nav class="rate-limit-nav">Rate limit navigation</nav>
+    <section class="override-approval-incident-summary">
+      <h2>Override approval incident summary</h2>
+      <p>Summary card that should not be part of the extracted body.</p>
+    </section>
+    <section class="override-approval-incident-note">
+      <h1>Override approval incident note</h1>
+      <p>
+        Override approval incident notes matter when operators need a precise record of
+        why an approval path stayed active during an ongoing service disruption.
+      </p>
+      <p>
+        The note ties incident evidence to queue pressure, failover checkpoints, and
+        approver rotation rather than ad hoc operational memory.
+      </p>
+      <p>
+        Teams still need to confirm grace thresholds, fallback regions, and change logs
+        before an incident note is treated as active approval evidence.
+      </p>
+      <p>
+        The document emphasizes preserving shared throughput stability and leaving a
+        durable incident-review trail for every override decision.
+      </p>
+    </section>
+    <section class="related-limit-guides">Related limit guides</section>
+    <div class="feedback-widget">Was this helpful?</div>
+  </body>
+</html>

--- a/tests/fixtures/extraction/together-audit-replay-waiver-exception-matrix.html
+++ b/tests/fixtures/extraction/together-audit-replay-waiver-exception-matrix.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Audit replay waiver exception matrix</title>
+  </head>
+  <body>
+    <aside class="policy-sidebar">Policy sidebar</aside>
+    <section class="audit-replay-waiver-exception-summary">
+      <h2>Audit replay waiver exception summary</h2>
+      <p>Summary card that should not survive extraction.</p>
+    </section>
+    <section class="audit-replay-matrix">
+      <h2>Audit replay matrix</h2>
+      <p>Matrix helper that should not be included in the body.</p>
+    </section>
+    <section class="audit-replay-waiver-exception-matrix">
+      <h1>Audit replay waiver exception matrix</h1>
+      <p>
+        Audit replay waiver exception matrices matter when operators need a precise map
+        of when replayed waiver records can bypass the standard verification path.
+      </p>
+      <p>
+        The matrix covers exception triggers, dashboard checks, reservation exports,
+        and replay prerequisites that must be proven in order.
+      </p>
+      <p>
+        Teams are expected to compare regional recovery playbooks, reconcile missing
+        snapshots, and verify queue exports before replaying any waiver exception.
+      </p>
+      <p>
+        The matrix also stresses attaching replayed waiver evidence to the same
+        recovery record used for follow-up review and escalation.
+      </p>
+    </section>
+    <section class="related-quota-guides">Related quota guides</section>
+    <div class="feedback-widget">Was this page helpful?</div>
+  </body>
+</html>

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -2114,6 +2114,64 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Audit replay matrix", content.text)
         self.assertNotIn("Related quota guides", content.text)
 
+    def test_prefers_openai_override_approval_incident_note_body_and_drops_limit_noise(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("openai-override-approval-incident-note.html"),
+            url="https://platform.openai.com/docs/guides/rate-limits/override-approval-incident-note",
+        )
+
+        self.assertIn(
+            "Override approval incident notes matter when operators need a precise record",
+            content.text,
+        )
+        self.assertIn("grace thresholds", content.text)
+        self.assertIn("fallback regions", content.text)
+        self.assertIn("shared throughput", content.text)
+        self.assertNotIn("Override approval incident summary", content.text)
+        self.assertNotIn("Rate limit navigation", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+
+    def test_prefers_anthropic_continuity_revalidation_waiver_faq_body_and_drops_limit_noise(
+        self,
+    ) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("anthropic-continuity-revalidation-waiver-faq.html"),
+            url="https://docs.anthropic.com/en/docs/usage/continuity-revalidation-waiver-faq",
+        )
+
+        self.assertIn(
+            "Continuity revalidation waiver FAQs matter when operators need direct answers",
+            content.text,
+        )
+        self.assertIn("review checkpoints", content.text)
+        self.assertIn("queue health evidence", content.text)
+        self.assertIn("fairness controls", content.text)
+        self.assertNotIn("Continuity revalidation waiver summary", content.text)
+        self.assertNotIn("Related limit guides", content.text)
+        self.assertNotIn("Contact security", content.text)
+
+    def test_prefers_together_audit_replay_waiver_exception_matrix_body_and_drops_quota_noise(
+        self,
+    ) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        content = extractor.extract_from_html(
+            _fixture("together-audit-replay-waiver-exception-matrix.html"),
+            url="https://docs.together.ai/docs/inference/audit-replay-waiver-exception-matrix",
+        )
+
+        self.assertIn(
+            "Audit replay waiver exception matrices matter when operators need a precise map",
+            content.text,
+        )
+        self.assertIn("exception triggers", content.text)
+        self.assertIn("dashboard checks", content.text)
+        self.assertIn("regional recovery playbooks", content.text)
+        self.assertNotIn("Audit replay waiver exception summary", content.text)
+        self.assertNotIn("Audit replay matrix", content.text)
+        self.assertNotIn("Related quota guides", content.text)
+
     def test_skips_google_news_aggregate_fixture(self) -> None:
         extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
 


### PR DESCRIPTION
## Summary
- add extraction fixtures for override approval incident note, continuity revalidation waiver FAQ, and audit replay waiver exception matrix pages
- extend source-specific cleanup rules for OpenAI, Anthropic, and Together developer policy docs
- bump release metadata to v1.2.43 and update launch/release docs

## Verification
- ./.venv-dev/bin/python -m unittest tests.test_content_extractor -v
- make check PYTHON=./.venv-dev/bin/python