### PR TITLE
docs: define discussions categories and issue triage guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,10 @@ title: "[Bug] "
 labels:
   - bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for reproducible defects. For usage questions or broader design discussion, start in GitHub Discussions instead.
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Security Reporting
     url: https://github.com/X-PG13/ainews-open/security/advisories/new
     about: Report sensitive vulnerabilities privately through GitHub Security Advisories instead of public issues.
+  - name: GitHub Discussions
+    url: https://github.com/X-PG13/ainews-open/discussions
+    about: Ask usage questions, validate early ideas, or share deployment notes without opening an issue first.
   - name: Support Policy
     url: https://github.com/X-PG13/ainews-open/blob/main/SUPPORT.md
     about: Read the support boundaries and version policy before opening broad usage requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,9 +1,13 @@
 name: Feature Request
-description: Propose a new capability or workflow improvement
+description: Propose a concrete capability or workflow improvement that is ready to be tracked as work
 title: "[Feature] "
 labels:
   - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when the change is concrete enough to track as implementation work. For early ideas or open-ended design exploration, start in GitHub Discussions first.
   - type: textarea
     id: problem
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ make check
 
 ## Issues And Security
 
-- Use the GitHub issue templates for bugs and feature requests.
+- Use GitHub issues for reproducible bugs, scoped documentation defects, and concrete feature work.
+- Use GitHub Discussions for usage questions, early ideas, deployment notes, and design exploration that is not yet implementation-ready.
+- Start with `docs/community-triage.md` and `SUPPORT.md` if you are not sure which channel fits.
 - Do not report vulnerabilities through public issues; follow `SECURITY.md`.
 - Private vulnerability reports should go through the GitHub Security Advisory channel configured in `.github/ISSUE_TEMPLATE/config.yml`.
-- Read `SUPPORT.md` before opening broad usage questions or support requests.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ make check
 - [PR Review Policy](docs/pr-review-policy.md)
 - [Release Artifacts](docs/release-artifacts.md)
 - [Use Cases](docs/use-cases.md)
+- [Community Triage](docs/community-triage.md)
 - [Contributor Playbook](docs/contributor-playbook.md)
 - [Release Checklist](docs/release-checklist.md)
 - [Support Policy](SUPPORT.md)
@@ -216,7 +217,7 @@ python -m pip install -e ".[dev]"
 
 This repository already includes the expected open-source project baseline:
 
