### PR TITLE
chore: prepare v1.2.47 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.47] - 2026-04-15
+
+### Added
+
+- Versioned digest history, rollback routes, and publish-target preview support for stored snapshots
+- Governance metadata and contributor-facing architecture docs through `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`, and `docs/architecture.md`
+
+### Changed
+
+- Package version is now `1.2.47`
+- Package author and maintainer metadata now point to `X-PG13 <2720174336@qq.com>`
+- Publication history now records the digest snapshot version used for each publish attempt and surfaces when a digest changed after publish
+
+### Fixed
+
+- Duplicate clustering for replayed or historical feeds now uses article publish time instead of the wall clock
+- Qualified publication history queries so digest version history no longer fails with `ambiguous column name: id`
+- Added service and API regression coverage for digest history, rollback, and publish preview flows
+
 ## [1.2.46] - 2026-04-11
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use AI News Open in research, operations reporting, or demos, please cite it using the metadata below."
 title: "AI News Open"
 type: software
-version: "1.2.46"
+version: "1.2.47"
 license: "MIT"
 abstract: "Open-source workflow for aggregating AI news, translating global coverage into Chinese, and publishing daily digests across channels."
 authors:

--- a/docs/github-launch-kit.md
+++ b/docs/github-launch-kit.md
@@ -6,18 +6,18 @@ This file is the first public-facing copy pack for the GitHub repository and rel
 
 ### Suggested Tag
 
-`v1.2.46`
+`v1.2.47`
 
 ### Suggested Title
 
-`AI News Open v1.2.46 · Frozen Digest Snapshot Editing`
+`AI News Open v1.2.47 · Auditable Digest Publishing`
 
 ### Release Notes
 
 ```md
-## AI News Open v1.2.46
+## AI News Open v1.2.47
 
-AI News Open `v1.2.46` adds a frozen digest snapshot workflow so maintainers can preview, edit, save, and publish a confirmed digest draft instead of relying on a live recompute at publish time.
+AI News Open `v1.2.47` makes digest publishing auditable end to end with version history, rollback, publish-target previews, and a more complete open-source governance baseline.
 
 ### What it does
 
@@ -40,10 +40,11 @@ AI News Open `v1.2.46` adds a frozen digest snapshot workflow so maintainers can
 
 ### Highlights in this release
 
-- New digest snapshot APIs for freezing a preview into a stored editable draft and updating that draft in place
-- New dashboard editor controls for manual rank, section overrides, publish title overrides, and publish summary overrides
-- Publish flows now reuse the confirmed snapshot behind a stored `digest_id`, which removes preview-versus-publish drift when new articles arrive between review and send
-- Compatibility docs and bilingual README guidance now describe the preview, snapshot, editor, and publish-from-snapshot contract
+- Stored digests now keep a versioned edit history with rollback APIs and dashboard history views
+- Publish flows can preview final Telegram, Feishu, static-site, and WeChat payloads before outbound delivery
+- Publication records now pin the digest snapshot version they were created from, making post-publish drift visible in the admin console
+- Historical-feed deduplication is stable again because duplicate clustering now uses article publish time rather than the ingest wall clock
+- Governance, maintainer ownership, citation metadata, and architecture docs are now first-class repository entry points
 
 ### Quick start
 

--- a/docs/releases/v1.2.47.md
+++ b/docs/releases/v1.2.47.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.47
+
+## Highlights
+
+- Added versioned digest snapshot history, rollback, and publish-target preview support across the API, service layer, repository, and admin console.
+- Stabilized duplicate clustering for historical feed replays by anchoring the dedup window to article publish time.
+- Added governance, maintainer, citation, and architecture metadata so the repository meets a stronger open-source baseline.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release workflow on tag push`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.46"
+version = "1.2.47"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.46"
+__version__ = "1.2.47"


### PR DESCRIPTION
## Summary
- bump package and citation metadata to 
- add the  changelog entry and release notes
- refresh the GitHub launch kit copy for the new release

