### PR TITLE
docs: refresh roadmap and add Chinese translation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,4 +11,7 @@ contact_links:
     about: Read the support boundaries and version policy before opening broad usage requests.
   - name: Roadmap
     url: https://github.com/X-PG13/ainews-open/blob/main/ROADMAP.md
-    about: Check planned priorities before filing roadmap-scale feature requests.
+    about: Check current maintainer priorities before filing roadmap-scale feature requests.
+  - name: 路线图（简体中文）
+    url: https://github.com/X-PG13/ainews-open/blob/main/ROADMAP.zh-CN.md
+    about: 提交路线图级别的功能请求前，先看当前版本规划和维护者优先级。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,7 +105,7 @@ make check
 - [贡献者手册](docs/contributor-playbook.md)
 - [发版清单](docs/release-checklist.zh-CN.md)
 - [支持策略](SUPPORT.md)
-- [路线图](ROADMAP.md)
+- [路线图](ROADMAP.zh-CN.md)
 
 ## 当前能力
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,29 +1,46 @@
 # Roadmap
 
-## v1.1 Operations And Reliability
+[English](./ROADMAP.md) · [简体中文](./ROADMAP.zh-CN.md)
 
-- Raise test coverage beyond the current baseline with more fixture-driven end-to-end tests.
-- Add richer health and telemetry surfaces for operators.
-- Harden release artifacts with checksums, SBOMs, and provenance.
-- Publish the package through trusted PyPI publishing.
+This roadmap tracks current maintainer priorities. Release notes remain the historical record after work ships.
 
-## v1.2 Content Quality
+## Current Status
 
-- Expand source-specific extraction rules for high-value AI media sites.
-- Add regression fixtures for additional Chinese and international publishers.
-- Improve digest ranking and editorial curation workflows.
-- Support stronger duplicate detection across syndication-heavy feeds.
+- Stable line: `v1.2.x`
+- Latest release: `v1.2.48`
+- Current open milestone: `v1.2.49`
+- Current open release-engineering item: trusted PyPI publishing bootstrap and the first package publish
 
-## v1.3 Product Surface
+## In Progress: v1.2.49 Maintenance
+
+- Configure the PyPI trusted publisher for `ainews-open`.
+- Publish the package to PyPI for the first time after the trusted-publisher bootstrap is complete.
+- Keep release automation, checksum verification, SBOM generation, and provenance attestation healthy as part of ongoing maintenance.
+
+## Planned: v1.3 Product Surface
 
 - Ship a public demo site backed by sample digests and API examples.
 - Add operator views for operation metrics and failure history.
 - Provide deployment recipes for Docker Compose, systemd, and GitHub Actions at production depth.
 - Improve multi-channel publishing previews before outbound sends.
 
-## Community Backlog
+## Ongoing Quality Work
 
-- Enable GitHub Discussions for usage questions and idea validation.
-- Maintain `good first issue`, `help wanted`, and `v1.x` labels as the default triage surface.
-- Document extension guides for adding sources, extraction rules, and publishers.
-- Define support windows and deprecation policy per minor release.
+- Expand source-specific extraction rules for high-value AI media sites.
+- Add regression fixtures for additional Chinese and international publishers.
+- Improve digest ranking and editorial curation workflows.
+- Support stronger duplicate detection across syndication-heavy feeds.
+
+## Recently Completed
+
+- Enabled GitHub Discussions and documented the issue-vs-discussion triage policy.
+- Defined support windows and deprecation policy for the public `v1.x` contract.
+- Hardened release artifacts with checksums, SBOMs, provenance, and smoke validation.
+- Added maintainer bootstrap guidance for GitHub Pages and PyPI setup.
+- Added governance, maintainer, citation, architecture, and review-policy documents to the repository baseline.
+
+## Community And Contributor Experience
+
+- Keep `good first issue`, `help wanted`, `v1.x`, and area labels current as triage metadata.
+- Document more worked examples for extending sources, extraction rules, and publishers over time.
+- Keep roadmap, milestone, and release documentation aligned so feature requests land against current priorities instead of stale backlog items.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,0 +1,46 @@
+# 路线图
+
+[English](./ROADMAP.md) · [简体中文](./ROADMAP.zh-CN.md)
+
+这份路线图只跟踪当前维护者的优先级。已经发布的工作会进入 release note，那里才是历史记录。
+
+## 当前状态
+
+- 稳定版本线：`v1.2.x`
+- 最新 release：`v1.2.48`
+- 当前开启的 milestone：`v1.2.49`
+- 当前唯一明确未完成的 release engineering 项：PyPI trusted publishing 初始化和首次发包
+
+## 进行中：v1.2.49 维护事项
+
+- 为 `ainews-open` 配置 PyPI trusted publisher。
+- 在 trusted publisher 初始化完成后，完成第一次 PyPI 发布。
+- 持续维护 release automation、checksum 校验、SBOM 生成和 provenance attestation。
+
+## 计划中：v1.3 产品能力
+
+- 提供基于示例 digest 和 API example 的公开 demo 站点。
+- 增加面向运维的指标视图和失败历史视图。
+- 补齐面向生产深度的 Docker Compose、systemd 和 GitHub Actions 部署方案。
+- 继续增强多渠道发布前的最终预览能力。
+
+## 持续推进的内容质量工作
+
+- 继续扩展高价值 AI 媒体站点的 source-specific extraction 规则。
+- 为更多中文和国际发布源补充回归夹具。
+- 改进 digest 排序和编辑策展流程。
+- 继续增强对 syndication-heavy feed 的重复检测能力。
+
+## 最近已完成
+
+- 已启用 GitHub Discussions，并补齐了 issue / discussion 分流规范。
+- 已为公开 `v1.x` 契约定义支持窗口和弃用策略。
+- 已为 release 产物补齐 checksum、SBOM、provenance 和 smoke 校验。
+- 已补齐 GitHub Pages 和 PyPI 初始化所需的 maintainer bootstrap 文档。
+- 已把治理、维护者、citation、架构和审核策略文档补进仓库基线。
+
+## 社区与贡献者体验
+
+- 继续把 `good first issue`、`help wanted`、`v1.x` 和 area labels 维护成稳定的分诊元数据。
+- 随着时间推进，为 source、extractor 和 publisher 扩展补更多可执行示例。
+- 保持 roadmap、milestone 和 release 文档同步，避免功能请求继续落到过时 backlog 上。


### PR DESCRIPTION
## Summary
- refresh `ROADMAP.md` so it reflects current maintainer priorities instead of already-completed backlog items
- add `ROADMAP.zh-CN.md` for the Chinese docs surface
- point the Chinese README and issue template contact links at the new current roadmap entry points

## Why
The repository roadmap had started to drift into a historical wishlist: several community backlog items were already done, while the one real open release-engineering item was PyPI trusted publishing. A stale roadmap makes an otherwise strong open-source repository look less maintained than it is.

## Validation
- `git diff --check`
- manual review of Markdown and YAML changes
- no code tests run because this change only updates documentation and GitHub issue-template metadata
