### PR TITLE
docs: define support windows and deprecation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ make check
 - [Troubleshooting](docs/troubleshooting.md)
 - [Monitoring](docs/monitoring.md)
 - [Maintainer Bootstrap](docs/maintainer-bootstrap.md)
+- [Support Lifecycle](docs/support-lifecycle.md)
 - [PR Review Policy](docs/pr-review-policy.md)
 - [Release Artifacts](docs/release-artifacts.md)
 - [Use Cases](docs/use-cases.md)
@@ -218,7 +219,7 @@ python -m pip install -e ".[dev]"
 
 This repository already includes the expected open-source project baseline:
 
-- Community docs: `CONTRIBUTING.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`, `docs/community-triage.md`
+- Community docs: `CONTRIBUTING.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `CITATION.cff`, `docs/community-triage.md`, `docs/support-lifecycle.md`
 - Collaboration templates: GitHub issue templates, pull request template, `CODEOWNERS`, and review policy
 - Quality gates: `ruff`, unit tests, coverage, package build validation, `pre-commit`
 - Automation: CI, tag-based release workflow, CodeQL, Dependabot

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,6 +97,7 @@ make check
 - [故障排查](docs/troubleshooting.zh-CN.md)
 - [监控接入](docs/monitoring.zh-CN.md)
 - [维护者初始化清单](docs/maintainer-bootstrap.zh-CN.md)
+- [支持生命周期](docs/support-lifecycle.zh-CN.md)
 - [PR 审核约定](docs/pr-review-policy.zh-CN.md)
 - [Release 产物校验](docs/release-artifacts.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)
@@ -218,7 +219,7 @@ python -m pip install -e ".[dev]"
 
 当前仓库已经补齐以下开源工程基线：
 
-- 社区文档：`CONTRIBUTING.md`、`SUPPORT.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`、`GOVERNANCE.md`、`MAINTAINERS.md`、`CITATION.cff`、`docs/community-triage.zh-CN.md`
+- 社区文档：`CONTRIBUTING.md`、`SUPPORT.md`、`CODE_OF_CONDUCT.md`、`SECURITY.md`、`CHANGELOG.md`、`GOVERNANCE.md`、`MAINTAINERS.md`、`CITATION.cff`、`docs/community-triage.zh-CN.md`、`docs/support-lifecycle.zh-CN.md`
 - 协作模板：GitHub issue templates、pull request template、`CODEOWNERS` 和审核约定
 - 质量门禁：`ruff` lint、单元测试、coverage、包构建校验、`pre-commit`
 - 自动化：CI、tag release workflow、CodeQL、Dependabot

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,9 +4,12 @@
 
 | Version line | Status | Notes |
 | --- | --- | --- |
-| `1.x` latest minor | Supported | Receives bug fixes, docs updates, and security guidance. |
-| Older `1.x` minors | Best effort | Upgrade to the latest `1.x` before opening support requests. |
+| `1.x` latest minor | Active support | Receives bug fixes, docs updates, and security guidance. |
+| `1.x` immediately previous minor | Maintenance support | Upgrade to the latest `1.x`; backports are best-effort and severe regressions are handled case by case. |
+| Older `1.x` minors | Unsupported | Historical releases only. |
 | `0.x` | Unsupported | Historical releases only. |
+
+See `docs/support-lifecycle.md` for the full minor-release support window and deprecation policy.
 
 ## Where To Ask For Help
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -17,7 +17,10 @@ Starting with `v1.0.0`, the project treats the following as stable public contra
 - Additive changes are allowed in `v1.x`.
 - Renaming or removing environment variables, CLI flags, HTTP routes, or exported JSON fields is treated as a breaking change.
 - Breaking changes must wait for `v2.0.0` or ship with an explicit compatibility bridge and migration notes.
+- Deprecations must be announced in a minor release before any hard removal or contract shutdown.
 - Exported JSON keeps a top-level `schema_version` field so downstream consumers can pin behavior.
+
+Use [support-lifecycle.md](./support-lifecycle.md) for the release-state policy and deprecation window that sits on top of this contract.
 
 ## Stable Environment Variables
 
@@ -180,6 +183,7 @@ This contract prevents duplicate records and repeated outbound publishes in the 
 When a future change must break contract:
 
 1. Document it in [CHANGELOG.md](../CHANGELOG.md).
-2. Add migration notes.
-3. Keep the old behavior during a deprecation window when practical.
-4. Only remove the old contract in the next major version.
+2. Add migration notes and replacement guidance.
+3. Mark the old contract as deprecated in the relevant docs.
+4. Keep the old behavior during the deprecation window defined in [support-lifecycle.md](./support-lifecycle.md).
+5. Only remove the old contract in the next major version unless a security or safety issue forces earlier action.

--- a/docs/support-lifecycle.md
+++ b/docs/support-lifecycle.md
@@ -1,0 +1,86 @@
+# Support Lifecycle
+
+[English](./support-lifecycle.md) · [简体中文](./support-lifecycle.zh-CN.md)
+
+This document defines the support window and deprecation policy for public AI News Open releases.
+
+## Support States
+
+AI News Open uses three release states for the current stable major line.
+
+- `Active support`: the latest released minor in the current major line. Maintainers accept bug fixes, docs updates, security guidance, and normal compatibility clarifications here.
+- `Maintenance support`: the immediately previous minor in the current major line. Maintainers may still help with upgrades, regressions, and security guidance, but backports are best-effort and new fixes should target the latest minor first.
+- `Unsupported`: any release older than the immediately previous minor, and all historical `0.x` releases.
+
+## Minor-Release Support Window
+
+Support moves forward one minor at a time.
+
+Example for `v1.x`:
+
+- when `1.2.x` is the newest released minor, `1.2.x` is `Active support`
+- `1.1.x` is `Maintenance support`
+- `1.0.x` and older are `Unsupported`
+
+When `1.3.0` ships:
+
+- `1.3.x` becomes `Active support`
+- `1.2.x` becomes `Maintenance support`
+- `1.1.x` and older become `Unsupported`
+
+This keeps the support policy predictable without promising long-lived backport branches for a single-maintainer project.
+
+## What Maintainers Support In Each State
+
+### Active Support
+
+- bug fixes and behavioral regressions
+- docs corrections and operator guidance
+- security guidance and release follow-up
+- compatibility clarifications for public contract changes
+
+### Maintenance Support
+
+- upgrade help to the latest minor
+- security guidance
+- severe regressions at maintainer discretion
+
+Maintenance support does not guarantee backported fixes. If a fix lands only on the latest minor, the recommended path is to upgrade.
+
+### Unsupported Releases
+
+- historical versions remain visible for reference
+- maintainers may still answer questions, but no compatibility guarantee is implied
+- new fixes should not target these releases
+
+## Deprecation Policy
+
+Deprecations apply to the public contract defined in [compatibility.md](./compatibility.md), including documented environment variables, CLI flags, HTTP routes, and exported JSON fields.
+
+Rules:
+
+- announce the deprecation in `CHANGELOG.md` in the first release that introduces it
+- document the replacement path or migration note in the relevant docs
+- keep the deprecated contract accepted for the rest of the current major line when practical
+- treat hard removals as major-version work by default
+
+For the current `v1.x` line, the default policy is:
+
+- deprecations may be introduced in a minor release
+- deprecated public contract remains supported through the rest of `v1.x` unless a security or safety issue requires earlier action
+- removals should wait for `v2.0.0`
+
+## Exception Path
+
+If a deprecated behavior cannot remain in place because of security, safety, or an external platform break:
+
+1. document the reason in `CHANGELOG.md`
+2. publish migration notes or fallback behavior
+3. keep a compatibility bridge when practical
+4. call out the operational impact in release notes before the old behavior is disabled
+
+## Related Docs
+
+- [SUPPORT.md](../SUPPORT.md)
+- [Compatibility Contract](./compatibility.md)
+- [Release Checklist](./release-checklist.md)

--- a/docs/support-lifecycle.zh-CN.md
+++ b/docs/support-lifecycle.zh-CN.md
@@ -1,0 +1,86 @@
+# 支持生命周期
+
+[English](./support-lifecycle.md) · [简体中文](./support-lifecycle.zh-CN.md)
+
+这份文档定义 AI News Open 公开版本的支持窗口和弃用策略。
+
+## 支持状态
+
+AI News Open 对当前稳定 major 线使用三种发布状态。
+
+- `Active support`：当前 major 线里最新发布的 minor。维护者会在这里接收 bug 修复、文档更新、安全指导和常规兼容性澄清。
+- `Maintenance support`：当前 major 线里紧邻最新版本的上一个 minor。维护者仍会处理升级指导、回归问题和安全指导，但回补修复是 best-effort，新修复默认优先落在最新 minor。
+- `Unsupported`：比“上一个 minor”更老的版本，以及所有历史 `0.x` 版本。
+
+## 按 Minor 推进的支持窗口
+
+支持窗口随着 minor 版本向前滚动。
+
+以 `v1.x` 为例：
+
+- 当 `1.2.x` 是最新发布的 minor 时，`1.2.x` 属于 `Active support`
+- `1.1.x` 属于 `Maintenance support`
+- `1.0.x` 及更老版本属于 `Unsupported`
+
+当 `1.3.0` 发布后：
+
+- `1.3.x` 变成 `Active support`
+- `1.2.x` 变成 `Maintenance support`
+- `1.1.x` 及更老版本变成 `Unsupported`
+
+这样可以让支持策略可预测，同时避免对单维护者仓库承诺长期 backport 分支。
+
+## 各支持状态下维护者实际支持什么
+
+### Active Support
+
+- bug 修复和行为回归
+- 文档修正和运维指导
+- 安全指导和发版后跟进
+- 面向公共契约的兼容性澄清
+
+### Maintenance Support
+
+- 升级到最新 minor 的指导
+- 安全指导
+- 严重回归问题的酌情处理
+
+`Maintenance support` 不承诺回补修复。如果修复只落在最新 minor，推荐路径就是升级。
+
+### Unsupported
+
+- 历史版本仍可作为参考
+- 维护者可以视情况回答问题，但不再隐含兼容性保证
+- 新修复不应再针对这些版本回补
+
+## 弃用策略
+
+弃用策略适用于 [compatibility.md](./compatibility.md) 里定义的公共契约，包括文档化的环境变量、CLI flag、HTTP 路由和导出的 JSON 字段。
+
+规则：
+
+- 第一次引入弃用时，要在 `CHANGELOG.md` 里明确记录
+- 相关文档里要给出替代方案或迁移说明
+- 在可行情况下，弃用后的旧契约应持续接受到当前 major 线结束
+- 默认只在下一个 major 版本做硬删除
+
+对当前 `v1.x` 线，默认策略是：
+
+- 可以在某个 minor 版本里引入弃用声明
+- 除非出现安全或稳定性问题，否则被弃用的公共契约会一直保留到 `v1.x` 结束
+- 真正移除应等待 `v2.0.0`
+
+## 例外路径
+
+如果某个已弃用行为因为安全、稳定性或外部平台变化而不能继续保留：
+
+1. 在 `CHANGELOG.md` 里说明原因
+2. 发布迁移说明或 fallback 行为
+3. 在可行时保留兼容桥接
+4. 在 release note 里明确写出停用旧行为的运维影响
+
+## 相关文档
+
+- [SUPPORT.md](../SUPPORT.md)
+- [Compatibility Contract](./compatibility.md)
+- [Release Checklist](./release-checklist.md)


### PR DESCRIPTION
## Summary
- add a dedicated support lifecycle guide in English and Simplified Chinese
- define active support, maintenance support, and unsupported states per minor release
- document the default deprecation policy for the public `v1.x` contract
- align `SUPPORT.md`, `docs/compatibility.md`, and the README doc entry points with the new policy

## Why
The roadmap already called out support windows and deprecation policy as missing open-source governance detail. The repository had a basic support table and a compatibility contract, but it still did not define a clear minor-release support window or a documented deprecation path contributors could reference.

## Validation
- `git diff --check`
- manual review of updated Markdown links and policy wording
- no code tests run because this change only touches documentation and repository policy text
