### PR TITLE
docs: add post-release smoke checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -70,8 +70,41 @@ python -m ainews --help
 
 ## After Release
 
-1. Verify the release page and demo page are still reachable.
-2. Confirm `Release Artifact Smoke` passed for the published tag. This is a mandatory pass gate before you announce or close the release work.
-3. Confirm the package metadata on GitHub and PyPI looks correct.
-4. Confirm `Latest` points to the intended tag.
-5. Announce the release using `docs/releases/` copy if applicable.
+Run the post-release smoke checklist before announcing the release or closing its milestone.
+
+### Published Tag And Release Page
+
+- [ ] The release page is published, not a draft, and not marked as a prerelease unless that was intentional.
+- [ ] The tag points to the intended `main` commit.
+- [ ] GitHub marks the intended tag as `Latest`.
+- [ ] The final release notes match `CHANGELOG.md` and `docs/releases/vX.Y.Z.md`.
+- [ ] The demo page and public docs links still load.
+
+### Automation And Assets
+
+- [ ] GitHub Actions `Release` completed successfully for the tag.
+- [ ] GitHub Actions `Release Artifact Smoke` completed successfully for the tag.
+- [ ] GitHub Actions `CI`, `Smoke`, and `CodeQL` are green for the release commit or tag.
+- [ ] The GitHub Release contains the wheel, source archive, `sha256sums.txt`, SBOM, and provenance attestation.
+- [ ] The [release artifact verification flow](./release-artifacts.md#copy-paste-verification-flow) passes against the published assets.
+
+### Install Smoke
+
+- [ ] A clean wheel install from the downloaded release asset succeeds.
+- [ ] A clean source archive install from the downloaded release asset succeeds.
+- [ ] `python -m ainews --help` runs from the clean install.
+- [ ] `python -m ainews stats` runs from the clean install.
+- [ ] Package metadata on GitHub and PyPI looks correct if PyPI publication is enabled for this release.
+
+### Closeout
+
+- [ ] Close the release milestone only after the release page, assets, and smoke workflows are verified.
+- [ ] Announce the release using `docs/releases/` copy if applicable.
+- [ ] Leave deferred work in a separate milestone instead of carrying it inside the closed release milestone.
+
+## Post-Release Failure Triage
+
+- Missing or partial release assets: confirm the tag points to the intended commit, then re-run the `Release` workflow. Do not move or recreate a public tag unless the published tag itself points to the wrong commit and the maintainer explicitly accepts the compatibility risk.
+- Failed `Release Artifact Smoke`: inspect whether the failure is checksum, wheel install, source archive install, CLI startup, or `/health` startup. Fix the release workflow or package issue in a follow-up PR, then publish a new patch tag if the released assets are already public.
+- Wrong release notes or `Latest` target: edit the GitHub Release metadata if the tag and assets are correct. If the wrong commit was tagged, stop and document the remediation before publishing another tag.
+- PyPI mismatch: treat PyPI as a separate release channel. If PyPI is disabled or deferred, keep the GitHub Release valid and leave PyPI work in its own milestone.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -70,8 +70,41 @@ python -m ainews --help
 
 ## 发版后
 
-1. 检查 Release 页面和 demo 页面仍可访问。
-2. 检查已发布 tag 的 `Release Artifact Smoke` 是否通过。这一项必须通过后，才能对外公告或结束这次发版。
-3. 检查 GitHub / PyPI 上的包元信息是否正确。
-4. 检查 `Latest` 是否指向预期 tag。
-5. 如需对外公告，可直接复用 `docs/releases/` 里的文案。
+对外公告 release 或关闭 milestone 前，先完成这份发版后 smoke checklist。
+
+### 已发布 tag 和 Release 页面
+
+- [ ] Release 页面已经发布，不是 draft；除非本次有意发 prerelease，否则不能标成 prerelease。
+- [ ] tag 指向预期的 `main` commit。
+- [ ] GitHub 的 `Latest` 指向预期 tag。
+- [ ] 最终 release notes 和 `CHANGELOG.md`、`docs/releases/vX.Y.Z.md` 一致。
+- [ ] demo 页面和公开文档链接仍然可访问。
+
+### 自动化和制品
+
+- [ ] GitHub Actions `Release` 在该 tag 上执行成功。
+- [ ] GitHub Actions `Release Artifact Smoke` 在该 tag 上执行成功。
+- [ ] release commit 或 tag 对应的 GitHub Actions `CI`、`Smoke`、`CodeQL` 都是绿色。
+- [ ] GitHub Release 包含 wheel、source archive、`sha256sums.txt`、SBOM 和 provenance attestation。
+- [ ] 按 [Release 产物校验](./release-artifacts.zh-CN.md) 文档里的完整流程校验已发布资产，并且全部通过。
+
+### 安装烟测
+
+- [ ] 从已下载的 release wheel 在干净环境里安装成功。
+- [ ] 从已下载的 source archive 在干净环境里安装成功。
+- [ ] 在干净安装环境里 `python -m ainews --help` 可以运行。
+- [ ] 在干净安装环境里 `python -m ainews stats` 可以运行。
+- [ ] 如果本次 release 启用了 PyPI 发布，确认 GitHub 和 PyPI 上的包元信息都正确。
+
+### 收尾
+
+- [ ] 只有在 Release 页面、制品和 smoke workflows 都确认后，才关闭 release milestone。
+- [ ] 如需对外公告，可直接复用 `docs/releases/` 里的文案。
+- [ ] 延期事项放到单独 milestone，不要留在已经关闭的 release milestone 里。
+
+## 发版后失败分流
+
+- Release 制品缺失或不完整：先确认 tag 指向预期 commit，再重跑 `Release` workflow。除非公开 tag 本身指错 commit，并且维护者明确接受兼容性风险，否则不要移动或重建公开 tag。
+- `Release Artifact Smoke` 失败：先判断失败点是 checksum、wheel 安装、source archive 安装、CLI 启动，还是 `/health` 启动。通过后续 PR 修复 release workflow 或打包问题；如果资产已经公开，修复后应发新的 patch tag。
+- Release notes 或 `Latest` 指向错误：如果 tag 和资产正确，只编辑 GitHub Release 元数据即可。如果 tag 指错 commit，先停下来记录修复方案，再发布新的 tag。
+- PyPI 不一致：把 PyPI 当成独立发布渠道处理。如果 PyPI 当前禁用或延期，保持 GitHub Release 有效，并把 PyPI 工作继续放在单独 milestone。


### PR DESCRIPTION
## Summary
- expand the release checklist with a reusable post-release smoke checklist
- cover tag, release page, workflows, release assets, clean installs, and milestone closeout
- add failure triage guidance for missing assets, failed smoke jobs, wrong release metadata, and PyPI mismatch

## Validation
- `git diff --check`
- `./.venv-dev/bin/python -m pytest tests/test_docs_links.py`
- `make check PYTHON=./.venv-dev/bin/python`

Closes #94