### PR TITLE
feat: add digest editor snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ After startup you can:
 - Use the Operations panel to inspect `/health`, recent pipeline runs, source cooldowns, source alerts, and publication failures in one screen
 - Browse the article pool, digest archive, publication history, and WeChat publish status
 - Trigger ingest, extraction, translation, digest generation, and publishing from the dashboard
+- Freeze a preview into a stored digest snapshot, edit ranking/section/title/summary overrides, and publish the confirmed snapshot instead of a fresh recompute
 
 ## Public Demo
 
@@ -112,7 +113,7 @@ The current version includes:
 - Article body extraction, source-specific cleanup, and local storage
 - LLM-powered translation and summary enrichment for international stories
 - Chinese daily digest generation and digest history
-- Editorial controls for `pin`, `must_include`, `suppress`, duplicate-primary selection, and digest selection preview with explicit inclusion/exclusion reasons
+- Editorial controls for `pin`, `must_include`, `suppress`, duplicate-primary selection, digest selection preview with explicit inclusion/exclusion reasons, and a frozen digest editor with publish-time overrides
 - A publication layer for Telegram, Feishu, a static site, and WeChat draft publishing
 - Feishu card messages and automatic WeChat cover upload
 - Publication history management and WeChat publish-status refresh
@@ -489,6 +490,18 @@ curl -X POST "http://127.0.0.1:8000/admin/digests/generate" \
   -H "X-Admin-Token: your-secret-token" \
   -d '{"region":"all","since_hours":48,"limit":20,"use_llm":true,"persist":true}'
 ```
+
+### `POST /admin/digests/preview`
+
+Build a ranked selection preview with explicit inclusion, suppression, duplicate-secondary, and ranked-out decisions.
+
+### `POST /admin/digests/snapshot`
+
+Freeze the current preview into a stored editable digest draft. Optional `editor_items` can override selection, manual rank, section title, publish title, and publish summary.
+
+### `PATCH /admin/digests/{digest_id}/editor`
+
+Update a frozen digest draft in place. Publishing with `digest_id` uses this stored snapshot so the outbound digest matches the reviewed editor state instead of a live recompute.
 
 ### `PATCH /admin/articles/{id}`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,7 @@ python -m ainews serve --port 8000
 - 直接在 Operations 总览里查看 `/health`、最近 pipeline、来源冷却、来源告警和发布失败
 - 查看新闻池、日报存档、发布历史和微信发布状态
 - 直接从控制台触发抓取、翻译、生成日报和发布
+- 把预览冻结成可编辑发布稿，调整排序、分组、发布标题和摘要，然后按冻结稿发布而不是实时重算
 
 ## 公开 Demo
 
@@ -112,7 +113,7 @@ make check
 - 文章正文抓取、source-specific 清洗与本地持久化
 - 国际新闻 LLM 翻译与摘要补全
 - 中文日报生成与历史存档
-- `pin`、`must_include`、`suppress`、重复簇主记录切换、带入选/排除原因的日报编辑预览等控制能力
+- `pin`、`must_include`、`suppress`、重复簇主记录切换、带入选/排除原因的日报编辑预览，以及可冻结的发布前编辑稿能力
 - 日报发布层，可推送到 Telegram、飞书、自建静态站点和微信公众号草稿箱
 - 飞书卡片消息和微信公众号封面自动上传
 - 发布历史管理与微信公众号发布状态刷新
@@ -489,6 +490,18 @@ curl -X POST "http://127.0.0.1:8000/admin/digests/generate" \
   -H "X-Admin-Token: your-secret-token" \
   -d '{"region":"all","since_hours":48,"limit":20,"use_llm":true,"persist":true}'
 ```
+
+### `POST /admin/digests/preview`
+
+生成带入选、压制、重复簇次记录、排序落选原因的选稿预览。
+
+### `POST /admin/digests/snapshot`
+
+把当前预览冻结成一份可编辑的日报草稿。可选 `editor_items` 支持覆盖是否入选、手工排序、分组标题、发布标题和发布摘要。
+
+### `PATCH /admin/digests/{digest_id}/editor`
+
+原地更新一份已冻结的编辑稿。之后使用 `digest_id` 发布时，会优先发布这份已确认快照，而不是临时重新计算。
 
 ### `PATCH /admin/articles/{id}`
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -70,6 +70,9 @@ The following routes are the intended stable HTTP surface for `v1.x`:
 - `POST /admin/enrich`
 - `POST /admin/extract`
 - `POST /admin/digests/generate`
+- `POST /admin/digests/preview`
+- `POST /admin/digests/snapshot`
+- `PATCH /admin/digests/{digest_id}/editor`
 - `POST /admin/pipeline`
 - `POST /admin/publish`
 - `GET /admin/digests`
@@ -97,6 +100,10 @@ The exported digest JSON keeps these top-level fields:
 - `digest`
 - `body_markdown`
 - `generation_mode`
+- `selection_preview`
+- `selection_decisions`
+- `selection_summary`
+- `editor_snapshot`
 - `stored_digest` when persistence is enabled
 
 The `digest` object keeps these fields:
@@ -108,6 +115,36 @@ The `digest` object keeps these fields:
 - `closing`
 - `provider`
 - `model`
+
+The `editor_snapshot` object keeps these fields:
+
+- `snapshot_status`
+- `frozen_at`
+- `updated_at`
+- `last_published_at`
+- `items`
+
+Each `editor_snapshot.items[]` entry keeps these fields:
+
+- `article_id`
+- `selected`
+- `base_decision`
+- `manual_rank`
+- `section_override`
+- `default_section`
+- `publish_title_override`
+- `publish_summary_override`
+- `original_title`
+- `original_summary`
+- `selection_reasons`
+- `rank_score`
+- `source_name`
+- `published_at`
+- `duplicate_count`
+- `is_pinned`
+- `must_include`
+- `is_suppressed`
+- `sort_index`
 
 The `articles` list keeps these fields as stable downstream contract:
 
@@ -131,6 +168,7 @@ The `articles` list keeps these fields as stable downstream contract:
 Publication behavior is part of the `v1.x` contract:
 
 - A stored digest plus target pair is idempotent by default.
+- When `digest_id` points at a stored digest with an `editor_snapshot`, publish routes reuse that frozen snapshot instead of rebuilding the digest live.
 - When the latest record for the same `digest_id + target` is `ok` or `pending`, the next publish call returns `skipped`.
 - A skipped duplicate publish does not create a new publication row.
 - `--force-republish` and `force_republish=true` bypass this guard intentionally.

--- a/src/ainews/api.py
+++ b/src/ainews/api.py
@@ -60,6 +60,28 @@ class DigestRequest(BaseModel):
     persist: bool = True
 
 
