### PR TITLE
docs: add governance and architecture metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use AI News Open in research, operations reporting, or demos, please cite it using the metadata below."
+title: "AI News Open"
+type: software
+version: "1.2.46"
+license: "MIT"
+abstract: "Open-source workflow for aggregating AI news, translating global coverage into Chinese, and publishing daily digests across channels."
+authors:
+  - family-names: "X-PG13"
+repository-code: "https://github.com/X-PG13/ainews-open"
+url: "https://github.com/X-PG13/ainews-open"
+keywords:
+  - "ai"
+  - "news"
+  - "digest"
+  - "fastapi"
+  - "rss"
+  - "telegram"
+  - "wechat"

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,68 @@
+# Governance
+
+## Scope
+
+This document defines how AI News Open makes decisions about code, documentation, releases, and community operations.
+
+## Current Model
+
+The repository currently operates with a single-maintainer model.
+
+- `CODEOWNERS` defines the default owner for each area.
+- Pull requests are the default path for behavior, contract, deployment, workflow, and governance changes.
+- Protected-branch checks, CI, and release workflows provide the baseline change-control system.
+
+This model optimizes for shipping velocity without dropping reviewability.
+
+## Decision Rules
+
+- Routine fixes, documentation updates, and source registry maintenance can be merged by the active maintainer once validation is complete.
+- Behavior changes that affect CLI output, API payloads, database schema, publishing targets, or release automation must include tests and docs updates in the same change.
+- Breaking changes must be called out in `CHANGELOG.md`, release notes, and any impacted operator documentation before release.
+- Security-sensitive issues follow `SECURITY.md` and should not be discussed in public issues before a fix and disclosure plan exists.
+- Governance, support, and review-process changes should be proposed through a pull request so the rationale is visible in-repo.
+
+## Maintainer Responsibilities
+
+Active maintainers are expected to:
+
+- keep CI, release, and packaging workflows passing;
+- triage issues and pull requests on a best-effort basis;
+- preserve documented compatibility and release expectations;
+- review security reports and coordinate fixes privately;
+- keep `README.md`, `CONTRIBUTING.md`, `SUPPORT.md`, and release notes aligned with reality.
+
+## Adding Maintainers
+
+New maintainers should meet all of the following:
+
+- sustained, high-quality contribution history across multiple changesets;
+- demonstrated familiarity with release, support, and security expectations;
+- willingness to review changes outside their original contribution area;
+- ability to keep project metadata and public communication accurate.
+
+When a maintainer is added, update all of the following together:
+
+- `MAINTAINERS.md`
+- `.github/CODEOWNERS`
+- protected-branch review settings
+- package and repository metadata if needed
+
+## Decision Escalation
+
+When there is disagreement:
+
+1. Prefer the most reversible option.
+2. Prefer documented contracts over ad hoc precedent.
+3. Prefer smaller scoped changes over bundled refactors.
+4. The active maintainer makes the final merge decision for unresolved disputes.
+
+## Community Signals
+
+The repository should keep these project-health signals current:
+
+- support boundaries in `SUPPORT.md`
+- security intake in `SECURITY.md`
+- contribution expectations in `CONTRIBUTING.md`
+- ownership routing in `.github/CODEOWNERS`
+- release history in `CHANGELOG.md` and `docs/releases/`

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,33 @@
+# Maintainers
+
+## Active Maintainers
+
+| Handle | Role | Responsibilities |
+| --- | --- | --- |
+| `@X-PG13` | Lead maintainer | Core application, release management, docs, workflows, issue triage, and security coordination |
+
+## Maintainer Expectations
+
+Active maintainers should:
+
+- review pull requests for correctness, scope, and release impact;
+- keep issue labels, templates, and roadmap signals usable for contributors;
+- verify release artifacts before tagging or publishing;
+- update governance and support documents when process expectations change.
+
+## Ownership Notes
+
+- Path-level ownership lives in `.github/CODEOWNERS`.
+- Security reporting flow lives in `SECURITY.md`.
+- User support boundaries live in `SUPPORT.md`.
+- PR review expectations live in `docs/pr-review-policy.md`.
+
+## Succession Checklist
+
+If ownership changes, update these files and settings in the same change:
+
+- `MAINTAINERS.md`
+- `GOVERNANCE.md`
+- `.github/CODEOWNERS`
+- `pyproject.toml` maintainer metadata
+- repository branch protection and release credentials

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ make check
 
 ## Operator Docs
 
+- [Architecture Overview](docs/architecture.md)
 - [Compatibility Contract](docs/compatibility.md)
 - [Configuration Matrix](docs/configuration.md)
 - [First Deploy Guide](docs/first-deploy.md)
@@ -215,7 +216,7 @@ python -m pip install -e ".[dev]"
 
 This repository already includes the expected open-source project baseline:
 
-- Community docs: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`
+- Community docs: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`
 - Collaboration templates: GitHub issue templates, pull request template, `CODEOWNERS`, and review policy
 - Quality gates: `ruff`, unit tests, coverage, package build validation, `pre-commit`
 - Automation: CI, tag-based release workflow, CodeQL, Dependabot
@@ -239,6 +240,9 @@ Recommended community scaffolding:
 
 - `ROADMAP.md`
 - `SUPPORT.md`
+- `GOVERNANCE.md`
+- `MAINTAINERS.md`
+- `docs/architecture.md`
 - `.github/labels.yml`
 
 ## LLM Translation and Digest Generation

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,6 +88,7 @@ make check
 
 ## 运维与交付文档
 