## Why
The repository now has merged fixes, publishing workflow improvements, and open-source governance additions on . This PR prepares the next tagged release so the protected-branch workflow can produce a clean  tag and GitHub Release.

## Validation
- ./.venv-dev/bin/python -m ruff check src tests
All checks passed!
./.venv-dev/bin/python -m coverage run -m unittest discover -s tests -v
./.venv-dev/bin/python -m coverage report
Name                              Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------
src/ainews/__init__.py                2      0      0      0   100%
src/ainews/alerting.py              103     14     36     10    83%   115, 127, 130, 153, 171, 183, 189, 196-198, 206, 217->212, 234-236
src/ainews/api.py                   676    289     24      4    58%   219, 220->222, 257-263, 267-273, 333-339, 343-349, 353-358, 381-395, 428, 433, 443-450, 461-468, 472-482, 491-504, 520-544, 564, 566, 568, 578, 580, 582, 591-598, 605-612, 626-633, 668-675, 690, 692, 695-696, 704-720, 737-744, 758-765, 781-788, 805-812, 828-835, 854-861, 869-885, 902-909, 929-936, 953-960, 972-979, 996-1003, 1011-1033, 1056, 1058, 1060, 1080-1087, 1096-1106, 1117-1134, 1151-1158, 1170-1177, 1189, 1191-1198
src/ainews/cli.py                   184     24     40     11    84%   252-258, 261-262, 265-274, 277-286, 289-298, 372-380, 383-393, 396-405, 426-440, 449-451, 462-463, 467
src/ainews/config.py                102      7     22      6    86%   26, 97->104, 100-102, 105-107, 112->115, 116->119
src/ainews/content_extractor.py     319     47    136     17    83%   2215, 2259, 2266-2269, 2272-2283, 2286-2290, 2293-2294, 2297, 2322-2323, 2357-2358, 2362, 2410, 2414, 2418->2422, 2456, 2464, 2466, 2500, 2523, 2525, 2543-2550, 2562, 2578
src/ainews/feed_parser.py            62      7     30     10    79%   29, 38, 39->33, 41, 53, 92->97, 95->97, 118->125, 120-123, 128->126
src/ainews/google_news.py            92      9     26      9    85%   35, 72, 149, 157, 163, 164->154, 166, 169-170, 171->164, 173
src/ainews/http.py                   66      1     10      1    97%   123
src/ainews/llm.py                    45      6     14      6    80%   43, 118, 123->116, 138, 157, 162-167
src/ainews/logging_utils.py          24      1     10      1    94%   41
src/ainews/metrics.py                39      9     20      5    66%   34-35, 62, 94->124, 103-114, 115->124
src/ainews/models.py                 65      5      0      0    92%   49-52, 64
src/ainews/publisher.py             440     72    182     60    77%   69-72, 80, 84, 113, 115, 132-139, 148, 184, 186, 217, 221-222, 227-231, 240-252, 258, 276, 292, 295->297, 303-305, 323-325, 363, 368->371, 419, 424, 437, 443, 446->449, 472, 474, 483-491, 499, 501, 507, 515-517, 523-525, 531-533, 544-546, 551, 565->560, 582->584, 584->588, 590->592, 596->598, 612, 615->618, 621->623, 623->626, 639, 640->643, 734, 833->836, 837->844, 847->849, 849->844, 855->867, 862->857, 868->871, 878, 893->896, 900->902, 908-909
src/ainews/repository.py            926    110    244     55    84%   461-463, 475-477, 489-491, 509-562, 594-600, 654-655, 726-729, 869, 956-958, 971, 991, 1002, 1096-1098, 1110->1120, 1155-1157, 1192-1193, 1477->1481, 1482-1483, 1486->1489, 1500->1517, 1532-1533, 1627->1630, 1631->1633, 1668->1673, 1713->1715, 1715->1699, 1729, 1779->1782, 1782->1785, 1786->1789, 1894, 2197-2199, 2203-2205, 2208-2209, 2260->2276, 2356, 2396, 2412-2428, 2567-2576, 2580, 2724-2726, 2738-2739, 2741, 2744-2745, 2747, 2750->2754, 2763, 2874-2875, 2894, 2912, 3129, 3186-3225, 3413->3417, 3421->3425, 3425->3429, 3535->3540, 3584, 3787-3788, 3791-3792, 3795-3796, 3805-3806, 3809
src/ainews/service.py              1346    136    418     92    87%   95, 338-341, 352, 363->367, 482, 492, 503-524, 611-623, 646, 794->819, 842->852, 865->884, 1023, 1049->1051, 1059, 1097, 1098->1100, 1178, 1181-1184, 1189, 1270, 1313, 1327, 1330, 1334, 1383, 1400, 1403, 1424, 1465-1474, 1477-1486, 1676, 1740, 1753, 1783->1786, 1787, 1791-1802, 1865, 1913->1916, 2030-2034, 2113, 2140-2164, 2170, 2207, 2227, 2229, 2232-2235, 2237->2239, 2244, 2326-2327, 2420, 2513-2514, 2516, 2605, 2618, 2620, 2650-2655, 2750-2751, 2753-2754, 2775->2791, 2824->2826, 2835-2840, 2848->2850, 2850->2852, 2857, 2860, 2864-2867, 2874, 2886, 2895, 2901, 2913, 2921, 2926, 3046, 3052, 3093, 3099-3100, 3133, 3143, 3150, 3157->3159, 3159->3161, 3161->3163, 3168, 3179, 3244, 3252, 3254, 3277-3278, 3303-3307, 3313, 3315, 3317, 3319, 3327, 3334, 3389->3391, 3399->3401, 3408-3410, 3422-3434
src/ainews/source_registry.py        21      1      6      1    93%   28
src/ainews/telemetry.py              41      0      4      0   100%
src/ainews/utils.py                 107     17     32     10    79%   86, 91, 96, 104, 106-107, 114, 120, 129, 137-142, 145, 161->159, 164
-----------------------------------------------------------------------------
TOTAL                              4660    755   1254    298    81%
./.venv-dev/bin/python -m build
running egg_info
writing src/ainews_open.egg-info/PKG-INFO
writing dependency_links to src/ainews_open.egg-info/dependency_links.txt
writing entry points to src/ainews_open.egg-info/entry_points.txt
writing requirements to src/ainews_open.egg-info/requires.txt
writing top-level names to src/ainews_open.egg-info/top_level.txt
reading manifest file 'src/ainews_open.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'src/ainews_open.egg-info/SOURCES.txt'
running sdist
running egg_info
writing src/ainews_open.egg-info/PKG-INFO
writing dependency_links to src/ainews_open.egg-info/dependency_links.txt
writing entry points to src/ainews_open.egg-info/entry_points.txt
writing requirements to src/ainews_open.egg-info/requires.txt
writing top-level names to src/ainews_open.egg-info/top_level.txt
reading manifest file 'src/ainews_open.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'src/ainews_open.egg-info/SOURCES.txt'
running check
creating ainews_open-1.2.47
creating ainews_open-1.2.47/src/ainews
creating ainews_open-1.2.47/src/ainews/web
creating ainews_open-1.2.47/src/ainews_open.egg-info
creating ainews_open-1.2.47/tests
copying files to ainews_open-1.2.47...
copying LICENSE -> ainews_open-1.2.47
copying README.md -> ainews_open-1.2.47
copying pyproject.toml -> ainews_open-1.2.47
copying setup.py -> ainews_open-1.2.47
copying src/ainews/__init__.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/__main__.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/alerting.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/api.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/cli.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/config.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/content_extractor.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/feed_parser.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/google_news.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/http.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/llm.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/logging_utils.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/metrics.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/models.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/publisher.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/repository.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/service.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/source_registry.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/sources.default.json -> ainews_open-1.2.47/src/ainews
copying src/ainews/telemetry.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/utils.py -> ainews_open-1.2.47/src/ainews
copying src/ainews/web/app.js -> ainews_open-1.2.47/src/ainews/web
copying src/ainews/web/index.html -> ainews_open-1.2.47/src/ainews/web
copying src/ainews/web/styles.css -> ainews_open-1.2.47/src/ainews/web
copying src/ainews_open.egg-info/PKG-INFO -> ainews_open-1.2.47/src/ainews_open.egg-info
copying src/ainews_open.egg-info/SOURCES.txt -> ainews_open-1.2.47/src/ainews_open.egg-info
copying src/ainews_open.egg-info/dependency_links.txt -> ainews_open-1.2.47/src/ainews_open.egg-info
copying src/ainews_open.egg-info/entry_points.txt -> ainews_open-1.2.47/src/ainews_open.egg-info
copying src/ainews_open.egg-info/requires.txt -> ainews_open-1.2.47/src/ainews_open.egg-info
copying src/ainews_open.egg-info/top_level.txt -> ainews_open-1.2.47/src/ainews_open.egg-info
copying tests/test_alerting.py -> ainews_open-1.2.47/tests
copying tests/test_api.py -> ainews_open-1.2.47/tests
copying tests/test_cli.py -> ainews_open-1.2.47/tests
copying tests/test_config.py -> ainews_open-1.2.47/tests
copying tests/test_content_extractor.py -> ainews_open-1.2.47/tests
copying tests/test_feed_parser.py -> ainews_open-1.2.47/tests
copying tests/test_google_news.py -> ainews_open-1.2.47/tests
copying tests/test_http.py -> ainews_open-1.2.47/tests
copying tests/test_integration_http.py -> ainews_open-1.2.47/tests
copying tests/test_logging_utils.py -> ainews_open-1.2.47/tests
copying tests/test_pipeline_e2e.py -> ainews_open-1.2.47/tests
copying tests/test_publisher.py -> ainews_open-1.2.47/tests
copying tests/test_repository.py -> ainews_open-1.2.47/tests
copying tests/test_service.py -> ainews_open-1.2.47/tests
copying tests/test_source_registry.py -> ainews_open-1.2.47/tests
copying tests/test_telemetry.py -> ainews_open-1.2.47/tests
copying tests/test_utils.py -> ainews_open-1.2.47/tests
copying src/ainews_open.egg-info/SOURCES.txt -> ainews_open-1.2.47/src/ainews_open.egg-info
Writing ainews_open-1.2.47/setup.cfg
Creating tar archive
removing 'ainews_open-1.2.47' (and everything under it)
running egg_info
writing src/ainews_open.egg-info/PKG-INFO
writing dependency_links to src/ainews_open.egg-info/dependency_links.txt
writing entry points to src/ainews_open.egg-info/entry_points.txt
writing requirements to src/ainews_open.egg-info/requires.txt
writing top-level names to src/ainews_open.egg-info/top_level.txt
reading manifest file 'src/ainews_open.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'src/ainews_open.egg-info/SOURCES.txt'
running bdist_wheel
running build
running build_py
creating build/lib/ainews
copying src/ainews/content_extractor.py -> build/lib/ainews
copying src/ainews/metrics.py -> build/lib/ainews
copying src/ainews/service.py -> build/lib/ainews
copying src/ainews/config.py -> build/lib/ainews
copying src/ainews/models.py -> build/lib/ainews
copying src/ainews/__init__.py -> build/lib/ainews
copying src/ainews/telemetry.py -> build/lib/ainews
copying src/ainews/llm.py -> build/lib/ainews
copying src/ainews/api.py -> build/lib/ainews
copying src/ainews/cli.py -> build/lib/ainews
copying src/ainews/utils.py -> build/lib/ainews
copying src/ainews/http.py -> build/lib/ainews
copying src/ainews/feed_parser.py -> build/lib/ainews
copying src/ainews/publisher.py -> build/lib/ainews
copying src/ainews/repository.py -> build/lib/ainews
copying src/ainews/alerting.py -> build/lib/ainews
copying src/ainews/google_news.py -> build/lib/ainews
copying src/ainews/source_registry.py -> build/lib/ainews
copying src/ainews/__main__.py -> build/lib/ainews
copying src/ainews/logging_utils.py -> build/lib/ainews
running egg_info
writing src/ainews_open.egg-info/PKG-INFO
writing dependency_links to src/ainews_open.egg-info/dependency_links.txt
writing entry points to src/ainews_open.egg-info/entry_points.txt
writing requirements to src/ainews_open.egg-info/requires.txt
writing top-level names to src/ainews_open.egg-info/top_level.txt
reading manifest file 'src/ainews_open.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'src/ainews_open.egg-info/SOURCES.txt'
copying src/ainews/sources.default.json -> build/lib/ainews
creating build/lib/ainews/web
copying src/ainews/web/index.html -> build/lib/ainews/web
copying src/ainews/web/styles.css -> build/lib/ainews/web
copying src/ainews/web/app.js -> build/lib/ainews/web
installing to build/bdist.macosx-10.9-universal2/wheel
running install
running install_lib
creating build/bdist.macosx-10.9-universal2/wheel
creating build/bdist.macosx-10.9-universal2/wheel/ainews
copying build/lib/ainews/content_extractor.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/metrics.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/service.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/config.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/models.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/sources.default.json -> build/bdist.macosx-10.9-universal2/wheel/./ainews
creating build/bdist.macosx-10.9-universal2/wheel/ainews/web
copying build/lib/ainews/web/index.html -> build/bdist.macosx-10.9-universal2/wheel/./ainews/web
copying build/lib/ainews/web/styles.css -> build/bdist.macosx-10.9-universal2/wheel/./ainews/web
copying build/lib/ainews/web/app.js -> build/bdist.macosx-10.9-universal2/wheel/./ainews/web
copying build/lib/ainews/__init__.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/telemetry.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/llm.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/api.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/cli.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/utils.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/http.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/feed_parser.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/publisher.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/repository.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/alerting.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/google_news.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/source_registry.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/__main__.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
copying build/lib/ainews/logging_utils.py -> build/bdist.macosx-10.9-universal2/wheel/./ainews
running install_egg_info
Copying src/ainews_open.egg-info to build/bdist.macosx-10.9-universal2/wheel/./ainews_open-1.2.47-py3.9.egg-info
running install_scripts
creating build/bdist.macosx-10.9-universal2/wheel/ainews_open-1.2.47.dist-info/WHEEL
creating '/Users/zhaoyifan/Desktop/news/dist/.tmp-gi04u3y3/ainews_open-1.2.47-py3-none-any.whl' and adding 'build/bdist.macosx-10.9-universal2/wheel' to it
adding 'ainews/__init__.py'
adding 'ainews/__main__.py'
adding 'ainews/alerting.py'
adding 'ainews/api.py'
adding 'ainews/cli.py'
adding 'ainews/config.py'
adding 'ainews/content_extractor.py'
adding 'ainews/feed_parser.py'
adding 'ainews/google_news.py'
adding 'ainews/http.py'
adding 'ainews/llm.py'
adding 'ainews/logging_utils.py'
adding 'ainews/metrics.py'
adding 'ainews/models.py'
adding 'ainews/publisher.py'
adding 'ainews/repository.py'
adding 'ainews/service.py'
adding 'ainews/source_registry.py'
adding 'ainews/sources.default.json'
adding 'ainews/telemetry.py'
adding 'ainews/utils.py'
adding 'ainews/web/app.js'
adding 'ainews/web/index.html'
adding 'ainews/web/styles.css'
adding 'ainews_open-1.2.47.dist-info/licenses/LICENSE'
adding 'ainews_open-1.2.47.dist-info/METADATA'
adding 'ainews_open-1.2.47.dist-info/WHEEL'
adding 'ainews_open-1.2.47.dist-info/entry_points.txt'
adding 'ainews_open-1.2.47.dist-info/top_level.txt'
adding 'ainews_open-1.2.47.dist-info/RECORD'
removing build/bdist.macosx-10.9-universal2/wheel
Successfully built ainews_open-1.2.47.tar.gz and ainews_open-1.2.47-py3-none-any.whl
