### PR TITLE
docs: align README community baseline links

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Recommended community scaffolding:
 
 - `ROADMAP.md`
 - `SUPPORT.md`
+- `docs/community-triage.md`
+- `docs/support-lifecycle.md`
 - `GOVERNANCE.md`
 - `MAINTAINERS.md`
 - `docs/architecture.md`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -241,9 +241,10 @@ python -m pip install -e ".[dev]"
 
 社区协作建议配套：
 
-- `ROADMAP.md`
+- `ROADMAP.zh-CN.md`
 - `SUPPORT.md`
 - `docs/community-triage.zh-CN.md`
+- `docs/support-lifecycle.zh-CN.md`
 - `GOVERNANCE.md`
 - `MAINTAINERS.md`
 - `docs/architecture.md`


### PR DESCRIPTION
## Summary
- add the community triage and support lifecycle docs to the English README baseline list
- switch the Chinese README baseline list to `ROADMAP.zh-CN.md`
- add the Chinese support lifecycle doc to the Chinese README baseline list

## Why
The repository documentation already had the right top-level entry points, but the later "community scaffolding" section still lagged behind recent governance additions and still pointed Chinese readers at the English roadmap path. This keeps the README guidance internally consistent.

## Validation
- `git diff --check`
- manual review of the updated README sections
- no code tests run because this change only updates documentation links
