### PR TITLE
docs: document release asset verification flow

### DIFF
--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -19,6 +19,80 @@ It downloads the published release assets, verifies checksums, installs the whee
 Treat this workflow as a release-completion gate. Do not announce a new public tag until it passes.
 For tags created through `.github/workflows/release.yml`, the smoke workflow is dispatched automatically after the GitHub Release is published. You can still re-run it manually for any published tag.
 
+## Copy-Paste Verification Flow
+
+Set `VERSION` to the release tag without the leading `v`, then download the release assets into a clean directory:
+
+```bash
+export VERSION=1.2.49
+export REPO=X-PG13/ainews-open
+mkdir -p "ainews-open-${VERSION}-release"
+cd "ainews-open-${VERSION}-release"
+
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/ainews_open-${VERSION}-py3-none-any.whl"
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/ainews_open-${VERSION}.tar.gz"
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/sha256sums.txt"
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/v${VERSION}-sbom.json"
+```
+
+Verify checksums with Python so the same command works on Linux and macOS:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import hashlib
+
+for line in Path("sha256sums.txt").read_text(encoding="utf-8").splitlines():
+    expected, filename = line.split(maxsplit=1)
+    filename = filename.lstrip("*")
+    actual = hashlib.sha256(Path(filename).read_bytes()).hexdigest()
+    if actual != expected.lower():
+        raise SystemExit(f"checksum mismatch: {filename}")
+    print(f"ok {filename}")
+PY
+```
+
+Install and smoke-check the downloaded wheel instead of installing `ainews-open` from PyPI:
+
+```bash
+python -m venv .venv-wheel
+. .venv-wheel/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "./ainews_open-${VERSION}-py3-none-any.whl"
+python -m ainews --help
+python -m ainews stats
+deactivate
+```
+
+Install the source archive in a separate clean environment:
+
+```bash
+python -m venv .venv-sdist
+. .venv-sdist/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "./ainews_open-${VERSION}.tar.gz"
+python -m ainews --help
+python -m ainews stats
+deactivate
+```
+
+Inspect the SBOM enough to confirm it is machine-readable CycloneDX JSON:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import json
+import os
+
+sbom_path = Path(f"v{os.environ['VERSION']}-sbom.json")
+sbom = json.loads(sbom_path.read_text(encoding="utf-8"))
+components = len(sbom.get("components", []))
+print(f"{sbom.get('bomFormat')} {sbom.get('specVersion')} components={components}")
+if sbom.get("bomFormat") != "CycloneDX":
+    raise SystemExit("unexpected SBOM format")
+PY
+```
+
 ## Download And Verify
 
 From a release page, download the wheel, source archive, and `sha256sums.txt`.

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -19,6 +19,80 @@
 这条 workflow 应该被视为 release 完成前的强制门禁。它没通过之前，不要对外公告新 tag。
 如果 tag 是通过 `.github/workflows/release.yml` 发出来的，这条 smoke workflow 会在 GitHub Release 发布后自动触发。你仍然可以针对任意已发布 tag 手动重跑。
 
+## 可直接复制的校验流程
+
+把 `VERSION` 设置为不带前导 `v` 的 release tag，然后把 release 资产下载到一个干净目录：
+
+```bash
+export VERSION=1.2.49
+export REPO=X-PG13/ainews-open
+mkdir -p "ainews-open-${VERSION}-release"
+cd "ainews-open-${VERSION}-release"
+
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/ainews_open-${VERSION}-py3-none-any.whl"
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/ainews_open-${VERSION}.tar.gz"
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/sha256sums.txt"
+curl -LO "https://github.com/${REPO}/releases/download/v${VERSION}/v${VERSION}-sbom.json"
+```
+
+用 Python 校验 checksum，这样同一条命令可以同时适用于 Linux 和 macOS：
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import hashlib
+
+for line in Path("sha256sums.txt").read_text(encoding="utf-8").splitlines():
+    expected, filename = line.split(maxsplit=1)
+    filename = filename.lstrip("*")
+    actual = hashlib.sha256(Path(filename).read_bytes()).hexdigest()
+    if actual != expected.lower():
+        raise SystemExit(f"checksum mismatch: {filename}")
+    print(f"ok {filename}")
+PY
+```
+
+从已下载的 wheel 安装，而不是从 PyPI 安装 `ainews-open`，并做最小烟测：
+
+```bash
+python -m venv .venv-wheel
+. .venv-wheel/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "./ainews_open-${VERSION}-py3-none-any.whl"
+python -m ainews --help
+python -m ainews stats
+deactivate
+```
+
+在另一个干净环境里从 source archive 安装：
+
+```bash
+python -m venv .venv-sdist
+. .venv-sdist/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "./ainews_open-${VERSION}.tar.gz"
+python -m ainews --help
+python -m ainews stats
+deactivate
+```
+
+检查 SBOM 至少是可机器读取的 CycloneDX JSON：
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import json
+import os
+
+sbom_path = Path(f"v{os.environ['VERSION']}-sbom.json")
+sbom = json.loads(sbom_path.read_text(encoding="utf-8"))
+components = len(sbom.get("components", []))
+print(f"{sbom.get('bomFormat')} {sbom.get('specVersion')} components={components}")
+if sbom.get("bomFormat") != "CycloneDX":
+    raise SystemExit("unexpected SBOM format")
+PY
+```
+
 ## 下载并校验
 
 从 Release 页面下载 wheel、source archive 和 `sha256sums.txt`。

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -61,7 +61,7 @@ git push origin vX.Y.Z
 - final release notes
 - artifact install and checksum verification guidance
 
-3. Verify the release artifact instructions still work:
+3. Follow the [release artifact verification flow](./release-artifacts.md#copy-paste-verification-flow) for the final tag. At minimum, verify the wheel installs and the CLI starts:
 
 ```bash
 python -m pip install ainews_open-X.Y.Z-py3-none-any.whl

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -61,7 +61,7 @@ git push origin vX.Y.Z
 - 最终版 release notes
 - release artifact 的安装与校验说明
 
-3. 额外验证一次 release artifact 安装说明可用：
+3. 按 [Release 产物校验](./release-artifacts.zh-CN.md) 文档里的完整流程校验最终 tag。至少要确认 wheel 可安装，并且 CLI 能启动：
 
 ```bash
 python -m pip install ainews_open-X.Y.Z-py3-none-any.whl


### PR DESCRIPTION
## Summary
- add a copy-pasteable GitHub Release asset verification flow
- cover wheel, sdist, checksum, and SBOM validation in English and Simplified Chinese
- point the release checklist at the fuller verification procedure

## Validation
- `git diff --check`
- `./.venv-dev/bin/python -m pytest tests/test_docs_links.py`
- `make check PYTHON=./.venv-dev/bin/python`

Closes #92