### PR TITLE
feat: add versioned digest snapshots and publish previews

### DIFF
--- a/src/ainews/api.py
+++ b/src/ainews/api.py
@@ -76,10 +76,20 @@ class DigestSnapshotRequest(BaseModel):
     limit: int = Field(default=30, ge=1, le=200)
     use_llm: bool = True
     editor_items: Optional[List[DigestEditorItemRequest]] = None
+    actor: Optional[str] = Field(default=None, max_length=80)
+    change_summary: Optional[str] = Field(default=None, max_length=240)
 
 
 class DigestEditorUpdateRequest(BaseModel):
     editor_items: List[DigestEditorItemRequest] = Field(min_length=1)
+    actor: Optional[str] = Field(default=None, max_length=80)
+    change_summary: Optional[str] = Field(default=None, max_length=240)
+
+
+class DigestRollbackRequest(BaseModel):
+    version: int = Field(ge=1)
+    actor: Optional[str] = Field(default=None, max_length=80)
+    change_summary: Optional[str] = Field(default=None, max_length=240)
 
 
 class PipelineRequest(BaseModel):
@@ -107,6 +117,15 @@ class PublishRequest(BaseModel):
     targets: Optional[List[str]] = None
     wechat_submit: Optional[bool] = None
     force_republish: bool = False
+
+
+class PublishPreviewRequest(BaseModel):
+    digest_id: Optional[int] = Field(default=None, ge=1)
+    region: str = Field(default="all")
+    since_hours: Optional[int] = Field(default=None, ge=1, le=720)
+    limit: int = Field(default=30, ge=1, le=200)
+    use_llm: bool = True
+    targets: Optional[List[str]] = None
 
 
 class RefreshPublicationsRequest(BaseModel):
@@ -904,6 +923,8 @@ def create_app() -> FastAPI:
                 limit=payload.limit,
                 use_llm=payload.use_llm,
                 editor_items=[item.model_dump() for item in list(payload.editor_items or [])],
+                actor=payload.actor or "",
+                change_summary=payload.change_summary or "",
             ))
         except HTTPException as exc:
             return _handle_route_http_exception(request, exc)
@@ -926,6 +947,51 @@ def create_app() -> FastAPI:
             return _sanitize_service_payload(service.update_digest_editor(
                 digest_id,
                 editor_items=[item.model_dump() for item in payload.editor_items],
+                actor=payload.actor or "",
+                change_summary=payload.change_summary or "",
+            ))
+        except HTTPException as exc:
+            return _handle_route_http_exception(request, exc)
+        except LookupError:
+            return _handle_route_lookup_error(request)
+        except ValueError:
+            return _handle_route_value_error(request)
+        except Exception:
+            return _handle_route_unexpected_error(request)
+
+    @app.get("/admin/digests/{digest_id}/history")
+    def admin_digest_history(
+        digest_id: int,
+        request: Request,
+        limit: int = Query(default=20, ge=1, le=100),
+        _: None = Depends(require_admin),
+    ) -> dict:
+        _begin_route_action(request, "admin_digest_history")
+        try:
+            return _sanitize_service_payload(service.list_digest_versions(digest_id, limit=limit))
+        except HTTPException as exc:
+            return _handle_route_http_exception(request, exc)
+        except LookupError:
+            return _handle_route_lookup_error(request)
+        except ValueError:
+            return _handle_route_value_error(request)
+        except Exception:
+            return _handle_route_unexpected_error(request)
+
+    @app.post("/admin/digests/{digest_id}/rollback")
+    def admin_digest_rollback(
+        digest_id: int,
+        payload: DigestRollbackRequest,
+        request: Request,
+        _: None = Depends(require_admin),
+    ) -> dict:
+        _begin_route_action(request, "admin_digest_rollback")
+        try:
+            return _sanitize_service_payload(service.rollback_digest_snapshot(
+                digest_id,
+                version=payload.version,
+                actor=payload.actor or "",
+                change_summary=payload.change_summary or "",
             ))
         except HTTPException as exc:
             return _handle_route_http_exception(request, exc)
@@ -985,6 +1051,31 @@ def create_app() -> FastAPI:
                 targets=payload.targets,
                 wechat_submit=payload.wechat_submit,
                 force_republish=payload.force_republish,
+            ))
+        except HTTPException as exc:
+            return _handle_route_http_exception(request, exc)
+        except LookupError:
+            return _handle_route_lookup_error(request)
+        except ValueError:
+            return _handle_route_value_error(request)
+        except Exception:
+            return _handle_route_unexpected_error(request)
+
+    @app.post("/admin/publish/preview")
+    def admin_publish_preview(
+        payload: PublishPreviewRequest,
+        request: Request,
+        _: None = Depends(require_admin),
+    ) -> dict:
+        _begin_route_action(request, "admin_publish_preview")
+        try:
+            return _sanitize_service_payload(service.preview_publication_targets(
+                digest_id=payload.digest_id,
+                region=payload.region,
+                since_hours=payload.since_hours,
+                limit=payload.limit,
+                use_llm=payload.use_llm,
+                targets=payload.targets,
             ))
         except HTTPException as exc:
             return _handle_route_http_exception(request, exc)

--- a/src/ainews/publisher.py
+++ b/src/ainews/publisher.py
@@ -173,6 +173,31 @@ class DigestPublisher:
         )
         return payload
 
