### PR TITLE
docs: add maintainer bootstrap guide for pages and pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ make check
 - [Database Migrations](docs/database-migrations.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Monitoring](docs/monitoring.md)
+- [Maintainer Bootstrap](docs/maintainer-bootstrap.md)
 - [PR Review Policy](docs/pr-review-policy.md)
 - [Release Artifacts](docs/release-artifacts.md)
 - [Use Cases](docs/use-cases.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,6 +96,7 @@ make check
 - [数据库迁移](docs/database-migrations.md)
 - [故障排查](docs/troubleshooting.zh-CN.md)
 - [监控接入](docs/monitoring.zh-CN.md)
+- [维护者初始化清单](docs/maintainer-bootstrap.zh-CN.md)
 - [PR 审核约定](docs/pr-review-policy.zh-CN.md)
 - [Release 产物校验](docs/release-artifacts.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -153,10 +153,7 @@ The repository also includes:
 - [codeql.yml](../.github/workflows/codeql.yml) for security analysis
 - [.github/dependabot.yml](../.github/dependabot.yml) for dependency update PRs
 
-Release maintainers should also configure:
-
-- a `pypi` environment with PyPI trusted publishing enabled
-- GitHub Pages if the demo site should be public
+If this is the first time you are enabling GitHub Pages or PyPI publishing for the repository, follow [maintainer-bootstrap.md](./maintainer-bootstrap.md) for the exact repository settings, environment names, and trusted-publisher fields expected by these workflows.
 
 Recommended secrets:
 

--- a/docs/deployment.zh-CN.md
+++ b/docs/deployment.zh-CN.md
@@ -148,6 +148,8 @@ sudo systemctl status ainews-open
 - [demo-pages.yml](../.github/workflows/demo-pages.yml)：发布 GitHub Pages demo
 - [codeql.yml](../.github/workflows/codeql.yml)：安全扫描
 
+如果这是你第一次给仓库启用 GitHub Pages 或 PyPI 发布，先看 [maintainer-bootstrap.zh-CN.md](./maintainer-bootstrap.zh-CN.md)。里面写清楚了这些 workflow 依赖的 GitHub 仓库设置、environment 名称和 PyPI trusted publisher 表单字段。
+
 推荐 secrets：
 
 - `AINEWS_LLM_BASE_URL`

--- a/docs/maintainer-bootstrap.md
+++ b/docs/maintainer-bootstrap.md
@@ -1,0 +1,86 @@
+# Maintainer Bootstrap
+
+[English](./maintainer-bootstrap.md) · [简体中文](./maintainer-bootstrap.zh-CN.md)
+
+This guide documents the one-time repository setup that maintainers need before GitHub Pages and PyPI publishing can run without guesswork.
+
+## What This Covers
+
+- GitHub Pages deployment for the sample demo via [demo-pages.yml](../.github/workflows/demo-pages.yml)
+- Trusted PyPI publishing via [pypi-publish.yml](../.github/workflows/pypi-publish.yml)
+- The repository variable and environment names that those workflows expect
+
+## Repository Values Used By This Repository
+
+If you fork or rename the repository, update these values before configuring external services:
+
+- GitHub owner: `X-PG13`
+- GitHub repository: `ainews-open`
+- Default branch: `main`
+- PyPI project name: `ainews-open`
+- GitHub Pages artifact path: `docs/demo/`
+- PyPI workflow file: `.github/workflows/pypi-publish.yml`
+- GitHub Pages workflow file: `.github/workflows/demo-pages.yml`
+
+## GitHub Pages One-Time Setup
+
+1. Open GitHub repository `Settings` -> `Pages`.
+2. Under `Build and deployment`, set `Source` to `GitHub Actions`.
+3. Keep [demo-pages.yml](../.github/workflows/demo-pages.yml) as the publishing workflow. It uploads `docs/demo/` and deploys it with the `github-pages` environment.
+4. Trigger the workflow once from `Actions` -> `Demo Pages` -> `Run workflow`, or push a change to `docs/demo/` on `main`.
+5. After the first successful deploy, check `Settings` -> `Environments` and confirm the `github-pages` environment is now visible for the Pages deployment job.
+6. Add a deployment protection rule on `github-pages` if you want to restrict deployments to the default branch, which matches GitHub's recommended setup for Pages workflows.
+7. Verify that `Settings` -> `Pages` shows the published site URL and that the demo is reachable.
+
+Notes:
+
+- GitHub Pages sites are public on the internet once published, even when the repository itself is private on supported plans.
+- If you later add a custom domain, configure it in `Settings` -> `Pages`; committing a `CNAME` file alone is not enough.
+
+## PyPI Trusted Publishing One-Time Setup
+
+1. Open GitHub repository `Settings` -> `Environments` -> `New environment`.
+2. Create an environment named exactly `pypi`.
+3. Optionally add required reviewers or wait timers to `pypi` if you want a manual approval gate before upload.
+4. Open GitHub repository `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`.
+5. Add a repository variable named `AINEWS_ENABLE_PYPI_PUBLISH` with value `true` if you want release publication to trigger PyPI uploads automatically.
+6. In PyPI, choose one of these setup paths:
+   - Existing project: open the `ainews-open` project, then go to `Manage` -> `Publishing` -> `Add a publisher`.
+   - Brand-new project: open your PyPI account `Publishing` page and add a pending publisher for project `ainews-open`.
+7. In the PyPI publisher form for GitHub Actions, use these values:
+   - Owner: `X-PG13`
+   - Repository name: `ainews-open`
+   - Workflow filename: `.github/workflows/pypi-publish.yml`
+   - Environment name: `pypi`
+   - Project name: `ainews-open` if you are creating a pending publisher
+8. Save the publisher. No PyPI API token secret is needed because [pypi-publish.yml](../.github/workflows/pypi-publish.yml) uses OIDC trusted publishing with `id-token: write`.
+
+## First Verification After Setup
+
+- GitHub Pages:
+  - Run `Demo Pages` once and confirm a successful deployment to `github-pages`.
+  - Open the published Pages URL and confirm the demo renders.
+- PyPI:
+  - Run `Publish To PyPI` manually from `Actions`, or publish a GitHub Release after `AINEWS_ENABLE_PYPI_PUBLISH=true` is set.
+  - Confirm the workflow enters the `pypi` environment and the release appears on PyPI.
+
+## How These Workflows Fit Together
+
+- [release.yml](../.github/workflows/release.yml) builds GitHub Release assets from tags.
+- [pypi-publish.yml](../.github/workflows/pypi-publish.yml) publishes the built package to PyPI when a GitHub Release is published, or when maintainers dispatch it manually.
+- [demo-pages.yml](../.github/workflows/demo-pages.yml) deploys the demo site from `docs/demo/` on `main` changes or manual dispatch.
+
+## Maintainer Audit Checklist
+
+- `Settings` -> `Pages` uses `GitHub Actions` as the source.
+- `Settings` -> `Environments` contains `github-pages` and `pypi`.
+- PyPI trusted publisher points to `.github/workflows/pypi-publish.yml`.
+- `AINEWS_ENABLE_PYPI_PUBLISH=true` is set if automatic PyPI publication is desired.
+- The latest `Demo Pages` and `Publish To PyPI` runs are green.
+
+## References
+
+- [GitHub Docs: Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
+- [GitHub Docs: Using custom workflows with GitHub Pages](https://docs.github.com/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+- [PyPI Docs: Adding a Trusted Publisher to an existing PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+- [PyPI Docs: Creating a PyPI Project with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)

--- a/docs/maintainer-bootstrap.zh-CN.md
+++ b/docs/maintainer-bootstrap.zh-CN.md
@@ -1,0 +1,86 @@
+# 维护者初始化清单
+
+[English](./maintainer-bootstrap.md) · [简体中文](./maintainer-bootstrap.zh-CN.md)
+
+这份文档记录维护者第一次启用 GitHub Pages 和 PyPI 发布时需要完成的一次性仓库设置，避免每次都靠猜 GitHub / PyPI 的界面选项。
+
+## 这份文档覆盖什么
+
+- 通过 [demo-pages.yml](../.github/workflows/demo-pages.yml) 发布 GitHub Pages demo
+- 通过 [pypi-publish.yml](../.github/workflows/pypi-publish.yml) 启用 PyPI trusted publishing
+- 这两条 workflow 依赖的仓库变量和 environment 名称
+
+## 当前仓库使用的固定值
+
+如果你 fork 或改名了仓库，先把下面这些值替换成你自己的，再去配置外部服务：
+
+- GitHub owner：`X-PG13`
+- GitHub 仓库名：`ainews-open`
+- 默认分支：`main`
+- PyPI 项目名：`ainews-open`
+- GitHub Pages artifact 路径：`docs/demo/`
+- PyPI workflow 文件：`.github/workflows/pypi-publish.yml`
+- GitHub Pages workflow 文件：`.github/workflows/demo-pages.yml`
+
+## GitHub Pages 一次性设置
+
+1. 打开 GitHub 仓库 `Settings` -> `Pages`。
+2. 在 `Build and deployment` 下，把 `Source` 设为 `GitHub Actions`。
+3. 保留 [demo-pages.yml](../.github/workflows/demo-pages.yml) 作为发布 workflow。它会上传 `docs/demo/`，并通过 `github-pages` environment 部署。
+4. 第一次可以从 `Actions` -> `Demo Pages` -> `Run workflow` 手动触发，也可以直接往 `main` 推送一笔涉及 `docs/demo/` 的改动。
+5. 第一次成功部署后，去 `Settings` -> `Environments` 确认 `github-pages` environment 已经出现在 Pages 部署任务对应的环境列表里。
+6. 如果你想把 Pages 部署限制在默认分支上，可以给 `github-pages` 加 deployment protection rule，这也符合 GitHub 对 Pages workflow 的推荐做法。
+7. 最后确认 `Settings` -> `Pages` 里已经显示站点 URL，并且 demo 页面能正常打开。
+
+注意：
+
+- GitHub Pages 一旦发布，对公网就是可访问的；即使仓库是私有仓库，在支持的套餐下站点本身仍然是公开的。
+- 如果之后要绑自定义域名，请在 `Settings` -> `Pages` 里配置；单独提交一个 `CNAME` 文件并不够。
+
+## PyPI Trusted Publishing 一次性设置
+
+1. 打开 GitHub 仓库 `Settings` -> `Environments` -> `New environment`。
+2. 新建一个名字必须精确为 `pypi` 的 environment。
+3. 如果你希望发布前有人审批，可以在 `pypi` 上额外加 required reviewers 或 wait timer。
+4. 打开 GitHub 仓库 `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`。
+5. 新增一个 repository variable：`AINEWS_ENABLE_PYPI_PUBLISH=true`。这样发布 GitHub Release 时才会自动触发 PyPI 上传。
+6. 在 PyPI 里，按你的场景走其中一种：
+   - 已有项目：进入 `ainews-open` 项目页，然后点 `Manage` -> `Publishing` -> `Add a publisher`
+   - 还没有项目：进入你自己的 PyPI 账号 `Publishing` 页面，为 `ainews-open` 新增一个 pending publisher
+7. 在 PyPI 的 GitHub Actions publisher 表单里，填下面这些值：
+   - Owner：`X-PG13`
+   - Repository name：`ainews-open`
+   - Workflow filename：`.github/workflows/pypi-publish.yml`
+   - Environment name：`pypi`
+   - 如果是 pending publisher，再填 Project name：`ainews-open`
+8. 保存 publisher。这里不需要单独配置 PyPI API token secret，因为 [pypi-publish.yml](../.github/workflows/pypi-publish.yml) 走的是 OIDC trusted publishing，只需要 `id-token: write`。
+
+## 完成设置后的首次验证
+
+- GitHub Pages：
+  - 手动跑一次 `Demo Pages`，确认成功部署到 `github-pages`
+  - 打开 Pages URL，确认 demo 页面能渲染
+- PyPI：
+  - 手动触发一次 `Publish To PyPI`，或者在 `AINEWS_ENABLE_PYPI_PUBLISH=true` 后发布一个 GitHub Release
+  - 确认 workflow 进入了 `pypi` environment，并且新版本已经出现在 PyPI 上
+
+## 这几条 Workflow 之间的关系
+
+- [release.yml](../.github/workflows/release.yml) 负责基于 tag 构建 GitHub Release 资产
+- [pypi-publish.yml](../.github/workflows/pypi-publish.yml) 会在 GitHub Release 发布后把包发到 PyPI，或者由维护者手动触发
+- [demo-pages.yml](../.github/workflows/demo-pages.yml) 会在 `main` 上的 demo 变更或手动触发时部署 `docs/demo/`
+
+## 维护者快速自检
+
+- `Settings` -> `Pages` 的 `Source` 已经是 `GitHub Actions`
+- `Settings` -> `Environments` 里有 `github-pages` 和 `pypi`
+- PyPI trusted publisher 指向 `.github/workflows/pypi-publish.yml`
+- 如果想自动发 PyPI，`AINEWS_ENABLE_PYPI_PUBLISH=true` 已设置
+- 最近一次 `Demo Pages` 和 `Publish To PyPI` workflow 都是绿色
+
+## 参考资料
+
+- [GitHub Docs: Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
+- [GitHub Docs: Using custom workflows with GitHub Pages](https://docs.github.com/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+- [PyPI Docs: Adding a Trusted Publisher to an existing PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+- [PyPI Docs: Creating a PyPI Project with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -32,6 +32,7 @@ make check
 
 Confirm:
 
+- one-time repository setup in [maintainer-bootstrap.md](./maintainer-bootstrap.md) is complete if this repository publishes to GitHub Pages or PyPI
 - GitHub Actions `CI` is green
 - GitHub Actions `CodeQL` is green
 - GitHub Actions `Release Artifact Smoke` is green for the last published tag

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -32,6 +32,7 @@ make check
 
 确认以下项都正常：
 
+- 如果仓库要启用 GitHub Pages 或 PyPI，先确认 [maintainer-bootstrap.zh-CN.md](./maintainer-bootstrap.zh-CN.md) 里的首次初始化已经完成
 - GitHub Actions `CI` 为绿色
 - GitHub Actions `CodeQL` 为绿色
 - 上一个已发布 tag 的 GitHub Actions `Release Artifact Smoke` 为绿色


### PR DESCRIPTION
## Summary
- add a dedicated maintainer bootstrap guide for the one-time GitHub Pages and PyPI setup
- document the exact repository settings, environment names, workflow files, and PyPI trusted-publisher fields this repository expects
- link the new guide from the README, deployment guide, and release checklist in both English and Simplified Chinese

## Why
The repository already includes Pages and PyPI workflows, but maintainers still had to guess through the GitHub and PyPI UI the first time they enabled them. This change turns that one-time setup into a documented bootstrap path instead of tribal knowledge.

Closes #7.

## Validation
- `git diff --check`
- manual review of updated Markdown links and workflow references
- official setup wording cross-checked against GitHub Pages and PyPI trusted publishing documentation
- no code tests run because this change only touches maintainer documentation