### PR TITLE
release: prepare v1.2.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project should be recorded in this file.
 
+## [1.2.49] - 2026-04-27
+
+### Added
+
+- Support lifecycle docs that define active support, maintenance support, unsupported releases, and the `v1.x` deprecation policy
+- Chinese roadmap translation plus a refreshed roadmap that separates current release priorities from completed governance work
+- Markdown relative-link regression test coverage for repository docs, `docs/`, and `.github/` Markdown files
+
+### Changed
+
+- Package version is now `1.2.49`
+- README community-baseline links now include the community triage and support lifecycle docs in both English and Simplified Chinese
+- Issue-template roadmap contact links now point contributors to current maintainer priorities in English and Simplified Chinese
+- GitHub Pages and release supply-chain workflow actions were refreshed to their newer major versions
+
+### Deferred
+
+- PyPI trusted publishing remains deferred in the `Deferred: PyPI` milestone until the PyPI project and trusted publisher are configured
+
 ## [1.2.48] - 2026-04-15
 
 ### Added

--- a/docs/releases/v1.2.49.md
+++ b/docs/releases/v1.2.49.md
@@ -1,0 +1,17 @@
+# AI News Open v1.2.49
+
+## Highlights
+
+- Added support lifecycle documentation for the `v1.x` line, including active support, maintenance support, unsupported releases, and deprecation expectations.
+- Refreshed the roadmap and added a Simplified Chinese roadmap so current priorities no longer read like stale backlog items.
+- Added regression coverage for Markdown relative links across root docs, `docs/`, and `.github/` Markdown files.
+- Updated GitHub Actions dependencies used by release provenance and GitHub Pages deployment workflows.
+
+## Deferred
+
+- PyPI trusted publishing is intentionally not part of this release. Issue `#86` now lives in the `Deferred: PyPI` milestone until the PyPI project and trusted publisher are configured.
+
+## Validation
+
+- `make check PYTHON=./.venv-dev/bin/python`
+- `Release workflow on tag push`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainews-open"
-version = "1.2.48"
+version = "1.2.49"
 description = "Open-source-ready daily AI news aggregation service for domestic and international AI coverage."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ainews/__init__.py
+++ b/src/ainews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.48"
+__version__ = "1.2.49"


### PR DESCRIPTION
## Summary
- bump package metadata and runtime version to `1.2.49`
- add the `1.2.49` changelog entry
- add `docs/releases/v1.2.49.md`
- move PyPI trusted publishing out of the `v1.2.49` milestone into `Deferred: PyPI`

## Why
`v1.2.49` packages the post-`v1.2.48` maintenance work: GitHub Actions dependency refreshes, support lifecycle docs, roadmap refresh, README community baseline alignment, and Markdown relative-link regression coverage. PyPI remains intentionally deferred until trusted publishing is configured.

## Validation
- `make check PYTHON=./.venv-dev/bin/python`