-- Community docs: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`
+- Community docs: `CONTRIBUTING.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`, `docs/community-triage.md`
 - Collaboration templates: GitHub issue templates, pull request template, `CODEOWNERS`, and review policy
 - Quality gates: `ruff`, unit tests, coverage, package build validation, `pre-commit`
 - Automation: CI, tag-based release workflow, CodeQL, Dependabot

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,7 @@ make check
 - [PR 审核约定](docs/pr-review-policy.zh-CN.md)
 - [Release 产物校验](docs/release-artifacts.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)
+- [社区分流规范](docs/community-triage.zh-CN.md)
 - [贡献者手册](docs/contributor-playbook.md)
 - [发版清单](docs/release-checklist.zh-CN.md)
 - [支持策略](SUPPORT.md)
@@ -216,7 +217,7 @@ python -m pip install -e ".[dev]"
 
 当前仓库已经补齐以下开源工程基线：
 
-- 社区文档：`CONTRIBUTING.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`、`GOVERNANCE.md`、`MAINTAINERS.md`、`CITATION.cff`
+- 社区文档：`CONTRIBUTING.md`、`SUPPORT.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`、`GOVERNANCE.md`、`MAINTAINERS.md`、`CITATION.cff`、`docs/community-triage.zh-CN.md`
 - 协作模板：GitHub issue templates、pull request template、`CODEOWNERS` 和审核约定
 - 质量门禁：`ruff` lint、单元测试、coverage、包构建校验、`pre-commit`
 - 自动化：CI、tag release workflow、CodeQL、Dependabot
@@ -240,6 +241,7 @@ python -m pip install -e ".[dev]"
 
 - `ROADMAP.md`
 - `SUPPORT.md`
+- `docs/community-triage.zh-CN.md`
 - `GOVERNANCE.md`
 - `MAINTAINERS.md`
 - `docs/architecture.md`

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,8 +12,15 @@
 
 - Bugs: open a GitHub issue with the bug template.
 - Security: use GitHub Security Advisories, not public issues.
-- Feature requests: use the feature request template.
-- Usage questions and design discussion: GitHub Discussions is the preferred destination once enabled for the repository.
+- Feature requests: use the feature request template once the request is concrete enough to track as implementation work.
+- Usage questions, early ideas, showcase posts, and design discussion: use GitHub Discussions. See `docs/community-triage.md` for the issue-vs-discussion split.
+
+## Discussions Categories
+
+- `Q&A`: installation, configuration, publishing, and upgrade help.
+- `Ideas`: early feature or workflow proposals that still need scope and tradeoff discussion.
+- `Show and Tell`: demos, deployment notes, and sample output from real usage.
+- `General`: community process and repository topics that do not fit the categories above.
 
 ## Maintainer Expectations
 

--- a/docs/community-triage.md
+++ b/docs/community-triage.md
@@ -1,0 +1,41 @@
+# Community Triage
+
+[English](./community-triage.md) · [简体中文](./community-triage.zh-CN.md)
+
+This repository uses GitHub Issues for actionable work items and GitHub Discussions for questions, idea validation, and community knowledge sharing.
+
+## Use GitHub Issues For
+
+- Reproducible bugs and regressions.
+- Concrete feature requests with a clear problem statement and expected outcome.
+- Scoped documentation defects or operator workflow gaps.
+- Release, packaging, CI, or compatibility work that should be tracked to completion.
+
+## Use GitHub Discussions For
+
+- Installation, configuration, publishing, or upgrade questions.
+- Early ideas that still need problem framing, API design, or workflow tradeoff discussion.
+- Showcase posts, deployment notes, and example digests from real usage.
+- General repository process questions that do not point to a specific actionable defect.
+
+## Recommended Discussions Categories
+
+- `Q&A`: usage help, debugging guidance, configuration questions, and operator how-to requests.
+- `Ideas`: proposed capabilities, workflow changes, and roadmap exploration before an issue is ready.
+- `Show and Tell`: demos, screenshots, deployment stories, and production lessons.
+- `General`: governance, contributor workflow, or other community topics that do not fit the categories above.
+
+## Maintainer Triage Rules
+
+- Move usage questions and broad design exploration out of Issues and into Discussions whenever no immediate implementation task exists.
+- Ask bug reporters to reproduce against the latest supported release or `main` before deep triage.
+- Use the `discussion` label when an issue needs design clarification before it can become implementation work.
+- Apply `good first issue` and `help wanted` only after the issue is concrete enough for someone else to pick up.
+- Add area labels such as `source`, `extractor`, `publisher`, `docs`, and `operations` after the scope is clear.
+- Redirect private vulnerability reports to `SECURITY.md` and GitHub Security Advisories instead of public threads.
+
+## Converting Between The Two
+
+- If a Discussion produces a bounded implementation task, open an Issue and link back to the discussion thread.
+- If an Issue turns out to be a support question, early idea, or showcase post, close it with a pointer to the appropriate Discussion category.
+- Keep the final actionable decision in the Issue so pull requests, milestones, and release notes still point to one tracked work item.

--- a/docs/community-triage.zh-CN.md
+++ b/docs/community-triage.zh-CN.md
@@ -1,0 +1,41 @@
+# 社区分流规范
+
+[English](./community-triage.md) · [简体中文](./community-triage.zh-CN.md)
+
+这个仓库把 GitHub Issues 用于可执行、可跟踪的工作项，把 GitHub Discussions 用于提问、想法验证和社区知识沉淀。
+
+## 适合开 GitHub Issue 的情况
+
+- 可复现的 bug 和回归问题。
+- 问题定义清楚、预期结果明确的功能请求。
+- 边界明确的文档缺陷或运维流程缺口。
+- 需要一路跟踪到完成的 release、打包、CI 或兼容性问题。
+
+## 适合开 GitHub Discussion 的情况
+
+- 安装、配置、发布链路或升级相关的使用问题。
+- 还在明确问题边界、API 设计或流程取舍的早期想法。
+- 部署经验、样例日报、效果截图等 showcase 内容。
+- 不对应某个明确缺陷的社区流程或仓库协作问题。
+
+## 建议的 Discussions 分类
+
+- `Q&A`：使用帮助、排障建议、配置问题和运维操作问答。
+- `Ideas`：还没收敛成可执行 issue 的能力提案、流程变更和 roadmap 探索。
+- `Show and Tell`：Demo、截图、部署经验和线上使用反馈。
+- `General`：治理、协作流程或其他不适合放进上面分类的话题。
+
+## 维护者分诊规则
+
+- 对于没有直接实施任务的使用问题或宽泛设计讨论，优先从 Issues 引导到 Discussions。
+- 深入分诊前，先要求 bug 报告在最新受支持 release 或 `main` 上复现。
+- 当 issue 还需要设计澄清、暂时不能直接实施时，使用 `discussion` 标签。
+- 只有当 issue 已经清晰到其他贡献者可以接手时，才加 `good first issue` 或 `help wanted`。
+- 范围明确后，再补 `source`、`extractor`、`publisher`、`docs`、`operations` 等领域标签。
+- 私密漏洞不要在公开线程里讨论，统一引导到 `SECURITY.md` 和 GitHub Security Advisories。
+
+## Issue 和 Discussion 之间如何切换
+
+- 如果某个 Discussion 已经收敛成边界清晰的实施任务，就新开一个 Issue，并回链到原讨论。
+- 如果某个 Issue 实际上是支持问题、早期想法或 showcase 内容，就关闭并引导到对应的 Discussion 分类。
+- 最终可执行的决定保留在 Issue 里，这样 PR、milestone 和 release note 仍然有唯一的跟踪入口。


### PR DESCRIPTION
## Summary
- add a dedicated community triage guide that defines when to use Issues vs Discussions
- recommend Discussions categories for Q&A, Ideas, Show and Tell, and General
- align SUPPORT, CONTRIBUTING, README entry points, and issue templates with the same routing

## Why
GitHub Discussions is enabled, but contributors still need a clear split between actionable Issues and broader community conversations. This keeps support questions and early idea validation out of the issue tracker while preserving a clear path from discussion to implementation work.

Closes #10.

## Validation
- `git diff --check`
- manual review of updated Markdown and issue template YAML
- no code tests run because this change only touches docs and GitHub issue/discussion routing metadata