### PR TITLE
chore: prepare v1.2.46 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.46] - 2026-04-11
+
+### Added
+
+- Frozen digest snapshot support with editable `manual_rank`, `section_override`, `publish_title_override`, and `publish_summary_override` fields
+- New admin routes `POST /admin/digests/snapshot` and `PATCH /admin/digests/{digest_id}/editor` for saving and revising publishable digest drafts
+
+### Changed
+
+- Package version is now `1.2.46`
+- Publish flows now prefer a stored digest snapshot when `digest_id` is supplied, so outbound content matches the reviewed editor state instead of a live recompute
+- The admin dashboard now includes a dedicated pre-publish digest editor panel for freezing, revising, and reviewing publish-time decisions
+
+### Fixed
+
+- Preserved editor snapshot state through stored digest payload reloads so previously archived digests can still be edited and republished safely
+- Kept digest compatibility docs and bilingual README guidance aligned with the new preview-to-snapshot publishing workflow
+
 ## [1.2.45] - 2026-04-10
 
 ### Added

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.44`
+`v1.2.46`
 
 ### Suggested Title
 
-`AI News Open v1.2.44 · Replay Note and Waiver Checklist Coverage`
+`AI News Open v1.2.46 · Frozen Digest Snapshot Editing`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.44
+## AI News Open v1.2.46
 
-AI News Open `v1.2.44` hardens extraction quality for override-approval-replay-note, continuity-revalidation-waiver-checklist, and audit-replay-waiver-escalation-faq layouts across more developer-doc publishers.
+AI News Open `v1.2.46` adds a frozen digest snapshot workflow so maintainers can preview, edit, save, and publish a confirmed digest draft instead of relying on a live recompute at publish time.
 
 ### What it does
 
@@ -40,10 +40,10 @@ AI News Open `v1.2.44` hardens extraction quality for override-approval-replay-n
 
 ### Highlights in this release
 
-- New deterministic override-approval-replay-note, continuity-revalidation-waiver-checklist, and audit-replay-waiver-escalation-faq fixtures for `OpenAI`, `Anthropic`, and `Together`
-- Better cleanup for override approval replay summaries, continuity revalidation waiver checklist summaries, audit replay waiver escalation summaries, audit replay matrices, and related-guide recirculation on developer policy pages
-- The international extraction suite now covers standard articles, live updates, briefing pages, multimedia-heavy pages, opinion layouts, paywall-heavy layouts, explainer/guide layouts, roundup/what-to-know layouts, interview/transcript layouts, longform analysis layouts, policy/research feature layouts, vendor benchmark layouts, conference recap layouts, vendor documentation layouts, API-reference/changelog layouts, migration/deprecation layouts, versioned-doc-notice layouts, support-policy layouts, compatibility-matrix layouts, release-channel-note layouts, incident-update layouts, postmortem layouts, outage-RCA layouts, security-bulletin layouts, trust-center-advisory layouts, compliance-update layouts, pricing-update layouts, service-tier-notice layouts, SKU-change layouts, usage-limit-notice layouts, rate-limit-update layouts, quota-policy layouts, burst-cap-notice layouts, concurrency-cap-update layouts, regional-quota-advisory layouts, soft-limit-warning layouts, grace-period-notice layouts, throughput-exception-policy layouts, temporary-overage-notice layouts, fairness-policy-update layouts, capacity-reservation-note layouts, burst-credit-notice layouts, queue-priority-update layouts, reservation-rollover-policy layouts, burst-credit-faq layouts, priority-escalation-guide layouts, rollover-exception-policy layouts, burst-credit-recovery-note layouts, escalation-rollback-checklist layouts, rollover-eligibility-guide layouts, burst-credit-recovery-faq layouts, rollback-exception-note layouts, eligibility-edge-case-advisory layouts, recovery-grace-period-note layouts, rollback-approval-matrix layouts, eligibility-exception-faq layouts, recovery-exception-matrix layouts, continuity-waiver-faq layouts, audit-restoration-checklist layouts, recovery-override-matrix layouts, continuity-exception-checklist layouts, audit-replay-faq layouts, recovery-override-faq layouts, continuity-revalidation-matrix layouts, audit-replay-checklist layouts, override-escalation-checklist layouts, continuity-revalidation-faq layouts, audit-replay-exception-matrix layouts, override-approval-matrix layouts, continuity-revalidation-checklist layouts, audit-replay-waiver-faq layouts, override-approval-faq layouts, continuity-revalidation-exception-matrix layouts, audit-replay-waiver-checklist layouts, override-approval-incident-note layouts, continuity-revalidation-waiver-faq layouts, audit-replay-waiver-exception-matrix layouts, override-approval-replay-note layouts, continuity-revalidation-waiver-checklist layouts, and audit-replay-waiver-escalation-faq layouts
-- Published-artifact smoke validation still runs automatically after release publication
+- New digest snapshot APIs for freezing a preview into a stored editable draft and updating that draft in place
+- New dashboard editor controls for manual rank, section overrides, publish title overrides, and publish summary overrides
+- Publish flows now reuse the confirmed snapshot behind a stored `digest_id`, which removes preview-versus-publish drift when new articles arrive between review and send
+- Compatibility docs and bilingual README guidance now describe the preview, snapshot, editor, and publish-from-snapshot contract
 
 ### Quick start
 

--- a/docs/releases/v1.2.46.md
+++ b/docs/releases/v1.2.46.md
@@ -1,0 +1,13 @@
+# AI News Open v1.2.46
+
+## Highlights
+
+- Added frozen digest snapshots so operators can turn a preview into a stored editable draft before publication.
+- Added digest editor controls for `manual_rank`, `section_override`, `publish_title_override`, and `publish_summary_override`.
+- Updated publication flow to publish the confirmed snapshot behind `digest_id` instead of recomputing selection at send time.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `node --check src/ainews/web/app.js`
+- `Release Artifact Smoke`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.45"
+version = "1.2.46"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.45"
+__version__ = "1.2.46"


### PR DESCRIPTION
## Summary
- bump package version to v1.2.46
- add changelog entry and release notes for the frozen digest snapshot editor workflow
- refresh the GitHub launch kit release copy

## Verification
- make check PYTHON=./.venv-dev/bin/python