### PR TITLE
fix: verify release checksums from downloaded assets

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -44,25 +44,26 @@ jobs:
 
       - name: Download release assets
         run: |
-          mkdir -p dist
+          mkdir -p release-assets
           gh release download "${RELEASE_TAG}" \
-            --dir dist \
+            --dir release-assets \
             --pattern "*.whl" \
             --pattern "*.tar.gz" \
             --pattern "sha256sums.txt"
-          ls -la dist
+          ls -la release-assets
 
       - name: Verify release checksums
-        run: sha256sum -c dist/sha256sums.txt
+        working-directory: release-assets
+        run: sha256sum -c sha256sums.txt
 
       - name: Install artifact
         run: |
           case "${{ matrix.artifact }}" in
             wheel)
-              ARTIFACT_PATH="$(find dist -maxdepth 1 -type f -name '*.whl' | head -n 1)"
+              ARTIFACT_PATH="$(find release-assets -maxdepth 1 -type f -name '*.whl' | head -n 1)"
               ;;
             sdist)
-              ARTIFACT_PATH="$(find dist -maxdepth 1 -type f -name '*.tar.gz' | head -n 1)"
+              ARTIFACT_PATH="$(find release-assets -maxdepth 1 -type f -name '*.tar.gz' | head -n 1)"
               ;;
           esac
           test -n "${ARTIFACT_PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,13 @@ jobs:
         run: python -m build
 
       - name: Generate artifact checksums
-        run: sha256sum dist/* > dist/sha256sums.txt
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          : > sha256sums.txt
+          for artifact in *.whl *.tar.gz; do
+            sha256sum "${artifact}" >> sha256sums.txt
+          done
 
       - name: Generate SBOM
         run: |

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -22,6 +22,7 @@ For tags created through `.github/workflows/release.yml`, the smoke workflow is 
 ## Download And Verify
 
 From a release page, download the wheel, source archive, and `sha256sums.txt`.
+Run the checksum command from the same directory that contains those downloaded files.
 
 ### Linux
 

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -22,6 +22,7 @@
 ## 下载并校验
 
 从 Release 页面下载 wheel、source archive 和 `sha256sums.txt`。
+在这些文件所在的同一目录里执行 checksum 校验命令。
 
 ### Linux
 


### PR DESCRIPTION
## Summary
- generate `sha256sums.txt` with release asset filenames instead of `dist/`-prefixed paths
- make `Release Artifact Smoke` verify checksums from the downloaded asset directory directly
- clarify the checksum verification step in the English and Chinese release artifact docs

## Why
During the `v1.2.47` post-release verification pass, the asset contents were correct but `sha256sums.txt` could not be used directly after downloading the release bundle because the recorded paths assumed a local `dist/` directory. This change makes the published checksum file match the user-facing verification path.

Closes #81

## Validation
- local equivalent smoke: generate bare-filename checksums for the release bundle and run `sha256sum -c sha256sums.txt` from the download directory
- `v1.2.47` wheel install smoke already verified separately during post-release validation