+    def preview(
+        self,
+        payload: Dict[str, object],
+        *,
+        targets: Optional[Iterable[str]] = None,
+    ) -> Dict[str, object]:
+        requested = self._normalize_targets(targets)
+        if not requested:
+            requested = self._normalize_targets(self.settings.publish_targets.split(","))
+        if not requested:
+            requested = ["telegram", "feishu", "static_site", "wechat"]
+
+        previews = []
+        for target in requested:
+            previews.append(
+                {
+                    "target": target,
+                    "preview": self._preview_target(target, payload),
+                }
+            )
+        return {
+            "requested_targets": requested,
+            "targets": previews,
+        }
+
     def _publish_target(
         self,
         target: str,
@@ -189,6 +214,41 @@ class DigestPublisher:
         if target == "wechat":
             submit = self.settings.wechat_publish_after_draft if wechat_submit is None else wechat_submit
             return self._publish_wechat(payload, submit=submit)
+        raise ValueError(f"unsupported publish target: {target}")
+
+    def _preview_target(self, target: str, payload: Dict[str, object]) -> Dict[str, object]:
+        if target == "telegram":
+            text = self._render_plain_text(payload)
+            return {
+                "text": text,
+                "chunks": self._split_text(text, max_chars=4000),
+            }
+        if target == "feishu":
+            text_body = self._build_feishu_text_body(payload)
+            card_body = self._build_feishu_card_body(payload)
+            card = card_body.get("card", {}) if isinstance(card_body, dict) else {}
+            header = card.get("header", {}) if isinstance(card, dict) else {}
+            return {
+                "text": clean_text(str((text_body.get("content") or {}).get("text") or "")),
+                "card": card_body,
+                "card_title": clean_text(str((header.get("title") or {}).get("content") or "")),
+            }
+        if target == "static_site":
+            return {
+                "html": self._render_static_site_html(payload),
+            }
+        if target == "wechat":
+            digest = payload.get("digest") or {}
+            articles = payload.get("articles") or []
+            primary_link = clean_text(self.settings.wechat_content_source_url)
+            if not primary_link and articles:
+                primary_link = clean_text(str(articles[0].get("url", "")))
+            return {
+                "title": self._wechat_title(str(digest.get("title", "AI 新闻日报"))),
+                "digest": truncate_text(str(digest.get("overview", "")), 120),
+                "content_source_url": primary_link,
+                "content_html": self._render_wechat_content(payload),
+            }
         raise ValueError(f"unsupported publish target: {target}")
 
     def _publish_telegram(self, payload: Dict[str, object]) -> PublicationResult:

--- a/src/ainews/repository.py
+++ b/src/ainews/repository.py
@@ -3278,22 +3278,22 @@ class ArticleRepository:
             publication_rows = connection.execute(
                 """
                 SELECT
-                    id,
-                    digest_id,
-                    digest_snapshot_version,
-                    target,
-                    status,
-                    external_id,
-                    message,
-                    response_payload,
-                    created_at,
-                    updated_at,
+                    publications.id,
+                    publications.digest_id,
+                    publications.digest_snapshot_version,
+                    publications.target,
+                    publications.status,
+                    publications.external_id,
+                    publications.message,
+                    publications.response_payload,
+                    publications.created_at,
+                    publications.updated_at,
                     COALESCE(d.current_version, 0) AS current_digest_version
                 FROM publications
                 LEFT JOIN digests AS d
                     ON d.id = publications.digest_id
                 WHERE publications.digest_id = ?
-                ORDER BY created_at DESC
+                ORDER BY publications.created_at DESC
                 """,
                 (digest_id,),
             ).fetchall()

--- a/src/ainews/repository.py
+++ b/src/ainews/repository.py
@@ -49,9 +49,18 @@ ARTICLE_EXTRA_COLUMNS = {
 
 PUBLICATION_EXTRA_COLUMNS = {
     "updated_at": "TEXT NOT NULL DEFAULT ''",
+    "digest_snapshot_version": "INTEGER NOT NULL DEFAULT 0",
 }
 
-CURRENT_SCHEMA_VERSION = 12
+DIGEST_EXTRA_COLUMNS = {
+    "updated_at": "TEXT NOT NULL DEFAULT ''",
+    "current_version": "INTEGER NOT NULL DEFAULT 1",
+    "created_by": "TEXT NOT NULL DEFAULT ''",
+    "updated_by": "TEXT NOT NULL DEFAULT ''",
+    "change_summary": "TEXT NOT NULL DEFAULT ''",
+}
+
+CURRENT_SCHEMA_VERSION = 13
 
 ARTICLE_SELECT_COLUMNS = """
     articles.id,
@@ -208,12 +217,32 @@ class ArticleRepository:
                     article_count INTEGER NOT NULL,
                     source_count INTEGER NOT NULL,
                     generated_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT '',
+                    current_version INTEGER NOT NULL DEFAULT 1,
+                    created_by TEXT NOT NULL DEFAULT '',
+                    updated_by TEXT NOT NULL DEFAULT '',
+                    change_summary TEXT NOT NULL DEFAULT '',
                     payload TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS digest_snapshot_versions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    digest_id INTEGER NOT NULL,
+                    version INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    created_by TEXT NOT NULL DEFAULT '',
+                    updated_by TEXT NOT NULL DEFAULT '',
+                    change_summary TEXT NOT NULL DEFAULT '',
+                    action TEXT NOT NULL DEFAULT '',
+                    restored_from_version INTEGER NOT NULL DEFAULT 0,
+                    payload TEXT NOT NULL,
+                    UNIQUE(digest_id, version)
                 );
 
                 CREATE TABLE IF NOT EXISTS publications (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     digest_id INTEGER,
+                    digest_snapshot_version INTEGER NOT NULL DEFAULT 0,
                     target TEXT NOT NULL,
                     status TEXT NOT NULL,
                     external_id TEXT NOT NULL,
@@ -316,6 +345,7 @@ class ArticleRepository:
                 """
             )
             self._ensure_article_migrations(connection)
+            self._ensure_digest_migrations(connection)
             self._ensure_publication_migrations(connection)
             self._ensure_source_state_migrations(connection)
             connection.executescript(
@@ -365,11 +395,23 @@ class ArticleRepository:
                 CREATE INDEX IF NOT EXISTS idx_digests_region_generated_at
                     ON digests(region, generated_at);
 
+                CREATE INDEX IF NOT EXISTS idx_digests_current_version
+                    ON digests(current_version);
+
+                CREATE INDEX IF NOT EXISTS idx_digest_snapshot_versions_digest_version
+                    ON digest_snapshot_versions(digest_id, version DESC);
+
+                CREATE INDEX IF NOT EXISTS idx_digest_snapshot_versions_created_at
+                    ON digest_snapshot_versions(created_at DESC);
+
                 CREATE INDEX IF NOT EXISTS idx_publications_created_at
                     ON publications(created_at);
 
                 CREATE INDEX IF NOT EXISTS idx_publications_digest_target
                     ON publications(digest_id, target, created_at);
+
+                CREATE INDEX IF NOT EXISTS idx_publications_digest_snapshot_version
+                    ON publications(digest_id, digest_snapshot_version, created_at);
 
                 CREATE INDEX IF NOT EXISTS idx_source_states_cooldown_until
                     ON source_states(cooldown_until);
@@ -421,6 +463,20 @@ class ArticleRepository:
                     raise
         self._backfill_article_metadata(connection)
 
+    def _ensure_digest_migrations(self, connection: sqlite3.Connection) -> None:
+        existing_columns = self._table_columns(connection, "digests")
+        for column_name, column_type in DIGEST_EXTRA_COLUMNS.items():
+            if column_name in existing_columns:
+                continue
+            try:
+                connection.execute(
+                    f"ALTER TABLE digests ADD COLUMN {column_name} {column_type}"
+                )
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+        self._backfill_digest_metadata(connection)
+
     def _ensure_publication_migrations(self, connection: sqlite3.Connection) -> None:
         existing_columns = self._table_columns(connection, "publications")
         for column_name, column_type in PUBLICATION_EXTRA_COLUMNS.items():
@@ -433,6 +489,102 @@ class ArticleRepository:
             except sqlite3.OperationalError as exc:
                 if "duplicate column name" not in str(exc).lower():
                     raise
+
+    def _backfill_digest_metadata(self, connection: sqlite3.Connection) -> None:
+        rows = connection.execute(
+            """
+            SELECT
+                id,
+                generated_at,
+                updated_at,
+                current_version,
+                created_by,
+                updated_by,
+                change_summary,
+                payload
+            FROM digests
+            """
+        ).fetchall()
+        for row in rows:
+            digest_id = int(row["id"])
+            payload = json.loads(row["payload"])
+            snapshot = payload.get("editor_snapshot") if isinstance(payload, dict) else {}
+            if not isinstance(snapshot, dict):
+                snapshot = {}
+            generated_at = clean_text(str(row["generated_at"] or ""))
+            updated_at = clean_text(str(row["updated_at"] or "")) or clean_text(
+                str(snapshot.get("updated_at") or "")
+            ) or generated_at
+            current_version = int(
+                row["current_version"]
+                or snapshot.get("version")
+                or 1
+            )
+            created_by = clean_text(str(row["created_by"] or "")) or clean_text(
+                str(snapshot.get("created_by") or "")
+            ) or "system"
+            updated_by = clean_text(str(row["updated_by"] or "")) or clean_text(
+                str(snapshot.get("updated_by") or "")
+            ) or created_by
+            change_summary = clean_text(str(row["change_summary"] or "")) or clean_text(
+                str(snapshot.get("change_summary") or "")
+            ) or "legacy digest snapshot"
+            connection.execute(
+                """
+                UPDATE digests
+                SET
+                    updated_at = ?,
+                    current_version = ?,
+                    created_by = ?,
+                    updated_by = ?,
+                    change_summary = ?
+                WHERE id = ?
+                """,
+                (
+                    updated_at,
+                    current_version,
+                    created_by,
+                    updated_by,
+                    change_summary,
+                    digest_id,
+                ),
+            )
+            existing_versions = connection.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM digest_snapshot_versions
+                WHERE digest_id = ?
+                """,
+                (digest_id,),
+            ).fetchone()
+            if int(existing_versions["total"] or 0) > 0:
+                continue
+            connection.execute(
+                """
+                INSERT INTO digest_snapshot_versions (
+                    digest_id,
+                    version,
+                    created_at,
+                    created_by,
+                    updated_by,
+                    change_summary,
+                    action,
+                    restored_from_version,
+                    payload
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    digest_id,
+                    current_version,
+                    updated_at or generated_at or utc_now().isoformat(),
+                    created_by,
+                    updated_by,
+                    change_summary,
+                    "backfill",
+                    0,
+                    json.dumps(payload, ensure_ascii=False),
+                ),
+            )
 
     def _ensure_source_state_migrations(self, connection: sqlite3.Connection) -> None:
         existing_columns = self._table_columns(connection, "source_states")
@@ -2799,9 +2951,17 @@ class ArticleRepository:
         article_count: int,
         source_count: int,
         payload: Optional[dict] = None,
+        created_by: str = "",
+        updated_by: str = "",
+        change_summary: str = "",
     ) -> dict:
         generated_at = utc_now().isoformat()
+        updated_at = generated_at
         stored_payload = payload or digest.to_dict()
+        created_by_value = clean_text(created_by) or "system"
+        updated_by_value = clean_text(updated_by) or created_by_value
+        change_summary_value = clean_text(change_summary) or "generated digest snapshot"
+        current_version = 1
 
         with self._connect() as connection:
             cursor = connection.execute(
@@ -2816,8 +2976,13 @@ class ArticleRepository:
                     article_count,
                     source_count,
                     generated_at,
+                    updated_at,
+                    current_version,
+                    created_by,
+                    updated_by,
+                    change_summary,
                     payload
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     region,
@@ -2829,10 +2994,27 @@ class ArticleRepository:
                     article_count,
                     source_count,
                     generated_at,
+                    updated_at,
+                    current_version,
+                    created_by_value,
+                    updated_by_value,
+                    change_summary_value,
                     json.dumps(stored_payload, ensure_ascii=False),
                 ),
             )
             digest_id = int(cursor.lastrowid)
+            self._insert_digest_snapshot_version(
+                connection,
+                digest_id=digest_id,
+                version=current_version,
+                created_at=updated_at,
+                created_by=created_by_value,
+                updated_by=updated_by_value,
+                change_summary=change_summary_value,
+                action="create",
+                restored_from_version=0,
+                payload=stored_payload,
+            )
 
         return self.get_digest(digest_id) or {}
 
@@ -2851,6 +3033,11 @@ class ArticleRepository:
                     article_count,
                     source_count,
                     generated_at,
+                    updated_at,
+                    current_version,
+                    created_by,
+                    updated_by,
+                    change_summary,
                     payload
                 FROM digests
                 WHERE id = ?
@@ -2871,7 +3058,11 @@ class ArticleRepository:
         article_count: int,
         source_count: int,
         payload: Dict[str, object],
+        updated_by: Optional[str] = None,
+        change_summary: Optional[str] = None,
+        updated_at: Optional[str] = None,
     ) -> Optional[dict]:
