### PR TITLE
chore: update package author and maintainer metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 authors = [
-  { name = "Open Source Contributors" }
+  { name = "X-PG13", email = "2720174336@qq.com" }
 ]
 maintainers = [
   { name = "X-PG13", email = "2720174336@qq.com" }


### PR DESCRIPTION
## Summary
- update the package `authors` metadata to use the public maintainer identity
- keep the existing maintainer metadata aligned with the same name and email

## Why
The repository metadata still used a placeholder author entry. This change makes the published package metadata match the actual public maintainer identity already used elsewhere in the repository.

## Validation
- inspected the resulting `pyproject.toml` metadata locally