+class DigestEditorItemRequest(BaseModel):
+    article_id: int = Field(ge=1)
+    selected: bool = True
+    manual_rank: Optional[int] = Field(default=None, ge=1, le=999)
+    section_override: Optional[str] = Field(default=None, max_length=80)
+    publish_title_override: Optional[str] = Field(default=None, max_length=300)
+    publish_summary_override: Optional[str] = Field(default=None, max_length=1000)
+
+
+class DigestSnapshotRequest(BaseModel):
+    region: str = Field(default="all")
+    article_ids: Optional[List[int]] = None
+    since_hours: Optional[int] = Field(default=None, ge=1, le=720)
+    limit: int = Field(default=30, ge=1, le=200)
+    use_llm: bool = True
+    editor_items: Optional[List[DigestEditorItemRequest]] = None
+
+
+class DigestEditorUpdateRequest(BaseModel):
+    editor_items: List[DigestEditorItemRequest] = Field(min_length=1)
+
+
 class PipelineRequest(BaseModel):
     region: str = Field(default="all")
     since_hours: Optional[int] = Field(default=None, ge=1, le=720)
@@ -857,6 +879,53 @@ def create_app() -> FastAPI:
                 limit=payload.limit,
                 use_llm=payload.use_llm,
                 persist=False,
+            ))
+        except HTTPException as exc:
+            return _handle_route_http_exception(request, exc)
+        except LookupError:
+            return _handle_route_lookup_error(request)
+        except ValueError:
+            return _handle_route_value_error(request)
+        except Exception:
+            return _handle_route_unexpected_error(request)
+
+    @app.post("/admin/digests/snapshot")
+    def admin_create_digest_snapshot(
+        payload: DigestSnapshotRequest,
+        request: Request,
+        _: None = Depends(require_admin),
+    ) -> dict:
+        _begin_route_action(request, "admin_create_digest_snapshot")
+        try:
+            return _sanitize_service_payload(service.create_digest_snapshot(
+                region=payload.region,
+                article_ids=payload.article_ids,
+                since_hours=payload.since_hours,
+                limit=payload.limit,
+                use_llm=payload.use_llm,
+                editor_items=[item.model_dump() for item in list(payload.editor_items or [])],
+            ))
+        except HTTPException as exc:
+            return _handle_route_http_exception(request, exc)
+        except LookupError:
+            return _handle_route_lookup_error(request)
+        except ValueError:
+            return _handle_route_value_error(request)
+        except Exception:
+            return _handle_route_unexpected_error(request)
+
+    @app.patch("/admin/digests/{digest_id}/editor")
+    def admin_update_digest_editor(
+        digest_id: int,
+        payload: DigestEditorUpdateRequest,
+        request: Request,
+        _: None = Depends(require_admin),
+    ) -> dict:
+        _begin_route_action(request, "admin_update_digest_editor")
+        try:
+            return _sanitize_service_payload(service.update_digest_editor(
+                digest_id,
+                editor_items=[item.model_dump() for item in payload.editor_items],
             ))
         except HTTPException as exc:
             return _handle_route_http_exception(request, exc)

--- a/src/ainews/repository.py
+++ b/src/ainews/repository.py
@@ -2860,6 +2860,45 @@ class ArticleRepository:
             ).fetchone()
         return self._row_to_digest_dict(row) if row else None
 