+        updated_at_value = clean_text(updated_at or "") or utc_now().isoformat()
         with self._connect() as connection:
             connection.execute(
                 """
@@ -2883,7 +3074,10 @@ class ArticleRepository:
                     model = ?,
                     article_count = ?,
                     source_count = ?,
-                    payload = ?
+                    payload = ?,
+                    updated_at = ?,
+                    updated_by = COALESCE(?, updated_by),
+                    change_summary = COALESCE(?, change_summary)
                 WHERE id = ?
                 """,
                 (
@@ -2894,8 +3088,92 @@ class ArticleRepository:
                     article_count,
                     source_count,
                     json.dumps(payload, ensure_ascii=False),
+                    updated_at_value,
+                    clean_text(updated_by or "") or None,
+                    clean_text(change_summary or "") or None,
                     digest_id,
                 ),
+            )
+        return self.get_digest(digest_id)
+
+    def save_digest_version(
+        self,
+        digest_id: int,
+        *,
+        title: str,
+        body_markdown: str,
+        provider: str,
+        model: str,
+        article_count: int,
+        source_count: int,
+        payload: Dict[str, object],
+        updated_by: str,
+        change_summary: str,
+        action: str,
+        restored_from_version: int = 0,
+    ) -> Optional[dict]:
+        updated_at = utc_now().isoformat()
+        actor = clean_text(updated_by) or "admin"
+        summary = clean_text(change_summary) or f"{clean_text(action) or 'snapshot'} update"
+        with self._connect() as connection:
+            current_row = connection.execute(
+                """
+                SELECT created_by, current_version
+                FROM digests
+                WHERE id = ?
+                LIMIT 1
+                """,
+                (digest_id,),
+            ).fetchone()
+            if current_row is None:
+                return None
+            created_by = clean_text(str(current_row["created_by"] or "")) or actor
+            next_version = int(current_row["current_version"] or 0) + 1
+            connection.execute(
+                """
+                UPDATE digests
+                SET
+                    title = ?,
+                    body_markdown = ?,
+                    provider = ?,
+                    model = ?,
+                    article_count = ?,
+                    source_count = ?,
+                    payload = ?,
+                    updated_at = ?,
+                    current_version = ?,
+                    created_by = ?,
+                    updated_by = ?,
+                    change_summary = ?
+                WHERE id = ?
+                """,
+                (
+                    title,
+                    body_markdown,
+                    provider,
+                    model,
+                    article_count,
+                    source_count,
+                    json.dumps(payload, ensure_ascii=False),
+                    updated_at,
+                    next_version,
+                    created_by,
+                    actor,
+                    summary,
+                    digest_id,
+                ),
+            )
+            self._insert_digest_snapshot_version(
+                connection,
+                digest_id=digest_id,
+                version=next_version,
+                created_at=updated_at,
+                created_by=created_by,
+                updated_by=actor,
+                change_summary=summary,
+                action=action,
+                restored_from_version=restored_from_version,
+                payload=payload,
             )
         return self.get_digest(digest_id)
 
@@ -2931,6 +3209,11 @@ class ArticleRepository:
                     article_count,
                     source_count,
                     generated_at,
+                    updated_at,
+                    current_version,
+                    created_by,
+                    updated_by,
+                    change_summary,
                     payload
                 FROM digests
                 {where_sql}
@@ -2947,10 +3230,136 @@ class ArticleRepository:
         payload["payload"] = json.loads(payload["payload"])
         return payload
 
