### PR TITLE
release: prepare v1.2.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.48] - 2026-04-15
+
+### Added
+
+- Community triage guidance that defines when contributors should use GitHub Issues versus GitHub Discussions
+- Maintainer bootstrap docs for first-time GitHub Pages and PyPI trusted publishing setup
+
+### Changed
+
+- Package version is now `1.2.48`
+- README, deployment, release checklist, support policy, and issue templates now point maintainers and contributors to the new release-operations and discussion-routing docs
+
+### Fixed
+
+- Release checksum files now use downloaded asset filenames so `sha256sum -c sha256sums.txt` works directly from the release download directory
+- Release artifact smoke verification now checks checksums from the downloaded asset directory instead of assuming a `dist/` prefix
+
 ## [1.2.47] - 2026-04-15
 
 ### Added

--- a/docs/releases/v1.2.48.md
+++ b/docs/releases/v1.2.48.md
@@ -1,0 +1,12 @@
+# AI News Open v1.2.48
+
+## Highlights
+
+- Fixed release checksum output so downloaded assets can be verified directly with `sha256sum -c sha256sums.txt`.
+- Added a dedicated community triage guide covering GitHub Issues versus Discussions, recommended Discussions categories, and maintainer routing rules.
+- Added a maintainer bootstrap guide for the one-time GitHub Pages and PyPI trusted publishing setup used by this repository.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release workflow on tag push`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.47"
+version = "1.2.48"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.47"
+__version__ = "1.2.48"


### PR DESCRIPTION
## Summary
- bump package version metadata from `1.2.47` to `1.2.48`
- add the `1.2.48` changelog entry for release checksum verification, community triage guidance, and maintainer bootstrap docs
- add the dedicated release notes file under `docs/releases/v1.2.48.md`

## Why
The v1.2.48 milestone scope is complete and `main` now contains the three post-v1.2.47 changes that should ship together as the next patch release. This PR turns that work into reviewable release bookkeeping.

## Validation
- `make check PYTHON=./.venv-dev/bin/python`
- `make smoke PYTHON=./.venv-dev/bin/python`

Note: the first sandboxed `make check` run failed only because localhost integration tests could not bind ports inside the sandbox. The rerun outside the sandbox passed.