+    def update_digest(
+        self,
+        digest_id: int,
+        *,
+        title: str,
+        body_markdown: str,
+        provider: str,
+        model: str,
+        article_count: int,
+        source_count: int,
+        payload: Dict[str, object],
+    ) -> Optional[dict]:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE digests
+                SET
+                    title = ?,
+                    body_markdown = ?,
+                    provider = ?,
+                    model = ?,
+                    article_count = ?,
+                    source_count = ?,
+                    payload = ?
+                WHERE id = ?
+                """,
+                (
+                    title,
+                    body_markdown,
+                    provider,
+                    model,
+                    article_count,
+                    source_count,
+                    json.dumps(payload, ensure_ascii=False),
+                    digest_id,
+                ),
+            )
+        return self.get_digest(digest_id)
+
     def list_digests(
         self,
         *,

--- a/src/ainews/service.py
+++ b/src/ainews/service.py
@@ -1177,6 +1177,113 @@ class NewsService:
     def list_digests(self, *, region: Optional[str] = None, limit: int = 20) -> List[dict]:
         return self.repository.list_digests(region=region, limit=limit)
 
+    def get_digest(self, digest_id: int) -> Dict[str, object]:
+        stored_digest = self.repository.get_digest(digest_id)
+        if stored_digest is None:
+            raise ValueError("digest not found")
+        return self._payload_from_stored_digest(stored_digest)
+
+    def create_digest_snapshot(
+        self,
+        *,
+        region: str = "all",
+        article_ids: Optional[Iterable[int]] = None,
+        since_hours: Optional[int] = None,
+        limit: int = 50,
+        use_llm: bool = True,
+        editor_items: Optional[List[dict]] = None,
+    ) -> Dict[str, object]:
+        payload = self.build_digest(
+            region=region,
+            article_ids=article_ids,
+            since_hours=since_hours,
+            limit=limit,
+            use_llm=use_llm,
+            persist=False,
+        )
+        editor_snapshot = self._merge_editor_snapshot_items(
+            payload.get("editor_snapshot"),
+            editor_items,
+        )
+        persisted_payload = self._apply_editor_snapshot_to_payload(
+            payload,
+            editor_snapshot,
+            snapshot_status="draft",
+            frozen_at=utc_now().isoformat(),
+        )
+        digest = persisted_payload["digest"]
+        stored_digest = self.repository.save_digest(
+            region=str(persisted_payload.get("region") or region),
+            since_hours=int(persisted_payload.get("since_hours") or since_hours or self.settings.default_lookback_hours),
+            digest=DailyDigest(
+                title=str(digest.get("title") or ""),
+                overview=str(digest.get("overview") or ""),
+                highlights=list(digest.get("highlights") or []),
+                sections=list(digest.get("sections") or []),
+                closing=str(digest.get("closing") or ""),
+                provider=str(digest.get("provider") or ""),
+                model=str(digest.get("model") or ""),
+            ),
+            body_markdown=str(persisted_payload.get("body_markdown") or ""),
+            article_count=len(list(persisted_payload.get("selection_preview") or [])),
+            source_count=len(
+                {
+                    str(article.get("source_id") or "")
+                    for article in list(persisted_payload.get("articles") or [])
+                    if article.get("source_id")
+                }
+            ),
+            payload=self._payload_for_storage(persisted_payload),
+        )
+        persisted_payload["stored_digest"] = stored_digest
+        return persisted_payload
+
+    def update_digest_editor(
+        self,
+        digest_id: int,
+        *,
+        editor_items: List[dict],
+    ) -> Dict[str, object]:
+        stored_digest = self.repository.get_digest(digest_id)
+        if stored_digest is None:
+            raise ValueError("digest not found")
+        payload = self._payload_from_stored_digest(stored_digest)
+        editor_snapshot = self._merge_editor_snapshot_items(
+            payload.get("editor_snapshot"),
+            editor_items,
+        )
+        updated_payload = self._apply_editor_snapshot_to_payload(
+            payload,
+            editor_snapshot,
+            snapshot_status="draft",
+            frozen_at=clean_text(str((payload.get("editor_snapshot") or {}).get("frozen_at", "")))
+            or utc_now().isoformat(),
+            last_published_at=clean_text(
+                str((payload.get("editor_snapshot") or {}).get("last_published_at", ""))
+            ),
+        )
+        digest = updated_payload["digest"]
+        stored_digest = self.repository.update_digest(
+            digest_id,
+            title=str(digest.get("title") or ""),
+            body_markdown=str(updated_payload.get("body_markdown") or ""),
+            provider=str(digest.get("provider") or ""),
+            model=str(digest.get("model") or ""),
+            article_count=len(list(updated_payload.get("selection_preview") or [])),
+            source_count=len(
+                {
+                    str(article.get("source_id") or "")
+                    for article in list(updated_payload.get("articles") or [])
+                    if article.get("source_id")
+                }
+            ),
+            payload=self._payload_for_storage(updated_payload),
+        )
+        if stored_digest is None:
+            raise ValueError("digest not found")
+        updated_payload["stored_digest"] = stored_digest
+        return updated_payload
+
     def list_publications(
         self,
         *,
@@ -1650,6 +1757,27 @@ class NewsService:
             publish_result["status"] = "ok"
         publish_result["publication_records"] = records
         publish_result["failure_categories"] = dict(failure_categories)
+        if digest_id is not None and int(publish_result.get("published", 0)) > 0:
+            updated_payload = self._mark_editor_snapshot_published(payload)
+            updated_digest = self.repository.update_digest(
+                digest_id,
+                title=str(updated_payload.get("digest", {}).get("title") or ""),
+                body_markdown=str(updated_payload.get("body_markdown") or ""),
+                provider=str(updated_payload.get("digest", {}).get("provider") or ""),
+                model=str(updated_payload.get("digest", {}).get("model") or ""),
+                article_count=len(list(updated_payload.get("selection_preview") or [])),
+                source_count=len(
+                    {
+                        str(article.get("source_id") or "")
+                        for article in list(updated_payload.get("articles") or [])
+                        if article.get("source_id")
+                    }
+                ),
+                payload=self._payload_for_storage(updated_payload),
+            )
+            if updated_digest is not None:
+                payload["editor_snapshot"] = updated_payload.get("editor_snapshot", {})
+                payload["stored_digest"] = updated_digest
         operation_record = self.telemetry.finish(
             operation,
             status=str(publish_result["status"]),
@@ -1741,6 +1869,13 @@ class NewsService:
         presented_articles = [self._present_article(article) for article in articles]
         selection = self._build_digest_selection(presented_articles)
         digest_articles = selection["selected_articles"]
+        editor_snapshot = self._build_editor_snapshot(
+            presented_articles,
+            selection,
+            snapshot_status="draft" if persist else "preview",
+        )
+        if persist:
+            editor_snapshot["frozen_at"] = utc_now().isoformat()
 
         generation_mode = "fallback"
         if use_llm and self.llm_client.is_configured() and digest_articles:
@@ -1776,6 +1911,7 @@ class NewsService:
             "selection_preview": selection["selection_preview"],
             "selection_decisions": selection["selection_decisions"],
             "selection_summary": selection["summary"],
+            "editor_snapshot": editor_snapshot,
             "digest": digest.to_dict(),
             "body_markdown": body_markdown,
             "generation_mode": generation_mode,
@@ -2109,6 +2245,335 @@ class NewsService:
             "must_include": bool(article.get("must_include")),
             "is_suppressed": bool(article.get("is_suppressed")),
         }
+
+    @staticmethod
+    def _default_digest_section_title(article: dict) -> str:
+        return "国内动态" if str(article.get("region", "international")) == "domestic" else "国际动态"
+
+    def _build_editor_snapshot(
+        self,
+        articles: List[dict],
+        selection: Dict[str, object],
+        *,
+        snapshot_status: str,
+    ) -> Dict[str, object]:
+        article_map = {int(article["id"]): article for article in articles if article.get("id") is not None}
+        selected_ids = {
+            int(item["article_id"]) for item in list(selection.get("selection_preview") or [])
+        }
+        manual_rank = 1
+        items: List[dict] = []
+        for index, decision_item in enumerate(list(selection.get("selection_decisions") or [])):
+            article_id = int(decision_item["article_id"])
+            article = article_map.get(article_id)
+            if article is None:
+                continue
+            summary = clean_text(
+                str(
+                    article.get("display_brief_zh")
+                    or article.get("compact_summary_zh")
+                    or article.get("display_summary_zh")
+                    or article.get("summary")
+                    or ""
+                )
+            )
+            item = self._coerce_editor_snapshot_item(
+                {
+                    "article_id": article_id,
+                    "selected": article_id in selected_ids,
+                    "base_decision": clean_text(str(decision_item.get("decision") or "")) or "selected",
+                    "manual_rank": manual_rank if article_id in selected_ids else None,
+                    "section_override": "",
+                    "default_section": self._default_digest_section_title(article),
+                    "publish_title_override": "",
+                    "publish_summary_override": "",
+                    "original_title": clean_text(str(article.get("display_title_zh") or article.get("title") or "")),
+                    "original_summary": summary,
+                    "selection_reasons": list(decision_item.get("selection_reasons") or []),
+                    "rank_score": float(decision_item.get("rank_score") or 0.0),
+                    "source_name": clean_text(str(article.get("source_name") or "")),
+                    "published_at": clean_text(str(article.get("published_at") or "")),
+                    "duplicate_count": int(article.get("duplicate_count") or 1),
+                    "is_pinned": bool(article.get("is_pinned")),
+                    "must_include": bool(article.get("must_include")),
+                    "is_suppressed": bool(article.get("is_suppressed")),
+                    "sort_index": index,
+                },
+                default_index=index,
+            )
+            if item["selected"]:
+                manual_rank += 1
+            items.append(item)
+        return {
+            "snapshot_status": snapshot_status,
+            "frozen_at": "",
+            "updated_at": utc_now().isoformat(),
+            "last_published_at": "",
+            "items": items,
+        }
+
+    def _merge_editor_snapshot_items(
+        self,
+        editor_snapshot_payload: object,
+        editor_items: Optional[List[dict]],
+    ) -> Dict[str, object]:
+        base_snapshot = dict(editor_snapshot_payload) if isinstance(editor_snapshot_payload, dict) else {}
+        base_items = [
+            self._coerce_editor_snapshot_item(item, default_index=index)
+            for index, item in enumerate(list(base_snapshot.get("items") or []))
+            if isinstance(item, dict)
+        ]
+        if not editor_items:
+            base_snapshot["items"] = base_items
+            return base_snapshot
+
+        overrides = {
+            int(item["article_id"]): self._coerce_editor_snapshot_item(item, default_index=index)
+            for index, item in enumerate(editor_items)
+            if isinstance(item, dict) and item.get("article_id") is not None
+        }
+        merged_items: List[dict] = []
+        for index, item in enumerate(base_items):
+            merged = dict(item)
+            override = overrides.get(int(item["article_id"]))
+            if override:
+                for key in (
+                    "selected",
+                    "manual_rank",
+                    "section_override",
+                    "publish_title_override",
+                    "publish_summary_override",
+                ):
+                    merged[key] = override.get(key)
+            merged["sort_index"] = index
+            merged_items.append(self._coerce_editor_snapshot_item(merged, default_index=index))
+
+        base_snapshot["items"] = merged_items
+        return base_snapshot
+
+    @staticmethod
+    def _coerce_editor_snapshot_item(item: dict, *, default_index: int) -> dict:
+        manual_rank = item.get("manual_rank")
+        try:
+            manual_rank_value = int(manual_rank) if manual_rank not in (None, "", False) else None
+        except (TypeError, ValueError):
+            manual_rank_value = None
+        if manual_rank_value is not None and manual_rank_value < 1:
+            manual_rank_value = None
+        return {
+            "article_id": int(item["article_id"]),
+            "selected": bool(item.get("selected")),
+            "base_decision": clean_text(str(item.get("base_decision") or "")) or "selected",
+            "manual_rank": manual_rank_value,
+            "section_override": clean_text(str(item.get("section_override") or "")),
+            "default_section": clean_text(str(item.get("default_section") or "")),
+            "publish_title_override": clean_text(str(item.get("publish_title_override") or "")),
+            "publish_summary_override": clean_text(str(item.get("publish_summary_override") or "")),
+            "original_title": clean_text(str(item.get("original_title") or "")),
+            "original_summary": clean_text(str(item.get("original_summary") or "")),
+            "selection_reasons": [clean_text(str(reason)) for reason in list(item.get("selection_reasons") or []) if clean_text(str(reason))],
+            "rank_score": float(item.get("rank_score") or 0.0),
+            "source_name": clean_text(str(item.get("source_name") or "")),
+            "published_at": clean_text(str(item.get("published_at") or "")),
+            "duplicate_count": int(item.get("duplicate_count") or 1),
+            "is_pinned": bool(item.get("is_pinned")),
+            "must_include": bool(item.get("must_include")),
+            "is_suppressed": bool(item.get("is_suppressed")),
+            "sort_index": int(item.get("sort_index") or default_index),
+        }
+
+    def _apply_editor_snapshot_to_payload(
+        self,
+        payload: Dict[str, object],
+        editor_snapshot: Dict[str, object],
+        *,
+        snapshot_status: str,
+        frozen_at: str = "",
+        last_published_at: str = "",
+    ) -> Dict[str, object]:
+        snapshot = self._merge_editor_snapshot_items(editor_snapshot, None)
+        snapshot["snapshot_status"] = snapshot_status
+        snapshot["frozen_at"] = clean_text(frozen_at) or clean_text(str(snapshot.get("frozen_at") or ""))
+        snapshot["last_published_at"] = clean_text(last_published_at) or clean_text(
+            str(snapshot.get("last_published_at") or "")
+        )
+        snapshot["updated_at"] = utc_now().isoformat()
+
+        articles = [dict(article) for article in list(payload.get("articles") or [])]
+        selection = self._editor_snapshot_to_selection(articles, snapshot)
+        digest = self._build_snapshot_digest(
+            selection["selected_articles"],
+            region=str(payload.get("region") or "all"),
+            since_hours=int(payload.get("since_hours") or self.settings.default_lookback_hours),
+        )
+
+        updated_payload = dict(payload)
+        updated_payload["selection_preview"] = selection["selection_preview"]
+        updated_payload["selection_decisions"] = selection["selection_decisions"]
+        updated_payload["selection_summary"] = selection["summary"]
+        updated_payload["editor_snapshot"] = snapshot
+        updated_payload["digest"] = digest.to_dict()
+        updated_payload["body_markdown"] = self._render_digest_markdown(digest)
+        updated_payload["generation_mode"] = "editor"
+        return updated_payload
+
+    def _editor_snapshot_to_selection(
+        self,
+        articles: List[dict],
+        editor_snapshot: Dict[str, object],
+    ) -> Dict[str, object]:
+        article_map = {int(article["id"]): article for article in articles if article.get("id") is not None}
+        snapshot_items = [
+            self._coerce_editor_snapshot_item(item, default_index=index)
+            for index, item in enumerate(list(editor_snapshot.get("items") or []))
+            if isinstance(item, dict)
+        ]
+        selected_articles: List[dict] = []
+        selection_preview: List[dict] = []
+        selection_decisions: List[dict] = []
+        duplicates_suppressed = 0
+        editorially_suppressed = 0
+        ranked_out = 0
+
+        for item in snapshot_items:
+            article = article_map.get(int(item["article_id"]))
+            if article is None:
+                continue
+            title = clean_text(item.get("publish_title_override")) or clean_text(item.get("original_title")) or clean_text(
+                str(article.get("display_title_zh") or article.get("title") or "")
+            )
+            summary = clean_text(item.get("publish_summary_override")) or clean_text(item.get("original_summary")) or clean_text(
+                str(article.get("compact_summary_zh") or article.get("display_summary_zh") or article.get("summary") or "")
+            )
+            section_title = clean_text(item.get("section_override")) or clean_text(item.get("default_section")) or self._default_digest_section_title(article)
+            reasons = list(item.get("selection_reasons") or [])
+            base_decision = clean_text(item.get("base_decision")) or "selected"
+            selected = bool(item.get("selected"))
+            decision = "selected" if selected else (base_decision if base_decision != "selected" else "editor_excluded")
+            if selected and base_decision != "selected":
+                reasons = ["manual_restore", base_decision, *reasons]
+            elif not selected and base_decision == "selected":
+                reasons = ["editor_excluded", *reasons]
+
+            decision_payload = {
+                "article_id": int(item["article_id"]),
+                "title": title,
+                "source_name": clean_text(item.get("source_name")) or clean_text(str(article.get("source_name") or "")),
+                "published_at": clean_text(item.get("published_at")) or clean_text(str(article.get("published_at") or "")),
+                "rank_score": float(item.get("rank_score") or article.get("rank_score") or 0.0),
+                "selection_reasons": reasons,
+                "decision": decision,
+                "duplicate_count": int(item.get("duplicate_count") or article.get("duplicate_count") or 1),
+                "is_pinned": bool(item.get("is_pinned") or article.get("is_pinned")),
+                "must_include": bool(item.get("must_include") or article.get("must_include")),
+                "is_suppressed": bool(item.get("is_suppressed") or article.get("is_suppressed")),
+                "manual_rank": item.get("manual_rank"),
+                "section": section_title,
+                "publish_summary": summary,
+            }
+            selection_decisions.append(decision_payload)
+            if selected:
+                selected_article = dict(article)
+                selected_article["display_title_zh"] = title
+                selected_article["display_summary_zh"] = summary
+                selected_article["compact_summary_zh"] = summary
+                selected_article["display_brief_zh"] = summary
+                selected_article["section_override"] = section_title
+                selected_article["manual_rank"] = item.get("manual_rank")
+                selected_article["rank_score"] = float(item.get("rank_score") or article.get("rank_score") or 0.0)
+                selected_articles.append(selected_article)
+                selection_preview.append(decision_payload)
+            elif decision == "duplicate_secondary":
+                duplicates_suppressed += 1
+            elif decision == "suppressed":
+                editorially_suppressed += 1
+            else:
+                ranked_out += 1
+
+        selected_articles.sort(
+            key=lambda article: (
+                int(article.get("manual_rank") or 10_000),
+                -float(article.get("rank_score") or 0.0),
+                -(
+                    parse_datetime(clean_text(str(article.get("published_at") or ""))).timestamp()
+                    if parse_datetime(clean_text(str(article.get("published_at") or "")))
+                    else 0.0
+                ),
+            )
+        )
+        selection_preview.sort(
+            key=lambda item: (
+                int(item.get("manual_rank") or 10_000),
+                -float(item.get("rank_score") or 0.0),
+            )
+        )
+        selection_decisions.sort(
+            key=lambda item: (
+                0 if item.get("decision") == "selected" else 1,
+                int(item.get("manual_rank") or 10_000),
+                -float(item.get("rank_score") or 0.0),
+                clean_text(str(item.get("published_at") or "")),
+            )
+        )
+        return {
+            "selected_articles": selected_articles,
+            "selection_preview": selection_preview,
+            "selection_decisions": selection_decisions,
+            "summary": {
+                "candidate_articles": len(snapshot_items),
+                "unique_candidates": len(snapshot_items) - duplicates_suppressed,
+                "selected_count": len(selected_articles),
+                "duplicates_suppressed": duplicates_suppressed,
+                "editorially_suppressed": editorially_suppressed,
+                "ranked_out": ranked_out,
+                "pinned_selected": sum(1 for item in selected_articles if item.get("is_pinned")),
+                "must_include_selected": sum(1 for item in selected_articles if item.get("must_include")),
+            },
+        }
+
+    def _build_snapshot_digest(
+        self,
+        articles: List[dict],
+        *,
+        region: str,
+        since_hours: int,
+    ) -> DailyDigest:
+        region_names = {
+            "all": "全网",
+            "domestic": "国内",
+            "international": "国际",
+        }
+        highlights = [
+            f"{article['display_title_zh']} | {article['source_name']}" for article in articles[:4]
+        ]
+        sections: List[Dict[str, object]] = []
+        section_index: Dict[str, int] = {}
+        for article in articles:
+            section_title = clean_text(str(article.get("section_override") or "")) or self._default_digest_section_title(article)
+            brief = clean_text(str(article.get("display_brief_zh", "")))
+            summary = clean_text(str(article.get("compact_summary_zh", "")))
+            line = f"{article['display_title_zh']}。{brief or summary}"
+            if section_title not in section_index:
+                section_index[section_title] = len(sections)
+                sections.append({"title": section_title, "items": []})
+            sections[section_index[section_title]]["items"].append(line)
+
+        return DailyDigest(
+            title=f"{format_local_date()} {region_names.get(region, '全网')} AI 新闻日报",
+            overview=f"最近 {since_hours} 小时已冻结 {len(articles)} 条 AI 新闻用于本次发布。",
+            highlights=highlights,
+            sections=sections,
+            closing="以上内容基于已确认的编辑稿生成，发布前仍可继续复核。",
+        )
+
+    def _mark_editor_snapshot_published(self, payload: Dict[str, object]) -> Dict[str, object]:
+        snapshot = dict(payload.get("editor_snapshot") or {})
+        snapshot["snapshot_status"] = "published"
+        snapshot["last_published_at"] = utc_now().isoformat()
+        snapshot["updated_at"] = utc_now().isoformat()
+        updated_payload = dict(payload)
+        updated_payload["editor_snapshot"] = snapshot
+        return updated_payload
 
     @staticmethod
     def _digest_rank(article: dict) -> tuple[float, List[str]]:
@@ -2775,6 +3240,14 @@ class NewsService:
         stored_payload = stored_digest.get("payload")
         if isinstance(stored_payload, dict) and stored_payload.get("digest"):
             payload = dict(stored_payload)
+            if not isinstance(payload.get("editor_snapshot"), dict):
+                articles = [dict(article) for article in list(payload.get("articles") or [])]
+                selection = self._build_digest_selection(articles)
+                payload["editor_snapshot"] = self._build_editor_snapshot(
+                    articles,
+                    selection,
+                    snapshot_status="draft",
+                )
             payload["stored_digest"] = stored_digest
             payload["generation_mode"] = "stored"
             return payload
@@ -2809,11 +3282,25 @@ class NewsService:
                 "pinned_selected": 0,
                 "must_include_selected": 0,
             },
+            "editor_snapshot": {
+                "snapshot_status": "draft",
+                "frozen_at": "",
+                "updated_at": "",
+                "last_published_at": "",
+                "items": [],
+            },
             "digest": dict(stored_digest.get("payload", {})),
             "body_markdown": str(stored_digest.get("body_markdown", "")),
             "generation_mode": "stored",
             "stored_digest": stored_digest,
         }
+
+    @staticmethod
+    def _payload_for_storage(payload: Dict[str, object]) -> Dict[str, object]:
+        stored_payload = dict(payload)
+        stored_payload.pop("stored_digest", None)
+        stored_payload.pop("operation", None)
+        return stored_payload
 
     def _export_digest_payload(self, payload: Dict[str, object]) -> List[str]:
         date_prefix = format_local_date().replace("-", "")

--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -1,6 +1,7 @@
 const state = {
   token: localStorage.getItem("ainews_admin_token") || "",
   currentDigest: null,
+  currentDigestPayload: null,
   currentArticles: [],
   selectedDigestId: null,
 };
@@ -13,6 +14,8 @@ const refs = {
   extractButton: document.getElementById("extractButton"),
   enrichButton: document.getElementById("enrichButton"),
   digestPreviewButton: document.getElementById("digestPreviewButton"),
+  freezeDigestButton: document.getElementById("freezeDigestButton"),
+  saveDigestEditorButton: document.getElementById("saveDigestEditorButton"),
   digestButton: document.getElementById("digestButton"),
   pipelineButton: document.getElementById("pipelineButton"),
   publishButton: document.getElementById("publishButton"),
@@ -23,6 +26,7 @@ const refs = {
   resetSourceCooldownsButton: document.getElementById("resetSourceCooldownsButton"),
   digestView: document.getElementById("digestView"),
   digestPreviewView: document.getElementById("digestPreviewView"),
+  digestEditorView: document.getElementById("digestEditorView"),
   digestArchive: document.getElementById("digestArchive"),
   articlesList: document.getElementById("articlesList"),
   regionSelect: document.getElementById("regionSelect"),
@@ -499,9 +503,11 @@ function renderDigest(payload) {
   if (!digest) {
     refs.digestView.innerHTML = '<p class="muted">还没有生成日报。</p>';
     refs.digestPreviewView.innerHTML = '<p class="muted">还没有预览结果。点击“选稿预览”或生成日报后会显示这里。</p>';
+    refs.digestEditorView.innerHTML = '<p class="muted">先生成预览或打开一份已保存的日报，编辑页才会出现。</p>';
     return;
   }
   state.currentDigest = digest;
+  state.currentDigestPayload = digestPayload;
   const highlights = (digest.highlights || [])
     .map((item) => `<li>${escapeHtml(item)}</li>`)
     .join("");
@@ -541,6 +547,7 @@ function renderDigest(payload) {
     ${digest.closing ? `<p class="article-brief">${escapeHtml(digest.closing)}</p>` : ""}
   `;
   renderDigestPreview(digestPayload);
+  renderDigestEditor(digestPayload);
 }
 
 function decisionLabel(decision) {
@@ -562,6 +569,18 @@ function decisionStatusClass(decision) {
   if (decision === "selected") return "status-good";
   if (decision === "ranked_out" || decision === "duplicate_secondary") return "status-pending";
   return "status-warn";
+}
+
+function snapshotStatusClass(status) {
+  if (status === "published") return "status-good";
+  if (status === "draft") return "status-pending";
+  return "";
+}
+
+function snapshotStatusLabel(status) {
+  if (status === "published") return "已发布快照";
+  if (status === "draft") return "编辑稿";
+  return "预览";
 }
 
 function renderDigestPreview(payload) {
@@ -598,6 +617,74 @@ function renderDigestPreview(payload) {
   `;
 }
 
+function renderDigestEditor(payload) {
+  const snapshot = payload?.editor_snapshot || null;
+  const items = snapshot?.items || [];
+  if (!items.length) {
+    refs.digestEditorView.innerHTML = '<p class="muted">先生成预览或打开一份已保存的日报，编辑页才会出现。</p>';
+    return;
+  }
+  const summary = payload?.selection_summary || {};
+  refs.digestEditorView.innerHTML = `
+    <p class="article-brief">
+      <span class="chip ${snapshotStatusClass(snapshot.snapshot_status)}">${escapeHtml(snapshotStatusLabel(snapshot.snapshot_status))}</span>
+      <span class="chip">候选 ${escapeHtml(String(summary.candidate_articles || items.length))}</span>
+      <span class="chip">入选 ${escapeHtml(String(summary.selected_count || 0))}</span>
+      ${
+        snapshot.last_published_at
+          ? `<span class="chip">最近发布 ${escapeHtml(snapshot.last_published_at)}</span>`
+          : ""
+      }
+    </p>
+    ${items
+      .map(
+        (item) => `
+          <article class="publication-card digest-editor-item" data-article-id="${item.article_id}">
+            <header class="publication-head">
+              <div>
+                <strong>${escapeHtml(item.original_title || "")}</strong>
+                <div class="publication-meta">
+                  <span>${escapeHtml(item.source_name || "")}</span>
+                  <span>${escapeHtml(item.published_at || "")}</span>
+                </div>
+              </div>
+              <div class="chip-row compact">
+                <span class="chip ${decisionStatusClass(item.base_decision === "selected" || item.selected ? "selected" : item.base_decision)}">${escapeHtml(decisionLabel(item.base_decision || "selected"))}</span>
+                <span class="chip">score ${escapeHtml(String(item.rank_score || 0))}</span>
+                ${item.must_include ? '<span class="chip">must_include</span>' : ""}
+                ${item.is_pinned ? '<span class="chip">pinned</span>' : ""}
+              </div>
+            </header>
+            <div class="form-grid digest-editor-grid">
+              <label class="check-label">
+                <input data-role="selected" type="checkbox" ${item.selected ? "checked" : ""} />
+                纳入发布稿
+              </label>
+              <label>
+                排序
+                <input data-role="manual-rank" type="number" min="1" max="999" value="${escapeAttribute(String(item.manual_rank || ""))}" />
+              </label>
+              <label>
+                分组标题
+                <input data-role="section-override" type="text" placeholder="${escapeAttribute(item.default_section || "")}" value="${escapeAttribute(item.section_override || "")}" />
+              </label>
+            </div>
+            <label>
+              发布标题
+              <input data-role="publish-title-override" type="text" placeholder="${escapeAttribute(item.original_title || "")}" value="${escapeAttribute(item.publish_title_override || "")}" />
+            </label>
+            <label>
+              发布摘要
+              <textarea data-role="publish-summary-override" placeholder="${escapeAttribute(item.original_summary || "")}">${escapeHtml(item.publish_summary_override || "")}</textarea>
+            </label>
+            <p class="article-brief"><strong>原因：</strong>${escapeHtml((item.selection_reasons || []).join(", ") || "none")}</p>
+          </article>
+        `
+      )
+      .join("")}
+  `;
+}
+
 function renderArchive(digests) {
   refs.digestArchive.innerHTML = digests.length
     ? digests
@@ -606,6 +693,11 @@ function renderArchive(digests) {
           <article class="archive-item" data-digest-id="${item.id}">
             <strong>${escapeHtml(item.title)}</strong>
             <p class="muted">${escapeHtml(item.generated_at)} · ${escapeHtml(item.region)} · ${item.article_count} 篇</p>
+            ${
+              item.payload?.editor_snapshot?.snapshot_status
+                ? `<div class="chip-row compact"><span class="chip ${snapshotStatusClass(item.payload.editor_snapshot.snapshot_status)}">${escapeHtml(snapshotStatusLabel(item.payload.editor_snapshot.snapshot_status))}</span></div>`
+                : ""
+            }
             <button class="button ghost" data-action="open-digest" data-digest-id="${item.id}">查看</button>
           </article>
         `
@@ -1204,6 +1296,63 @@ async function previewDigest() {
   renderDigest(payload);
 }
 
+function collectDigestEditorItems() {
+  return Array.from(refs.digestEditorView.querySelectorAll(".digest-editor-item")).map((card) => {
+    const articleId = Number(card.dataset.articleId);
+    const selected = card.querySelector('[data-role="selected"]').checked;
+    const manualRankRaw = card.querySelector('[data-role="manual-rank"]').value.trim();
+    return {
+      article_id: articleId,
+      selected,
+      manual_rank: manualRankRaw ? Number(manualRankRaw) : null,
+      section_override: card.querySelector('[data-role="section-override"]').value.trim() || null,
+      publish_title_override:
+        card.querySelector('[data-role="publish-title-override"]').value.trim() || null,
+      publish_summary_override:
+        card.querySelector('[data-role="publish-summary-override"]').value.trim() || null,
+    };
+  });
+}
+
+async function freezeDigestSnapshot() {
+  const filters = getFilters();
+  const payload = await fetchJson("/admin/digests/snapshot", {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      region: filters.region,
+      since_hours: filters.since_hours,
+      limit: filters.limit,
+      use_llm: true,
+      article_ids: (state.currentDigestPayload?.articles || []).map((item) => item.id),
+      editor_items: collectDigestEditorItems(),
+    }),
+  });
+  logJob("freeze digest snapshot", payload);
+  renderDigest(payload);
+  setSelectedDigestId(payload.stored_digest?.id || payload.digest?.stored_digest?.id || null);
+  await refreshAll();
+}
+
+async function saveDigestEditor() {
+  const digestId =
+    state.currentDigestPayload?.stored_digest?.id || state.selectedDigestId || null;
+  if (!digestId) {
+    throw new Error("请先冻结为编辑稿，再保存编辑修改");
+  }
+  const payload = await fetchJson(`/admin/digests/${digestId}/editor`, {
+    method: "PATCH",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      editor_items: collectDigestEditorItems(),
+    }),
+  });
+  logJob("save digest editor", payload);
+  renderDigest(payload);
+  setSelectedDigestId(payload.stored_digest?.id || digestId);
+  await refreshAll();
+}
+
 async function runPipeline() {
   const filters = getFilters();
   const payload = await fetchJson("/admin/pipeline", {
@@ -1230,10 +1379,13 @@ async function runPipeline() {
 async function runPublish() {
   const filters = getFilters();
   const targets = getPublishTargets();
+  const digestId =
+    state.currentDigestPayload?.stored_digest?.id || state.selectedDigestId || null;
   const payload = await fetchJson("/admin/publish", {
     method: "POST",
     headers: adminHeaders(),
     body: JSON.stringify({
+      digest_id: digestId,
       region: filters.region,
       since_hours: filters.since_hours,
       limit: filters.limit,
@@ -1292,6 +1444,8 @@ refs.ingestButton.addEventListener("click", () => runIngest().catch((error) => l
 refs.extractButton.addEventListener("click", () => runExtract().catch((error) => logJob("extract failed", { error: error.message })));
 refs.enrichButton.addEventListener("click", () => runEnrich().catch((error) => logJob("enrich failed", { error: error.message })));
 refs.digestPreviewButton.addEventListener("click", () => previewDigest().catch((error) => logJob("digest preview failed", { error: error.message })));
+refs.freezeDigestButton.addEventListener("click", () => freezeDigestSnapshot().catch((error) => logJob("freeze digest snapshot failed", { error: error.message })));
+refs.saveDigestEditorButton.addEventListener("click", () => saveDigestEditor().catch((error) => logJob("save digest editor failed", { error: error.message })));
 refs.digestButton.addEventListener("click", () => runDigest().catch((error) => logJob("digest failed", { error: error.message })));
 refs.pipelineButton.addEventListener("click", () => runPipeline().catch((error) => logJob("pipeline failed", { error: error.message })));
 refs.publishButton.addEventListener("click", () => runPublish().catch((error) => logJob("publish failed", { error: error.message })));

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -189,6 +189,21 @@
         <article class="panel">
           <div class="section-head">
             <div>
+              <p class="eyebrow">Editor</p>
+              <h2>发布前编辑页</h2>
+            </div>
+            <div class="toolbar-row">
+              <button id="freezeDigestButton" class="button ghost">冻结为编辑稿</button>
+              <button id="saveDigestEditorButton" class="button secondary">保存编辑稿</button>
+            </div>
+          </div>
+          <p class="muted">在这里调整最终顺序、分组、发布标题和发布摘要。保存后，发布链路会优先使用当前冻结稿而不是实时重算。</p>
+          <div id="digestEditorView" class="publication-list"></div>
+        </article>
+
+        <article class="panel">
+          <div class="section-head">
+            <div>
               <p class="eyebrow">Archive</p>
                 <h2>历史日报</h2>
               </div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -252,6 +252,92 @@ class ApiTestCase(unittest.TestCase):
         self.assertIn("selection_preview", payload)
         self.assertIn("selection_decisions", payload)
 
+    def test_admin_digest_snapshot_freezes_editor_payload(self) -> None:
+        self._seed_article()
+        self._seed_article(
+            title="Anthropic documents new rollback controls",
+            url="https://example.com/anthropic-rollback",
+        )
+        repository = ArticleRepository(Path(self._temp_dir.name) / "data" / "ainews.db")
+        anthropic_id = next(
+            int(item["id"])
+            for item in repository.list_articles(limit=10, include_hidden=True)
+            if item["title"] == "Anthropic documents new rollback controls"
+        )
+
+        response = self.client.post(
+            "/admin/digests/snapshot",
+            headers={"X-Admin-Token": "secret-token"},
+            json={
+                "region": "all",
+                "since_hours": 72,
+                "limit": 10,
+                "use_llm": False,
+                "editor_items": [
+                    {
+                        "article_id": anthropic_id,
+                        "selected": True,
+                        "manual_rank": 1,
+                        "section_override": "厂商动态",
+                        "publish_title_override": "编辑后标题",
+                        "publish_summary_override": "编辑后摘要",
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["editor_snapshot"]["snapshot_status"], "draft")
+        self.assertTrue(payload["stored_digest"]["id"] >= 1)
+        self.assertEqual(payload["selection_preview"][0]["title"], "编辑后标题")
+
+    def test_admin_digest_editor_update_persists_overrides(self) -> None:
+        self._seed_article()
+        self._seed_article(
+            title="Anthropic documents new rollback controls",
+            url="https://example.com/anthropic-rollback",
+        )
+        create_response = self.client.post(
+            "/admin/digests/snapshot",
+            headers={"X-Admin-Token": "secret-token"},
+            json={
+                "region": "all",
+                "since_hours": 72,
+                "limit": 10,
+                "use_llm": False,
+            },
+        )
+        self.assertEqual(create_response.status_code, 200)
+        created = create_response.json()
+        digest_id = created["stored_digest"]["id"]
+        anthropic_item = next(
+            item
+            for item in created["editor_snapshot"]["items"]
+            if item["original_title"] == "Anthropic documents new rollback controls"
+        )
+
+        update_response = self.client.patch(
+            f"/admin/digests/{digest_id}/editor",
+            headers={"X-Admin-Token": "secret-token"},
+            json={
+                "editor_items": [
+                    {
+                        "article_id": anthropic_item["article_id"],
+                        "selected": True,
+                        "manual_rank": 1,
+                        "publish_title_override": "编辑后标题",
+                        "publish_summary_override": "编辑后摘要",
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(update_response.status_code, 200)
+        payload = update_response.json()
+        self.assertEqual(payload["selection_preview"][0]["title"], "编辑后标题")
+        self.assertEqual(payload["generation_mode"], "editor")
+
     def test_admin_can_promote_duplicate_primary(self) -> None:
         repository = ArticleRepository(Path(self._temp_dir.name) / "data" / "ainews.db")
         published = utc_now()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -506,6 +506,213 @@ class ServiceFilterTestCase(unittest.TestCase):
             )
             self.assertIn("suppressed", suppressed["selection_reasons"])
 
+    def test_create_digest_snapshot_persists_editor_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = Settings(
+                database_path=Path(temp_dir) / "ainews.db",
+                sources_file=Path(temp_dir) / "sources.json",
+            )
+            repository = ArticleRepository(settings.database_path)
+            source = SourceDefinition(
+                id="openai-news",
+                name="OpenAI News",
+                url="https://openai.com/news/rss.xml",
+                region="international",
+                language="en",
+                country="US",
+                topic="company",
+            )
+            now = utc_now()
+            repository.insert_if_new(
+                ArticleRecord(
+                    source_id=source.id,
+                    source_name=source.name,
+                    title="OpenAI launches enterprise governance controls",
+                    url="https://openai.com/index/enterprise-governance",
+                    canonical_url="https://openai.com/index/enterprise-governance",
+                    summary="Direct release coverage.",
+                    published_at=now,
+                    discovered_at=now,
+                    language="en",
+                    region="international",
+                    country="US",
+                    topic="company",
+                    content_hash=make_content_hash(
+                        "OpenAI launches enterprise governance controls",
+                        "Direct release coverage.",
+                    ),
+                    dedup_key=make_dedup_key("OpenAI launches enterprise governance controls"),
+                    raw_payload={},
+                )
+            )
+            repository.insert_if_new(
+                ArticleRecord(
+                    source_id="anthropic-news",
+                    source_name="Anthropic News",
+                    title="Anthropic documents new rollback controls",
+                    url="https://anthropic.com/news/rollback-controls",
+                    canonical_url="https://anthropic.com/news/rollback-controls",
+                    summary="Another strong enterprise AI story.",
+                    published_at=now,
+                    discovered_at=now,
+                    language="en",
+                    region="international",
+                    country="US",
+                    topic="company",
+                    content_hash=make_content_hash(
+                        "Anthropic documents new rollback controls",
+                        "Another strong enterprise AI story.",
+                    ),
+                    dedup_key=make_dedup_key("Anthropic documents new rollback controls"),
+                    raw_payload={},
+                )
+            )
+            article_ids = [int(item["id"]) for item in repository.list_articles(limit=10, include_hidden=True)]
+            anthropic_id = next(
+                int(item["id"])
+                for item in repository.list_articles(limit=10, include_hidden=True)
+                if item["source_id"] == "anthropic-news"
+            )
+            service = NewsService(
+                settings,
+                repository=repository,
+                source_registry=StubRegistry([source]),
+            )
+
+            snapshot = service.create_digest_snapshot(
+                region="all",
+                article_ids=article_ids,
+                since_hours=24,
+                limit=10,
+                use_llm=False,
+                editor_items=[
+                    {
+                        "article_id": anthropic_id,
+                        "selected": True,
+                        "manual_rank": 1,
+                        "section_override": "厂商动态",
+                        "publish_title_override": "编辑后：Anthropic 回滚控制",
+                        "publish_summary_override": "编辑后摘要",
+                    }
+                ],
+            )
+
+            self.assertEqual(snapshot["editor_snapshot"]["snapshot_status"], "draft")
+            self.assertTrue(snapshot["stored_digest"]["id"] >= 1)
+            self.assertEqual(snapshot["selection_preview"][0]["article_id"], anthropic_id)
+            self.assertEqual(snapshot["selection_preview"][0]["title"], "编辑后：Anthropic 回滚控制")
+            self.assertEqual(snapshot["digest"]["sections"][0]["title"], "厂商动态")
+            self.assertIn("编辑后摘要", snapshot["digest"]["sections"][0]["items"][0])
+
+    def test_update_digest_editor_rewrites_snapshot_and_publish_uses_it(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = Settings(
+                database_path=Path(temp_dir) / "ainews.db",
+                sources_file=Path(temp_dir) / "sources.json",
+            )
+            repository = ArticleRepository(settings.database_path)
+            source = SourceDefinition(
+                id="openai-news",
+                name="OpenAI News",
+                url="https://openai.com/news/rss.xml",
+                region="international",
+                language="en",
+                country="US",
+                topic="company",
+            )
+            now = utc_now()
+            repository.insert_if_new(
+                ArticleRecord(
+                    source_id=source.id,
+                    source_name=source.name,
+                    title="OpenAI launches enterprise governance controls",
+                    url="https://openai.com/index/enterprise-governance",
+                    canonical_url="https://openai.com/index/enterprise-governance",
+                    summary="Direct release coverage.",
+                    published_at=now,
+                    discovered_at=now,
+                    language="en",
+                    region="international",
+                    country="US",
+                    topic="company",
+                    content_hash=make_content_hash(
+                        "OpenAI launches enterprise governance controls",
+                        "Direct release coverage.",
+                    ),
+                    dedup_key=make_dedup_key("OpenAI launches enterprise governance controls"),
+                    raw_payload={},
+                )
+            )
+            repository.insert_if_new(
+                ArticleRecord(
+                    source_id="anthropic-news",
+                    source_name="Anthropic News",
+                    title="Anthropic documents new rollback controls",
+                    url="https://anthropic.com/news/rollback-controls",
+                    canonical_url="https://anthropic.com/news/rollback-controls",
+                    summary="Another strong enterprise AI story.",
+                    published_at=now,
+                    discovered_at=now,
+                    language="en",
+                    region="international",
+                    country="US",
+                    topic="company",
+                    content_hash=make_content_hash(
+                        "Anthropic documents new rollback controls",
+                        "Another strong enterprise AI story.",
+                    ),
+                    dedup_key=make_dedup_key("Anthropic documents new rollback controls"),
+                    raw_payload={},
+                )
+            )
+            service = NewsService(
+                settings,
+                repository=repository,
+                source_registry=StubRegistry([source]),
+                publisher=StubPublisher(),
+            )
+            created = service.create_digest_snapshot(
+                region="all",
+                article_ids=[
+                    int(item["id"])
+                    for item in repository.list_articles(limit=10, include_hidden=True)
+                ],
+                since_hours=24,
+                limit=10,
+                use_llm=False,
+            )
+            digest_id = int(created["stored_digest"]["id"])
+            item_by_source = {
+                item["source_name"]: item for item in created["editor_snapshot"]["items"]
+            }
+            updated = service.update_digest_editor(
+                digest_id,
+                editor_items=[
+                    {
+                        "article_id": item_by_source["Anthropic News"]["article_id"],
+                        "selected": True,
+                        "manual_rank": 1,
+                        "publish_title_override": "编辑后：Anthropic 优先",
+                        "publish_summary_override": "编辑后摘要 A",
+                    },
+                    {
+                        "article_id": item_by_source["OpenAI News"]["article_id"],
+                        "selected": True,
+                        "manual_rank": 2,
+                        "publish_summary_override": "编辑后摘要 B",
+                    },
+                ],
+            )
+
+            self.assertEqual(updated["selection_preview"][0]["title"], "编辑后：Anthropic 优先")
+            self.assertEqual(updated["generation_mode"], "editor")
+            publish_result = service.publish_digest(digest_id=digest_id, targets=["static_site"])
+            self.assertEqual(publish_result["digest"]["selection_preview"][0]["title"], "编辑后：Anthropic 优先")
+            self.assertEqual(
+                publish_result["digest"]["editor_snapshot"]["snapshot_status"],
+                "published",
+            )
+
     def test_enrich_and_digest_with_llm_client(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             settings = Settings(


### PR DESCRIPTION
## Summary
- add frozen digest snapshots with editable ranking, section, title, and summary overrides
- add admin API and dashboard support for snapshot freeze/save and publish-from-snapshot behavior
- document the new digest editor workflow and compatibility surface

## Verification
- make check PYTHON=./.venv-dev/bin/python
- node --check src/ainews/web/app.js