+    def get_digest_version(self, digest_id: int, version: int) -> Optional[dict]:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT
+                    id,
+                    digest_id,
+                    version,
+                    created_at,
+                    created_by,
+                    updated_by,
+                    change_summary,
+                    action,
+                    restored_from_version,
+                    payload
+                FROM digest_snapshot_versions
+                WHERE digest_id = ? AND version = ?
+                LIMIT 1
+                """,
+                (digest_id, version),
+            ).fetchone()
+        return self._row_to_digest_version_dict(row) if row else None
+
+    def list_digest_versions(self, digest_id: int, *, limit: int = 20) -> List[dict]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    id,
+                    digest_id,
+                    version,
+                    created_at,
+                    created_by,
+                    updated_by,
+                    change_summary,
+                    action,
+                    restored_from_version,
+                    payload
+                FROM digest_snapshot_versions
+                WHERE digest_id = ?
+                ORDER BY version DESC
+                LIMIT ?
+                """,
+                (digest_id, limit),
+            ).fetchall()
+            publication_rows = connection.execute(
+                """
+                SELECT
+                    id,
+                    digest_id,
+                    digest_snapshot_version,
+                    target,
+                    status,
+                    external_id,
+                    message,
+                    response_payload,
+                    created_at,
+                    updated_at,
+                    COALESCE(d.current_version, 0) AS current_digest_version
+                FROM publications
+                LEFT JOIN digests AS d
+                    ON d.id = publications.digest_id
+                WHERE publications.digest_id = ?
+                ORDER BY created_at DESC
+                """,
+                (digest_id,),
+            ).fetchall()
+        publications_by_version: Dict[int, List[Dict[str, object]]] = {}
+        for row in publication_rows:
+            publication = self._row_to_publication_dict(row)
+            version = int(publication.get("digest_snapshot_version") or 0)
+            publications_by_version.setdefault(version, []).append(publication)
+        versions = [self._row_to_digest_version_dict(row) for row in rows]
+        for item in versions:
+            version = int(item.get("version") or 0)
+            item["publication_records"] = publications_by_version.get(version, [])
+        return versions
+
+    @staticmethod
+    def _row_to_digest_version_dict(row: sqlite3.Row) -> Dict[str, object]:
+        payload = dict(row)
+        payload["payload"] = json.loads(payload["payload"])
+        return payload
+
+    @staticmethod
+    def _insert_digest_snapshot_version(
+        connection: sqlite3.Connection,
+        *,
+        digest_id: int,
+        version: int,
+        created_at: str,
+        created_by: str,
+        updated_by: str,
+        change_summary: str,
+        action: str,
+        restored_from_version: int,
+        payload: Dict[str, object],
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO digest_snapshot_versions (
+                digest_id,
+                version,
+                created_at,
+                created_by,
+                updated_by,
+                change_summary,
+                action,
+                restored_from_version,
+                payload
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                digest_id,
+                version,
+                created_at,
+                clean_text(created_by) or "system",
+                clean_text(updated_by) or clean_text(created_by) or "system",
+                clean_text(change_summary),
+                clean_text(action),
+                restored_from_version,
+                json.dumps(payload, ensure_ascii=False),
+            ),
+        )
+
     def save_publication(
         self,
         *,
         digest_id: Optional[int],
+        digest_snapshot_version: int = 0,
         target: str,
         status: str,
         external_id: str = "",
@@ -2964,6 +3373,7 @@ class ArticleRepository:
                 """
                 INSERT INTO publications (
                     digest_id,
+                    digest_snapshot_version,
                     target,
                     status,
                     external_id,
@@ -2971,10 +3381,11 @@ class ArticleRepository:
                     response_payload,
                     created_at,
                     updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     digest_id,
+                    digest_snapshot_version,
                     target,
                     status,
                     external_id,
@@ -3032,17 +3443,21 @@ class ArticleRepository:
             row = connection.execute(
                 """
                 SELECT
-                    id,
-                    digest_id,
-                    target,
-                    status,
-                    external_id,
-                    message,
-                    response_payload,
-                    created_at,
-                    updated_at
+                    publications.id,
+                    publications.digest_id,
+                    publications.digest_snapshot_version,
+                    publications.target,
+                    publications.status,
+                    publications.external_id,
+                    publications.message,
+                    publications.response_payload,
+                    publications.created_at,
+                    publications.updated_at,
+                    COALESCE(d.current_version, 0) AS current_digest_version
                 FROM publications
-                WHERE id = ?
+                LEFT JOIN digests AS d
+                    ON d.id = publications.digest_id
+                WHERE publications.id = ?
                 LIMIT 1
                 """,
                 (publication_id,),
@@ -3063,16 +3478,16 @@ class ArticleRepository:
         publication_id_list = list(publication_ids or [])
         if publication_id_list:
             placeholders = ",".join("?" for _ in publication_id_list)
-            clauses.append(f"id IN ({placeholders})")
+            clauses.append(f"publications.id IN ({placeholders})")
             params.extend(publication_id_list)
         if digest_id is not None:
-            clauses.append("digest_id = ?")
+            clauses.append("publications.digest_id = ?")
             params.append(digest_id)
         if target:
-            clauses.append("target = ?")
+            clauses.append("publications.target = ?")
             params.append(target)
         if status:
-            clauses.append("status = ?")
+            clauses.append("publications.status = ?")
             params.append(status)
 
         where_sql = ""
@@ -3084,18 +3499,22 @@ class ArticleRepository:
             rows = connection.execute(
                 f"""
                 SELECT
-                    id,
-                    digest_id,
-                    target,
-                    status,
-                    external_id,
-                    message,
-                    response_payload,
-                    created_at,
-                    updated_at
+                    publications.id,
+                    publications.digest_id,
+                    publications.digest_snapshot_version,
+                    publications.target,
+                    publications.status,
+                    publications.external_id,
+                    publications.message,
+                    publications.response_payload,
+                    publications.created_at,
+                    publications.updated_at,
+                    COALESCE(d.current_version, 0) AS current_digest_version
                 FROM publications
+                LEFT JOIN digests AS d
+                    ON d.id = publications.digest_id
                 {where_sql}
-                ORDER BY created_at DESC
+                ORDER BY publications.created_at DESC
                 LIMIT ?
                 """,
                 params,
@@ -3109,13 +3528,13 @@ class ArticleRepository:
         target: str,
         statuses: Optional[Iterable[str]] = None,
     ) -> Optional[dict]:
-        clauses = ["digest_id = ?", "target = ?"]
+        clauses = ["publications.digest_id = ?", "publications.target = ?"]
         params: List[object] = [digest_id, target]
 
         status_list = [str(item) for item in (statuses or []) if str(item)]
         if status_list:
             placeholders = ",".join("?" for _ in status_list)
-            clauses.append(f"status IN ({placeholders})")
+            clauses.append(f"publications.status IN ({placeholders})")
             params.extend(status_list)
 
         where_sql = " AND ".join(clauses)
@@ -3123,18 +3542,22 @@ class ArticleRepository:
             row = connection.execute(
                 f"""
                 SELECT
-                    id,
-                    digest_id,
-                    target,
-                    status,
-                    external_id,
-                    message,
-                    response_payload,
-                    created_at,
-                    updated_at
+                    publications.id,
+                    publications.digest_id,
+                    publications.digest_snapshot_version,
+                    publications.target,
+                    publications.status,
+                    publications.external_id,
+                    publications.message,
+                    publications.response_payload,
+                    publications.created_at,
+                    publications.updated_at,
+                    COALESCE(d.current_version, 0) AS current_digest_version
                 FROM publications
+                LEFT JOIN digests AS d
+                    ON d.id = publications.digest_id
                 WHERE {where_sql}
-                ORDER BY created_at DESC
+                ORDER BY publications.created_at DESC
                 LIMIT 1
                 """,
                 params,
@@ -3145,6 +3568,11 @@ class ArticleRepository:
     def _row_to_publication_dict(row: sqlite3.Row) -> Dict[str, object]:
         payload = dict(row)
         payload["response_payload"] = json.loads(payload["response_payload"])
+        payload["digest_changed_after_publish"] = bool(
+            int(payload.get("digest_snapshot_version") or 0) > 0
+            and int(payload.get("current_digest_version") or 0)
+            > int(payload.get("digest_snapshot_version") or 0)
+        )
         return payload
 
     def get_schema_version(self) -> int:

--- a/src/ainews/service.py
+++ b/src/ainews/service.py
@@ -1183,6 +1183,16 @@ class NewsService:
             raise ValueError("digest not found")
         return self._payload_from_stored_digest(stored_digest)
 
+    def list_digest_versions(self, digest_id: int, *, limit: int = 20) -> Dict[str, object]:
+        stored_digest = self.repository.get_digest(digest_id)
+        if stored_digest is None:
+            raise ValueError("digest not found")
+        return {
+            "digest_id": digest_id,
+            "current_version": int(stored_digest.get("current_version") or 1),
+            "versions": self.repository.list_digest_versions(digest_id, limit=limit),
+        }
+
     def create_digest_snapshot(
         self,
         *,
@@ -1192,6 +1202,8 @@ class NewsService:
         limit: int = 50,
         use_llm: bool = True,
         editor_items: Optional[List[dict]] = None,
+        actor: str = "",
+        change_summary: str = "",
     ) -> Dict[str, object]:
         payload = self.build_digest(
             region=region,
@@ -1210,6 +1222,10 @@ class NewsService:
             editor_snapshot,
             snapshot_status="draft",
             frozen_at=utc_now().isoformat(),
+            version=1,
+            created_by=self._editor_actor(actor),
+            updated_by=self._editor_actor(actor),
+            change_summary=self._editor_change_summary(change_summary, fallback="frozen from preview"),
         )
         digest = persisted_payload["digest"]
         stored_digest = self.repository.save_digest(
@@ -1234,6 +1250,9 @@ class NewsService:
                 }
             ),
             payload=self._payload_for_storage(persisted_payload),
+            created_by=self._editor_actor(actor),
+            updated_by=self._editor_actor(actor),
+            change_summary=self._editor_change_summary(change_summary, fallback="frozen from preview"),
         )
         persisted_payload["stored_digest"] = stored_digest
         return persisted_payload
@@ -1243,6 +1262,8 @@ class NewsService:
         digest_id: int,
         *,
         editor_items: List[dict],
+        actor: str = "",
+        change_summary: str = "",
     ) -> Dict[str, object]:
         stored_digest = self.repository.get_digest(digest_id)
         if stored_digest is None:
@@ -1261,9 +1282,15 @@ class NewsService:
             last_published_at=clean_text(
                 str((payload.get("editor_snapshot") or {}).get("last_published_at", ""))
             ),
+            version=int(stored_digest.get("current_version") or 1) + 1,
+            created_by=clean_text(
+                str((payload.get("editor_snapshot") or {}).get("created_by") or stored_digest.get("created_by") or "")
+            ) or self._editor_actor(actor),
+            updated_by=self._editor_actor(actor),
+            change_summary=self._editor_change_summary(change_summary, fallback="updated digest editor"),
         )
         digest = updated_payload["digest"]
-        stored_digest = self.repository.update_digest(
+        stored_digest = self.repository.save_digest_version(
             digest_id,
             title=str(digest.get("title") or ""),
             body_markdown=str(updated_payload.get("body_markdown") or ""),
@@ -1278,11 +1305,112 @@ class NewsService:
                 }
             ),
             payload=self._payload_for_storage(updated_payload),
+            updated_by=self._editor_actor(actor),
+            change_summary=self._editor_change_summary(change_summary, fallback="updated digest editor"),
+            action="edit",
         )
         if stored_digest is None:
             raise ValueError("digest not found")
         updated_payload["stored_digest"] = stored_digest
         return updated_payload
+
+    def rollback_digest_snapshot(
+        self,
+        digest_id: int,
+        *,
+        version: int,
+        actor: str = "",
+        change_summary: str = "",
+    ) -> Dict[str, object]:
+        stored_digest = self.repository.get_digest(digest_id)
+        if stored_digest is None:
+            raise ValueError("digest not found")
+        target_version = self.repository.get_digest_version(digest_id, version)
+        if target_version is None:
+            raise ValueError("digest snapshot version not found")
+        payload = self._payload_from_stored_digest(stored_digest)
+        version_payload = target_version.get("payload")
+        if not isinstance(version_payload, dict) or not version_payload.get("digest"):
+            raise ValueError("digest snapshot version payload is invalid")
+        rollback_payload = dict(version_payload)
+        rollback_payload["stored_digest"] = stored_digest
+        rollback_payload["generation_mode"] = "editor"
+        updated_payload = self._apply_editor_snapshot_to_payload(
+            rollback_payload,
+            rollback_payload.get("editor_snapshot") if isinstance(rollback_payload.get("editor_snapshot"), dict) else {},
+            snapshot_status="draft",
+            frozen_at=clean_text(
+                str((rollback_payload.get("editor_snapshot") or {}).get("frozen_at", ""))
+            ) or utc_now().isoformat(),
+            last_published_at=clean_text(
+                str((rollback_payload.get("editor_snapshot") or {}).get("last_published_at", ""))
+            ),
+            version=int(stored_digest.get("current_version") or 1) + 1,
+            created_by=clean_text(
+                str((payload.get("editor_snapshot") or {}).get("created_by") or stored_digest.get("created_by") or "")
+            ) or self._editor_actor(actor),
+            updated_by=self._editor_actor(actor),
+            change_summary=self._editor_change_summary(
+                change_summary,
+                fallback=f"rolled back to version {version}",
+            ),
+        )
+        digest = updated_payload["digest"]
+        stored_digest = self.repository.save_digest_version(
+            digest_id,
+            title=str(digest.get("title") or ""),
+            body_markdown=str(updated_payload.get("body_markdown") or ""),
+            provider=str(digest.get("provider") or ""),
+            model=str(digest.get("model") or ""),
+            article_count=len(list(updated_payload.get("selection_preview") or [])),
+            source_count=len(
+                {
+                    str(article.get("source_id") or "")
+                    for article in list(updated_payload.get("articles") or [])
+                    if article.get("source_id")
+                }
+            ),
+            payload=self._payload_for_storage(updated_payload),
+            updated_by=self._editor_actor(actor),
+            change_summary=self._editor_change_summary(
+                change_summary,
+                fallback=f"rolled back to version {version}",
+            ),
+            action="rollback",
+            restored_from_version=version,
+        )
+        if stored_digest is None:
+            raise ValueError("digest not found")
+        updated_payload["stored_digest"] = stored_digest
+        return updated_payload
+
+    def preview_publication_targets(
+        self,
+        *,
+        digest_id: Optional[int] = None,
+        region: str = "all",
+        since_hours: Optional[int] = None,
+        limit: int = 30,
+        use_llm: bool = True,
+        targets: Optional[Iterable[str]] = None,
+    ) -> Dict[str, object]:
+        if digest_id is not None:
+            stored_digest = self.repository.get_digest(digest_id)
+            if stored_digest is None:
+                raise ValueError("digest not found")
+            payload = self._payload_from_stored_digest(stored_digest)
+        else:
+            payload = self.build_digest(
+                region=region,
+                since_hours=since_hours,
+                limit=limit,
+                use_llm=use_llm,
+                persist=False,
+            )
+        return {
+            "digest": payload,
+            "preview_targets": self.publisher.preview(payload, targets=targets),
+        }
 
     def list_publications(
         self,
@@ -1709,6 +1837,11 @@ class NewsService:
         }
         records = []
         merged_targets = []
+        snapshot_version = int(
+            (payload.get("editor_snapshot") or {}).get("version")
+            or (payload.get("stored_digest") or {}).get("current_version")
+            or 0
+        )
         failure_categories: Counter[str] = Counter()
         for target in requested_targets:
             if target in already_published:
@@ -1738,6 +1871,7 @@ class NewsService:
             merged_targets.append(item)
             record = self.repository.save_publication(
                 digest_id=digest_id,
+                digest_snapshot_version=snapshot_version,
                 target=str(item.get("target", "")),
                 status=self._publication_record_status(item),
                 external_id=str(item.get("external_id", "")),
@@ -1751,6 +1885,7 @@ class NewsService:
         publish_result["targets"] = merged_targets
         publish_result["published"] = int(publish_result.get("published", 0))
         publish_result["skipped"] = len(already_published)
+        publish_result["digest_snapshot_version"] = snapshot_version
         if publish_result.get("errors", 0):
             publish_result["status"] = "partial_error"
         else:
@@ -1876,6 +2011,10 @@ class NewsService:
         )
         if persist:
             editor_snapshot["frozen_at"] = utc_now().isoformat()
+            editor_snapshot["version"] = 1
+            editor_snapshot["created_by"] = "system"
+            editor_snapshot["updated_by"] = "system"
+            editor_snapshot["change_summary"] = "generated digest snapshot"
 
         generation_mode = "fallback"
         if use_llm and self.llm_client.is_configured() and digest_articles:
@@ -1926,6 +2065,9 @@ class NewsService:
                 article_count=len(presented_articles),
                 source_count=len({article["source_id"] for article in presented_articles}),
                 payload=payload,
+                created_by="system",
+                updated_by="system",
+                change_summary="generated digest snapshot",
             )
 
         operation_record = self.telemetry.finish(
@@ -2250,6 +2392,14 @@ class NewsService:
     def _default_digest_section_title(article: dict) -> str:
         return "国内动态" if str(article.get("region", "international")) == "domestic" else "国际动态"
 
+    @staticmethod
+    def _editor_actor(actor: str) -> str:
+        return clean_text(actor) or "admin"
+
+    @staticmethod
+    def _editor_change_summary(change_summary: str, *, fallback: str) -> str:
+        return clean_text(change_summary) or fallback
+
     def _build_editor_snapshot(
         self,
         articles: List[dict],
@@ -2305,6 +2455,10 @@ class NewsService:
                 manual_rank += 1
             items.append(item)
         return {
+            "version": 0,
+            "created_by": "",
+            "updated_by": "",
+            "change_summary": "",
             "snapshot_status": snapshot_status,
             "frozen_at": "",
             "updated_at": utc_now().isoformat(),
@@ -2388,10 +2542,20 @@ class NewsService:
         editor_snapshot: Dict[str, object],
         *,
         snapshot_status: str,
+        version: Optional[int] = None,
+        created_by: str = "",
+        updated_by: str = "",
+        change_summary: str = "",
         frozen_at: str = "",
         last_published_at: str = "",
     ) -> Dict[str, object]:
         snapshot = self._merge_editor_snapshot_items(editor_snapshot, None)
+        snapshot["version"] = int(version or snapshot.get("version") or 1)
+        snapshot["created_by"] = clean_text(created_by) or clean_text(str(snapshot.get("created_by") or "")) or "admin"
+        snapshot["updated_by"] = clean_text(updated_by) or clean_text(str(snapshot.get("updated_by") or "")) or snapshot["created_by"]
+        snapshot["change_summary"] = clean_text(change_summary) or clean_text(
+            str(snapshot.get("change_summary") or "")
+        )
         snapshot["snapshot_status"] = snapshot_status
         snapshot["frozen_at"] = clean_text(frozen_at) or clean_text(str(snapshot.get("frozen_at") or ""))
         snapshot["last_published_at"] = clean_text(last_published_at) or clean_text(
@@ -3248,6 +3412,10 @@ class NewsService:
                     selection,
                     snapshot_status="draft",
                 )
+            payload["editor_snapshot"] = self._apply_editor_snapshot_metadata_from_store(
+                payload.get("editor_snapshot"),
+                stored_digest,
+            )
             payload["stored_digest"] = stored_digest
             payload["generation_mode"] = "stored"
             return payload
@@ -3283,9 +3451,13 @@ class NewsService:
                 "must_include_selected": 0,
             },
             "editor_snapshot": {
+                "version": int(stored_digest.get("current_version") or 1),
+                "created_by": clean_text(str(stored_digest.get("created_by") or "")) or "system",
+                "updated_by": clean_text(str(stored_digest.get("updated_by") or "")) or "system",
+                "change_summary": clean_text(str(stored_digest.get("change_summary") or "")),
                 "snapshot_status": "draft",
                 "frozen_at": "",
-                "updated_at": "",
+                "updated_at": clean_text(str(stored_digest.get("updated_at") or "")),
                 "last_published_at": "",
                 "items": [],
             },
@@ -3301,6 +3473,21 @@ class NewsService:
         stored_payload.pop("stored_digest", None)
         stored_payload.pop("operation", None)
         return stored_payload
+
+    @staticmethod
+    def _apply_editor_snapshot_metadata_from_store(
+        editor_snapshot: object,
+        stored_digest: Dict[str, object],
+    ) -> Dict[str, object]:
+        snapshot = dict(editor_snapshot) if isinstance(editor_snapshot, dict) else {}
+        snapshot["version"] = int(snapshot.get("version") or stored_digest.get("current_version") or 1)
+        snapshot["created_by"] = clean_text(str(snapshot.get("created_by") or stored_digest.get("created_by") or "")) or "system"
+        snapshot["updated_by"] = clean_text(str(snapshot.get("updated_by") or stored_digest.get("updated_by") or "")) or snapshot["created_by"]
+        snapshot["change_summary"] = clean_text(
+            str(snapshot.get("change_summary") or stored_digest.get("change_summary") or "")
+        )
+        snapshot["updated_at"] = clean_text(str(snapshot.get("updated_at") or stored_digest.get("updated_at") or ""))
+        return snapshot
 
     def _export_digest_payload(self, payload: Dict[str, object]) -> List[str]:
         date_prefix = format_local_date().replace("-", "")

--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -4,6 +4,7 @@ const state = {
   currentDigestPayload: null,
   currentArticles: [],
   selectedDigestId: null,
+  editorActor: localStorage.getItem("ainews_digest_editor_actor") || "",
 };
 
 const refs = {
@@ -16,6 +17,8 @@ const refs = {
   digestPreviewButton: document.getElementById("digestPreviewButton"),
   freezeDigestButton: document.getElementById("freezeDigestButton"),
   saveDigestEditorButton: document.getElementById("saveDigestEditorButton"),
+  digestEditorActorInput: document.getElementById("digestEditorActorInput"),
+  digestChangeSummaryInput: document.getElementById("digestChangeSummaryInput"),
   digestButton: document.getElementById("digestButton"),
   pipelineButton: document.getElementById("pipelineButton"),
   publishButton: document.getElementById("publishButton"),
@@ -27,6 +30,8 @@ const refs = {
   digestView: document.getElementById("digestView"),
   digestPreviewView: document.getElementById("digestPreviewView"),
   digestEditorView: document.getElementById("digestEditorView"),
+  digestHistoryView: document.getElementById("digestHistoryView"),
+  refreshDigestHistoryButton: document.getElementById("refreshDigestHistoryButton"),
   digestArchive: document.getElementById("digestArchive"),
   articlesList: document.getElementById("articlesList"),
   regionSelect: document.getElementById("regionSelect"),
@@ -49,6 +54,8 @@ const refs = {
   retryExtractionSelectionButton: document.getElementById("retryExtractionSelectionButton"),
   sourceAlertsList: document.getElementById("sourceAlertsList"),
   refreshSourceAlertsButton: document.getElementById("refreshSourceAlertsButton"),
+  publishPreviewView: document.getElementById("publishPreviewView"),
+  refreshPublishPreviewButton: document.getElementById("refreshPublishPreviewButton"),
   operationsSummary: document.getElementById("operationsSummary"),
   operationsHealth: document.getElementById("operationsHealth"),
   operationsMetrics: document.getElementById("operationsMetrics"),
@@ -61,6 +68,7 @@ const refs = {
 };
 
 refs.adminToken.value = state.token;
+refs.digestEditorActorInput.value = state.editorActor;
 
 function adminHeaders() {
   const headers = { "Content-Type": "application/json" };
@@ -90,6 +98,13 @@ function getFilters() {
     since_hours: Number(refs.sinceHoursSelect.value),
     limit: Number(refs.limitInput.value),
     max_items_per_source: Number(refs.maxItemsInput.value),
+  };
+}
+
+function getDigestEditorMeta() {
+  return {
+    actor: refs.digestEditorActorInput.value.trim() || null,
+    change_summary: refs.digestChangeSummaryInput.value.trim() || null,
   };
 }
 
@@ -504,6 +519,8 @@ function renderDigest(payload) {
     refs.digestView.innerHTML = '<p class="muted">还没有生成日报。</p>';
     refs.digestPreviewView.innerHTML = '<p class="muted">还没有预览结果。点击“选稿预览”或生成日报后会显示这里。</p>';
     refs.digestEditorView.innerHTML = '<p class="muted">先生成预览或打开一份已保存的日报，编辑页才会出现。</p>';
+    refs.digestHistoryView.innerHTML = '<p class="muted">冻结为编辑稿后，这里会显示版本历史和回滚入口。</p>';
+    refs.publishPreviewView.innerHTML = '<p class="muted">打开一份日报或冻结编辑稿后，这里会显示目标平台最终预览。</p>';
     return;
   }
   state.currentDigest = digest;
@@ -548,6 +565,13 @@ function renderDigest(payload) {
   `;
   renderDigestPreview(digestPayload);
   renderDigestEditor(digestPayload);
+  const digestId = digestPayload?.stored_digest?.id || null;
+  if (digestId) {
+    loadDigestHistory(digestId).catch((error) => logJob("load digest history failed", { error: error.message, digestId }));
+  } else {
+    refs.digestHistoryView.innerHTML = '<p class="muted">冻结为编辑稿后，这里会显示版本历史和回滚入口。</p>';
+  }
+  loadPublishPreview(digestId).catch((error) => logJob("load publish preview failed", { error: error.message, digestId }));
 }
 
 function decisionLabel(decision) {
@@ -685,6 +709,128 @@ function renderDigestEditor(payload) {
   `;
 }
 
+function renderDigestHistory(payload) {
+  const versions = payload?.versions || [];
+  const currentVersion = payload?.current_version || 0;
+  if (!versions.length) {
+    refs.digestHistoryView.innerHTML = '<p class="muted">当前还没有可用的编辑版本历史。</p>';
+    return;
+  }
+  refs.digestHistoryView.innerHTML = versions
+    .map((item) => {
+      const publicationRecords = item.publication_records || [];
+      return `
+        <article class="publication-card">
+          <header class="publication-head">
+            <div>
+              <strong>v${escapeHtml(String(item.version || 0))}</strong>
+              <div class="publication-meta">
+                <span>${escapeHtml(item.created_at || "")}</span>
+                <span>created_by: ${escapeHtml(item.created_by || "system")}</span>
+                <span>updated_by: ${escapeHtml(item.updated_by || item.created_by || "system")}</span>
+              </div>
+            </div>
+            <div class="chip-row compact">
+              ${item.version === currentVersion ? '<span class="chip status-good">当前版本</span>' : ""}
+              ${item.action ? `<span class="chip">${escapeHtml(item.action)}</span>` : ""}
+              ${item.restored_from_version ? `<span class="chip">from v${escapeHtml(String(item.restored_from_version))}</span>` : ""}
+            </div>
+          </header>
+          <p class="article-brief">${escapeHtml(item.change_summary || "no change summary")}</p>
+          ${
+            publicationRecords.length
+              ? `<div class="chip-row">${publicationRecords
+                  .map(
+                    (record) =>
+                      `<span class="chip ${publicationStatusClass(record.status)}">${escapeHtml(publicationTargetLabel(record.target))} · ${escapeHtml(publicationStatusLabel(record.status))}${record.digest_changed_after_publish ? " · stale" : ""}</span>`
+                  )
+                  .join("")}</div>`
+              : '<p class="muted">这一版还没有发布记录。</p>'
+          }
+          ${
+            item.version !== currentVersion
+              ? `<div class="article-actions"><button class="button ghost" data-action="rollback-digest-version" data-version="${item.version}">回滚到这一版</button></div>`
+              : ""
+          }
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderPublishPreview(payload) {
+  const targets = payload?.preview_targets?.targets || [];
+  if (!targets.length) {
+    refs.publishPreviewView.innerHTML = '<p class="muted">选择一份日报后，这里会显示目标平台最终预览。</p>';
+    return;
+  }
+  refs.publishPreviewView.innerHTML = targets
+    .map((entry) => {
+      const target = entry.target;
+      const preview = entry.preview || {};
+      if (target === "telegram") {
+        return `
+          <article class="publication-card">
+            <header class="publication-head">
+              <strong>Telegram</strong>
+              <span class="chip">chunks ${escapeHtml(String((preview.chunks || []).length || 0))}</span>
+            </header>
+            <pre class="terminal">${escapeHtml(preview.text || "")}</pre>
+          </article>
+        `;
+      }
+      if (target === "feishu") {
+        return `
+          <article class="publication-card">
+            <header class="publication-head">
+              <strong>飞书</strong>
+              <span class="chip">${escapeHtml(preview.card_title || "interactive card")}</span>
+            </header>
+            <p class="article-brief"><strong>文本消息</strong></p>
+            <pre class="terminal">${escapeHtml(preview.text || "")}</pre>
+          </article>
+        `;
+      }
+      if (target === "static_site") {
+        return `
+          <article class="publication-card">
+            <header class="publication-head">
+              <strong>静态站点</strong>
+              <span class="chip">HTML</span>
+            </header>
+            <iframe class="preview-frame" sandbox="" srcdoc="${escapeAttribute(preview.html || "")}"></iframe>
+          </article>
+        `;
+      }
+      if (target === "wechat") {
+        const wechatDocument = `
+          <!doctype html>
+          <html lang="zh-CN"><head><meta charset="utf-8"><style>
+          body{font-family:-apple-system,BlinkMacSystemFont,'PingFang SC','Noto Sans SC',sans-serif;padding:18px;color:#1b1711;background:#fff;}
+          h1{font-size:22px;line-height:1.35;margin:0 0 12px;}
+          .digest{color:#6f665b;font-size:14px;margin-bottom:14px;}
+          img{max-width:100%;}
+          </style></head><body>
+          <h1>${escapeHtml(preview.title || "")}</h1>
+          <p class="digest">${escapeHtml(preview.digest || "")}</p>
+          ${preview.content_html || ""}
+          </body></html>
+        `;
+        return `
+          <article class="publication-card">
+            <header class="publication-head">
+              <strong>公众号</strong>
+              <span class="chip">${escapeHtml(preview.content_source_url || "no source link")}</span>
+            </header>
+            <iframe class="preview-frame" sandbox="" srcdoc="${escapeAttribute(wechatDocument)}"></iframe>
+          </article>
+        `;
+      }
+      return "";
+    })
+    .join("");
+}
+
 function renderArchive(digests) {
   refs.digestArchive.innerHTML = digests.length
     ? digests
@@ -692,10 +838,10 @@ function renderArchive(digests) {
           (item) => `
           <article class="archive-item" data-digest-id="${item.id}">
             <strong>${escapeHtml(item.title)}</strong>
-            <p class="muted">${escapeHtml(item.generated_at)} · ${escapeHtml(item.region)} · ${item.article_count} 篇</p>
+            <p class="muted">${escapeHtml(item.generated_at)} · ${escapeHtml(item.region)} · ${item.article_count} 篇 · v${escapeHtml(String(item.current_version || 1))}</p>
             ${
               item.payload?.editor_snapshot?.snapshot_status
-                ? `<div class="chip-row compact"><span class="chip ${snapshotStatusClass(item.payload.editor_snapshot.snapshot_status)}">${escapeHtml(snapshotStatusLabel(item.payload.editor_snapshot.snapshot_status))}</span></div>`
+                ? `<div class="chip-row compact"><span class="chip ${snapshotStatusClass(item.payload.editor_snapshot.snapshot_status)}">${escapeHtml(snapshotStatusLabel(item.payload.editor_snapshot.snapshot_status))}</span><span class="chip">${escapeHtml(item.updated_by || item.created_by || "system")}</span></div>`
                 : ""
             }
             <button class="button ghost" data-action="open-digest" data-digest-id="${item.id}">查看</button>
@@ -758,6 +904,16 @@ function renderPublications(publications) {
                 <div class="chip-row compact">
                   <span class="chip">${escapeHtml(publicationTargetLabel(publication.target))}</span>
                   <span class="chip ${publicationStatusClass(publication.status)}">${escapeHtml(publicationStatusLabel(publication.status))}</span>
+                  ${
+                    publication.digest_snapshot_version
+                      ? `<span class="chip">v${escapeHtml(String(publication.digest_snapshot_version))}</span>`
+                      : ""
+                  }
+                  ${
+                    publication.digest_changed_after_publish
+                      ? '<span class="chip warn">发布后已变更</span>'
+                      : ""
+                  }
                 </div>
                 <span class="muted">${escapeHtml(publication.updated_at || publication.created_at || "")}</span>
               </header>
@@ -1093,11 +1249,44 @@ async function loadDigests() {
   }
 }
 
+async function loadDigestHistory(digestId = null) {
+  const resolvedDigestId =
+    digestId || state.currentDigestPayload?.stored_digest?.id || state.selectedDigestId || null;
+  if (!resolvedDigestId) {
+    refs.digestHistoryView.innerHTML = '<p class="muted">冻结为编辑稿后，这里会显示版本历史和回滚入口。</p>';
+    return;
+  }
+  const payload = await fetchJson(`/admin/digests/${resolvedDigestId}/history?limit=20`, {
+    headers: adminHeaders(),
+  });
+  renderDigestHistory(payload);
+}
+
 async function loadPublications() {
   const payload = await fetchJson(`/admin/publications?${buildPublicationQuery().toString()}`, {
     headers: adminHeaders(),
   });
   renderPublications(payload.publications || []);
+}
+
+async function loadPublishPreview(digestId = null) {
+  const filters = getFilters();
+  const resolvedDigestId =
+    digestId || state.currentDigestPayload?.stored_digest?.id || state.selectedDigestId || null;
+  const targets = getPublishTargets();
+  const payload = await fetchJson("/admin/publish/preview", {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      digest_id: resolvedDigestId,
+      region: filters.region,
+      since_hours: filters.since_hours,
+      limit: filters.limit,
+      use_llm: true,
+      targets: targets.length ? targets : null,
+    }),
+  });
+  renderPublishPreview(payload);
 }
 
 async function loadExtractionOps() {
@@ -1316,6 +1505,7 @@ function collectDigestEditorItems() {
 
 async function freezeDigestSnapshot() {
   const filters = getFilters();
+  const editorMeta = getDigestEditorMeta();
   const payload = await fetchJson("/admin/digests/snapshot", {
     method: "POST",
     headers: adminHeaders(),
@@ -1326,6 +1516,8 @@ async function freezeDigestSnapshot() {
       use_llm: true,
       article_ids: (state.currentDigestPayload?.articles || []).map((item) => item.id),
       editor_items: collectDigestEditorItems(),
+      actor: editorMeta.actor,
+      change_summary: editorMeta.change_summary,
     }),
   });
   logJob("freeze digest snapshot", payload);
@@ -1340,14 +1532,39 @@ async function saveDigestEditor() {
   if (!digestId) {
     throw new Error("请先冻结为编辑稿，再保存编辑修改");
   }
+  const editorMeta = getDigestEditorMeta();
   const payload = await fetchJson(`/admin/digests/${digestId}/editor`, {
     method: "PATCH",
     headers: adminHeaders(),
     body: JSON.stringify({
       editor_items: collectDigestEditorItems(),
+      actor: editorMeta.actor,
+      change_summary: editorMeta.change_summary,
     }),
   });
   logJob("save digest editor", payload);
+  renderDigest(payload);
+  setSelectedDigestId(payload.stored_digest?.id || digestId);
+  await refreshAll();
+}
+
+async function rollbackDigestVersion(version) {
+  const digestId =
+    state.currentDigestPayload?.stored_digest?.id || state.selectedDigestId || null;
+  if (!digestId) {
+    throw new Error("请先打开一份已保存的日报");
+  }
+  const editorMeta = getDigestEditorMeta();
+  const payload = await fetchJson(`/admin/digests/${digestId}/rollback`, {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      version,
+      actor: editorMeta.actor,
+      change_summary: editorMeta.change_summary,
+    }),
+  });
+  logJob("rollback digest version", payload);
   renderDigest(payload);
   setSelectedDigestId(payload.stored_digest?.id || digestId);
   await refreshAll();
@@ -1432,6 +1649,10 @@ refs.saveTokenButton.addEventListener("click", () => {
   localStorage.setItem("ainews_admin_token", state.token);
   logJob("token", { saved: Boolean(state.token) });
 });
+refs.digestEditorActorInput.addEventListener("change", () => {
+  state.editorActor = refs.digestEditorActorInput.value.trim();
+  localStorage.setItem("ainews_digest_editor_actor", state.editorActor);
+});
 
 refs.refreshAllButton.addEventListener("click", refreshAll);
 refs.refreshSourcesButton.addEventListener("click", () =>
@@ -1446,6 +1667,8 @@ refs.enrichButton.addEventListener("click", () => runEnrich().catch((error) => l
 refs.digestPreviewButton.addEventListener("click", () => previewDigest().catch((error) => logJob("digest preview failed", { error: error.message })));
 refs.freezeDigestButton.addEventListener("click", () => freezeDigestSnapshot().catch((error) => logJob("freeze digest snapshot failed", { error: error.message })));
 refs.saveDigestEditorButton.addEventListener("click", () => saveDigestEditor().catch((error) => logJob("save digest editor failed", { error: error.message })));
+refs.refreshDigestHistoryButton.addEventListener("click", () => loadDigestHistory().catch((error) => logJob("load digest history failed", { error: error.message })));
+refs.refreshPublishPreviewButton.addEventListener("click", () => loadPublishPreview().catch((error) => logJob("load publish preview failed", { error: error.message })));
 refs.digestButton.addEventListener("click", () => runDigest().catch((error) => logJob("digest failed", { error: error.message })));
 refs.pipelineButton.addEventListener("click", () => runPipeline().catch((error) => logJob("pipeline failed", { error: error.message })));
 refs.publishButton.addEventListener("click", () => runPublish().catch((error) => logJob("publish failed", { error: error.message })));
@@ -1470,6 +1693,11 @@ refs.publicationTargetFilter.addEventListener("change", () =>
 );
 refs.publicationStatusFilter.addEventListener("change", () =>
   loadPublications().catch((error) => logJob("load publications failed", { error: error.message }))
+);
+refs.publishTargetInputs.forEach((input) =>
+  input.addEventListener("change", () =>
+    loadPublishPreview().catch((error) => logJob("load publish preview failed", { error: error.message }))
+  )
 );
 refs.extractionStatusFilter.addEventListener("change", () =>
   loadExtractionOps().catch((error) => logJob("load extraction ops failed", { error: error.message }))
@@ -1514,6 +1742,16 @@ refs.articlesList.addEventListener("click", async (event) => {
     }
   } catch (error) {
     logJob("article update failed", { error: error.message, articleId });
+  }
+});
+
+refs.digestHistoryView.addEventListener("click", async (event) => {
+  const button = event.target.closest('button[data-action="rollback-digest-version"]');
+  if (!button) return;
+  try {
+    await rollbackDigestVersion(Number(button.dataset.version));
+  } catch (error) {
+    logJob("rollback digest version failed", { error: error.message, version: button.dataset.version });
   }
 });
 

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -198,7 +198,45 @@
             </div>
           </div>
           <p class="muted">在这里调整最终顺序、分组、发布标题和发布摘要。保存后，发布链路会优先使用当前冻结稿而不是实时重算。</p>
+          <div class="form-grid">
+            <label>
+              编辑者
+              <input id="digestEditorActorInput" type="text" placeholder="例如：X-PG13" />
+            </label>
+            <label>
+              变更摘要
+              <input id="digestChangeSummaryInput" type="text" placeholder="例如：调整头条顺序并补标题" />
+            </label>
+          </div>
           <div id="digestEditorView" class="publication-list"></div>
+        </article>
+
+        <article class="panel">
+          <div class="section-head">
+            <div>
+              <p class="eyebrow">History</p>
+              <h2>编辑稿版本历史</h2>
+            </div>
+            <div class="toolbar-row">
+              <button id="refreshDigestHistoryButton" class="button ghost">刷新历史</button>
+            </div>
+          </div>
+          <p class="muted">每次保存编辑稿都会生成新版本。你可以查看变更摘要、发布记录，并一键回滚到旧版本。</p>
+          <div id="digestHistoryView" class="publication-list"></div>
+        </article>
+
+        <article class="panel">
+          <div class="section-head">
+            <div>
+              <p class="eyebrow">Publish Preview</p>
+              <h2>目标平台最终预览</h2>
+            </div>
+            <div class="toolbar-row">
+              <button id="refreshPublishPreviewButton" class="button ghost">刷新预览</button>
+            </div>
+          </div>
+          <p class="muted">这里展示 Telegram、飞书、静态站点和公众号的最终输出形态，确保发布内容和冻结稿一致。</p>
+          <div id="publishPreviewView" class="publication-list"></div>
         </article>
 
         <article class="panel">

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -481,6 +481,15 @@ textarea {
   text-decoration: underline;
 }
 
+.preview-frame {
+  width: 100%;
+  min-height: 420px;
+  margin-top: 12px;
+  border: 1px solid rgba(23, 23, 23, 0.08);
+  border-radius: 16px;
+  background: #fff;
+}
+
 @media (max-width: 1100px) {
   .hero,
   .operations-grid,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -338,6 +338,86 @@ class ApiTestCase(unittest.TestCase):
         self.assertEqual(payload["selection_preview"][0]["title"], "编辑后标题")
         self.assertEqual(payload["generation_mode"], "editor")
 
+    def test_admin_digest_history_rollback_and_publish_preview_routes(self) -> None:
+        self._seed_article()
+        self._seed_article(
+            title="Anthropic documents new rollback controls",
+            url="https://example.com/anthropic-rollback",
+        )
+        create_response = self.client.post(
+            "/admin/digests/snapshot",
+            headers={"X-Admin-Token": "secret-token"},
+            json={
+                "region": "all",
+                "since_hours": 72,
+                "limit": 10,
+                "use_llm": False,
+            },
+        )
+        self.assertEqual(create_response.status_code, 200)
+        created = create_response.json()
+        digest_id = created["stored_digest"]["id"]
+        original_title = created["selection_preview"][0]["title"]
+        anthropic_item = next(
+            item
+            for item in created["editor_snapshot"]["items"]
+            if item["original_title"] == "Anthropic documents new rollback controls"
+        )
+
+        update_response = self.client.patch(
+            f"/admin/digests/{digest_id}/editor",
+            headers={"X-Admin-Token": "secret-token"},
+            json={
+                "editor_items": [
+                    {
+                        "article_id": anthropic_item["article_id"],
+                        "selected": True,
+                        "manual_rank": 1,
+                        "publish_title_override": "编辑后标题",
+                        "publish_summary_override": "编辑后摘要",
+                    }
+                ],
+                "actor": "editor-bot",
+                "change_summary": "promote anthropic",
+            },
+        )
+        self.assertEqual(update_response.status_code, 200)
+        self.assertEqual(update_response.json()["stored_digest"]["current_version"], 2)
+
+        history_response = self.client.get(
+            f"/admin/digests/{digest_id}/history",
+            headers={"X-Admin-Token": "secret-token"},
+        )
+        self.assertEqual(history_response.status_code, 200)
+        history = history_response.json()
+        self.assertEqual(history["current_version"], 2)
+        self.assertEqual([item["version"] for item in history["versions"][:2]], [2, 1])
+
+        preview_response = self.client.post(
+            "/admin/publish/preview",
+            headers={"X-Admin-Token": "secret-token"},
+            json={"digest_id": digest_id, "targets": ["static_site"]},
+        )
+        self.assertEqual(preview_response.status_code, 200)
+        self.assertEqual(
+            preview_response.json()["preview_targets"]["requested_targets"],
+            ["static_site"],
+        )
+
+        rollback_response = self.client.post(
+            f"/admin/digests/{digest_id}/rollback",
+            headers={"X-Admin-Token": "secret-token"},
+            json={
+                "version": 1,
+                "actor": "editor-bot",
+                "change_summary": "restore version 1",
+            },
+        )
+        self.assertEqual(rollback_response.status_code, 200)
+        rollback_payload = rollback_response.json()
+        self.assertEqual(rollback_payload["stored_digest"]["current_version"], 3)
+        self.assertEqual(rollback_payload["selection_preview"][0]["title"], original_title)
+
     def test_admin_can_promote_duplicate_primary(self) -> None:
         repository = ArticleRepository(Path(self._temp_dir.name) / "data" / "ainews.db")
         published = utc_now()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -158,6 +158,21 @@ class StubPublisher:
             "errors": 0,
         }
 
+    def preview(self, payload, *, targets=None):
+        requested = self.normalize_targets(targets) or ["static_site"]
+        return {
+            "requested_targets": requested,
+            "targets": [
+                {
+                    "target": target,
+                    "preview": {
+                        "title": str((payload.get("digest") or {}).get("title") or ""),
+                    },
+                }
+                for target in requested
+            ],
+        }
+
     def can_refresh_publication(self, publication):
         return publication.get("target") == "wechat"
 
@@ -712,6 +727,167 @@ class ServiceFilterTestCase(unittest.TestCase):
                 publish_result["digest"]["editor_snapshot"]["snapshot_status"],
                 "published",
             )
+
+    def test_digest_versions_rollback_and_preview_targets_are_persisted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = Settings(
+                database_path=Path(temp_dir) / "ainews.db",
+                sources_file=Path(temp_dir) / "sources.json",
+            )
+            repository = ArticleRepository(settings.database_path)
+            source = SourceDefinition(
+                id="openai-news",
+                name="OpenAI News",
+                url="https://openai.com/news/rss.xml",
+                region="international",
+                language="en",
+                country="US",
+                topic="company",
+            )
+            now = utc_now()
+            repository.insert_if_new(
+                ArticleRecord(
+                    source_id=source.id,
+                    source_name=source.name,
+                    title="OpenAI launches enterprise governance controls",
+                    url="https://openai.com/index/enterprise-governance",
+                    canonical_url="https://openai.com/index/enterprise-governance",
+                    summary="Direct release coverage.",
+                    published_at=now,
+                    discovered_at=now,
+                    language="en",
+                    region="international",
+                    country="US",
+                    topic="company",
+                    content_hash=make_content_hash(
+                        "OpenAI launches enterprise governance controls",
+                        "Direct release coverage.",
+                    ),
+                    dedup_key=make_dedup_key("OpenAI launches enterprise governance controls"),
+                    raw_payload={},
+                )
+            )
+            repository.insert_if_new(
+                ArticleRecord(
+                    source_id="anthropic-news",
+                    source_name="Anthropic News",
+                    title="Anthropic documents new rollback controls",
+                    url="https://anthropic.com/news/rollback-controls",
+                    canonical_url="https://anthropic.com/news/rollback-controls",
+                    summary="Another strong enterprise AI story.",
+                    published_at=now,
+                    discovered_at=now,
+                    language="en",
+                    region="international",
+                    country="US",
+                    topic="company",
+                    content_hash=make_content_hash(
+                        "Anthropic documents new rollback controls",
+                        "Another strong enterprise AI story.",
+                    ),
+                    dedup_key=make_dedup_key("Anthropic documents new rollback controls"),
+                    raw_payload={},
+                )
+            )
+            service = NewsService(
+                settings,
+                repository=repository,
+                source_registry=StubRegistry([source]),
+                publisher=StubPublisher(),
+            )
+            articles = repository.list_articles(limit=10, include_hidden=True)
+            article_ids = [int(item["id"]) for item in articles]
+            openai_id = next(int(item["id"]) for item in articles if item["source_id"] == "openai-news")
+            anthropic_id = next(
+                int(item["id"]) for item in articles if item["source_id"] == "anthropic-news"
+            )
+
+            created = service.create_digest_snapshot(
+                region="all",
+                article_ids=article_ids,
+                since_hours=24,
+                limit=10,
+                use_llm=False,
+                editor_items=[
+                    {
+                        "article_id": openai_id,
+                        "selected": True,
+                        "manual_rank": 1,
+                        "publish_title_override": "版本1：OpenAI 优先",
+                        "publish_summary_override": "版本1摘要",
+                    }
+                ],
+                actor="editor-a",
+                change_summary="initial snapshot",
+            )
+            digest_id = int(created["stored_digest"]["id"])
+            version_one_title = created["selection_preview"][0]["title"]
+            self.assertEqual(created["stored_digest"]["current_version"], 1)
+
+            updated = service.update_digest_editor(
+                digest_id,
+                editor_items=[
+                    {
+                        "article_id": anthropic_id,
+                        "selected": True,
+                        "manual_rank": 1,
+                        "publish_title_override": "版本2：Anthropic 优先",
+                        "publish_summary_override": "版本2摘要",
+                    },
+                    {
+                        "article_id": openai_id,
+                        "selected": True,
+                        "manual_rank": 2,
+                    },
+                ],
+                actor="editor-b",
+                change_summary="promote anthropic",
+            )
+
+            self.assertEqual(updated["stored_digest"]["current_version"], 2)
+            self.assertEqual(updated["selection_preview"][0]["title"], "版本2：Anthropic 优先")
+            history = service.list_digest_versions(digest_id, limit=10)
+            self.assertEqual(history["current_version"], 2)
+            self.assertEqual([item["version"] for item in history["versions"][:2]], [2, 1])
+            self.assertEqual(history["versions"][0]["change_summary"], "promote anthropic")
+
+            preview = service.preview_publication_targets(
+                digest_id=digest_id,
+                targets=["static_site", "telegram"],
+            )
+            self.assertEqual(
+                preview["preview_targets"]["requested_targets"],
+                ["static_site", "telegram"],
+            )
+            self.assertEqual(len(preview["preview_targets"]["targets"]), 2)
+
+            publish_result = service.publish_digest(digest_id=digest_id, targets=["static_site"])
+            self.assertEqual(publish_result["digest_snapshot_version"], 2)
+            self.assertEqual(
+                publish_result["publication_records"][0]["digest_snapshot_version"],
+                2,
+            )
+            history = service.list_digest_versions(digest_id, limit=10)
+            version_two = next(item for item in history["versions"] if item["version"] == 2)
+            self.assertEqual(
+                version_two["publication_records"][0]["digest_snapshot_version"],
+                2,
+            )
+
+            rolled_back = service.rollback_digest_snapshot(
+                digest_id,
+                version=1,
+                actor="editor-c",
+                change_summary="restore version 1",
+            )
+
+            self.assertEqual(rolled_back["stored_digest"]["current_version"], 3)
+            self.assertEqual(rolled_back["selection_preview"][0]["title"], version_one_title)
+            history = service.list_digest_versions(digest_id, limit=10)
+            latest = history["versions"][0]
+            self.assertEqual(latest["version"], 3)
+            self.assertEqual(latest["action"], "rollback")
+            self.assertEqual(latest["restored_from_version"], 1)
 
     def test_enrich_and_digest_with_llm_client(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- add versioned digest snapshot storage with actor and change-summary metadata
- expose digest history and rollback APIs
- record publication snapshot versions and show when a digest changed after publish
- add publish-target preview support for Telegram, Feishu, static site, and WeChat
- surface version history, rollback, and final publish previews in the admin console

## Why
Frozen digests were editable, but they did not have a first-class version history or rollback path. Operators also could not inspect the final target-specific rendering before outbound publish. This change makes the editorial workflow auditable and safer.

## Validation
- targeted API and service tests for digest snapshot editing and publish flows
- full `make check PYTHON=./.venv-dev/bin/python`