+- [架构总览](docs/architecture.md)
 - [兼容性约定](docs/compatibility.md)
 - [配置矩阵](docs/configuration.zh-CN.md)
 - [首次部署指南](docs/first-deploy.zh-CN.md)
@@ -215,7 +216,7 @@ python -m pip install -e ".[dev]"
 
 当前仓库已经补齐以下开源工程基线：
 
-- 社区文档：`CONTRIBUTING.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`
+- 社区文档：`CONTRIBUTING.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`、`GOVERNANCE.md`、`MAINTAINERS.md`、`CITATION.cff`
 - 协作模板：GitHub issue templates、pull request template、`CODEOWNERS` 和审核约定
 - 质量门禁：`ruff` lint、单元测试、coverage、包构建校验、`pre-commit`
 - 自动化：CI、tag release workflow、CodeQL、Dependabot
@@ -239,6 +240,9 @@ python -m pip install -e ".[dev]"
 
 - `ROADMAP.md`
 - `SUPPORT.md`
+- `GOVERNANCE.md`
+- `MAINTAINERS.md`
+- `docs/architecture.md`
 - `.github/labels.yml`
 
 ## LLM 翻译与日报

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture Overview
+
+## System Shape
+
+AI News Open is a layered Python application with one shared SQLite data store and three operator-facing surfaces:
+
+- CLI for scheduled and local workflows
+- FastAPI for automation and admin APIs
+- Zero-build web console for operational control
+
+The same service layer drives all three so behavior stays consistent across entrypoints.
+
+## End-To-End Flow
+
+1. Source definitions are loaded from `src/ainews/sources.default.json` or an override file.
+2. Feed items are fetched and parsed into normalized `ArticleRecord` objects.
+3. URLs, titles, and content-derived signals are used to deduplicate and group cross-source variants.
+4. Article bodies are extracted and optionally enriched through an OpenAI-compatible LLM.
+5. A digest payload is built, optionally frozen into an editable snapshot, and persisted.
+6. The publishing layer renders that payload into channel-specific formats and records publication history.
+
+## Core Modules
+
+| Path | Responsibility |
+| --- | --- |
+| `src/ainews/cli.py` | CLI entrypoint and command routing |
+| `src/ainews/api.py` | FastAPI app and admin/public HTTP routes |
+| `src/ainews/service.py` | Application orchestration, business rules, and workflow composition |
+| `src/ainews/repository.py` | SQLite schema, persistence, deduplication, and query layer |
+| `src/ainews/content_extractor.py` | Article body extraction and source cleanup heuristics |
+| `src/ainews/publisher.py` | Channel rendering and outbound publishing adapters |
+| `src/ainews/llm.py` | OpenAI-compatible enrichment and digest generation client |
+| `src/ainews/telemetry.py` / `metrics.py` | Runtime history, counters, and monitoring surfaces |
+| `src/ainews/web/` | Static admin console assets |
+
+## Data Boundaries
+
+- `articles` are the operational source of truth for ingest, extraction, enrichment, and editorial curation.
+- `digests` store persisted snapshot payloads that can be served again without recomputing a fresh digest.
+- `digest_snapshot_versions` tracks editor history and rollback points for stored digests.
+- `publications` is append-only history for outbound delivery attempts and status refreshes.
+
+## Important Invariants
+
+- Duplicate clustering should be stable across replayed or historical feeds; it must not depend on the wall clock alone.
+- Admin actions exposed in the dashboard should map to API routes and service-layer methods together.
+- Publication records must preserve the digest snapshot version they were created from.
+- Public error payloads must stay sanitized even when internal exceptions contain sensitive details.
+
+## Extension Points
+
+- Add or disable feeds in `src/ainews/sources.default.json`.
+- Improve extraction behavior in `src/ainews/content_extractor.py` with fixture-backed tests.
+- Add publish targets in `src/ainews/publisher.py`, then wire CLI, API, and docs in the same change.
+- Extend operator views through `src/ainews/api.py` and `src/ainews/web/` without introducing a frontend build step unless there is a strong reason.
+
+## Operational Design Choices
+
+- SQLite is the default persistence layer to keep local and single-node deployment simple.
+- Static frontend assets keep the admin surface easy to inspect, patch, and ship.
+- OpenAI-compatible LLM configuration keeps the enrichment layer provider-flexible.
+- Docker, Compose, monitoring assets, and release workflows are shipped in-repo so operators can audit the full path to production.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ Repository = "https://github.com/X-PG13/ainews-open"
 Documentation = "https://github.com/X-PG13/ainews-open#readme"
 Issues = "https://github.com/X-PG13/ainews-open/issues"
 Changelog = "https://github.com/X-PG13/ainews-open/blob/main/CHANGELOG.md"
+Support = "https://github.com/X-PG13/ainews-open/blob/main/SUPPORT.md"
+Security = "https://github.com/X-PG13/ainews-open/security/policy"
+Governance = "https://github.com/X-PG13/ainews-open/blob/main/GOVERNANCE.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- add `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`, and `docs/architecture.md`
- link governance, support, security, and architecture entry points from the README files
- expose support, security, and governance URLs in `pyproject.toml`

## Why
The repository already had strong engineering automation, but it was still missing a few high-signal documents that external users and contributors expect from mature open-source projects: governance, maintainer ownership, citation metadata, and a concise architecture overview.

## Validation
- docs and metadata verified in the full `make check PYTHON=./.venv-dev/bin/python` pass
