### PR TITLE
docs: improve release planning navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,16 @@ make check
 - [Troubleshooting](docs/troubleshooting.md)
 - [Monitoring](docs/monitoring.md)
 - [Maintainer Bootstrap](docs/maintainer-bootstrap.md)
+- [Roadmap](ROADMAP.md)
 - [Support Lifecycle](docs/support-lifecycle.md)
 - [PR Review Policy](docs/pr-review-policy.md)
+- [Release Notes](docs/releases/README.md)
 - [Release Artifacts](docs/release-artifacts.md)
 - [Use Cases](docs/use-cases.md)
 - [Community Triage](docs/community-triage.md)
 - [Contributor Playbook](docs/contributor-playbook.md)
 - [Release Checklist](docs/release-checklist.md)
 - [Support Policy](SUPPORT.md)
-- [Roadmap](ROADMAP.md)
 
 ## What You Get
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,15 +97,16 @@ make check
 - [故障排查](docs/troubleshooting.zh-CN.md)
 - [监控接入](docs/monitoring.zh-CN.md)
 - [维护者初始化清单](docs/maintainer-bootstrap.zh-CN.md)
+- [路线图](ROADMAP.zh-CN.md)
 - [支持生命周期](docs/support-lifecycle.zh-CN.md)
 - [PR 审核约定](docs/pr-review-policy.zh-CN.md)
+- [Release Notes](docs/releases/README.zh-CN.md)
 - [Release 产物校验](docs/release-artifacts.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)
 - [社区分流规范](docs/community-triage.zh-CN.md)
 - [贡献者手册](docs/contributor-playbook.md)
 - [发版清单](docs/release-checklist.zh-CN.md)
 - [支持策略](SUPPORT.md)
-- [路线图](ROADMAP.zh-CN.md)
 
 ## 当前能力
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,15 +7,20 @@ This roadmap tracks current maintainer priorities. Release notes remain the hist
 ## Current Status
 
 - Stable line: `v1.2.x`
-- Latest release: `v1.2.48`
-- Current open milestone: `v1.2.49`
-- Current open release-engineering item: trusted PyPI publishing bootstrap and the first package publish
+- Latest release: `v1.2.49`
+- Current open milestone: `v1.2.50`
+- Deferred release-engineering item: trusted PyPI publishing bootstrap and the first package publish
 
-## In Progress: v1.2.49 Maintenance
+## In Progress: v1.2.50 Maintenance
+
+- Improve release verification and post-release smoke documentation.
+- Keep roadmap, support lifecycle, and release notes easier to discover from primary docs entry points.
+- Keep release automation, checksum verification, SBOM generation, and provenance attestation healthy as ongoing maintenance.
+
+## Deferred: PyPI
 
 - Configure the PyPI trusted publisher for `ainews-open`.
 - Publish the package to PyPI for the first time after the trusted-publisher bootstrap is complete.
-- Keep release automation, checksum verification, SBOM generation, and provenance attestation healthy as part of ongoing maintenance.
 
 ## Planned: v1.3 Product Surface
 
@@ -44,3 +49,8 @@ This roadmap tracks current maintainer priorities. Release notes remain the hist
 - Keep `good first issue`, `help wanted`, `v1.x`, and area labels current as triage metadata.
 - Document more worked examples for extending sources, extraction rules, and publishers over time.
 - Keep roadmap, milestone, and release documentation aligned so feature requests land against current priorities instead of stale backlog items.
+
+## Related Docs
+
+- [Release Notes](docs/releases/README.md)
+- [Support Lifecycle](docs/support-lifecycle.md)

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -7,15 +7,20 @@
 ## 当前状态
 
 - 稳定版本线：`v1.2.x`
-- 最新 release：`v1.2.48`
-- 当前开启的 milestone：`v1.2.49`
-- 当前唯一明确未完成的 release engineering 项：PyPI trusted publishing 初始化和首次发包
+- 最新 release：`v1.2.49`
+- 当前开启的 milestone：`v1.2.50`
+- 延期的 release engineering 项：PyPI trusted publishing 初始化和首次发包
 
-## 进行中：v1.2.49 维护事项
+## 进行中：v1.2.50 维护事项
+
+- 改进 release 校验和发版后 smoke 文档。
+- 让 roadmap、支持生命周期和 release notes 更容易从主要文档入口发现。
+- 持续维护 release automation、checksum 校验、SBOM 生成和 provenance attestation。
+
+## 延期：PyPI
 
 - 为 `ainews-open` 配置 PyPI trusted publisher。
 - 在 trusted publisher 初始化完成后，完成第一次 PyPI 发布。
-- 持续维护 release automation、checksum 校验、SBOM 生成和 provenance attestation。
 
 ## 计划中：v1.3 产品能力
 
@@ -44,3 +49,8 @@
 - 继续把 `good first issue`、`help wanted`、`v1.x` 和 area labels 维护成稳定的分诊元数据。
 - 随着时间推进，为 source、extractor 和 publisher 扩展补更多可执行示例。
 - 保持 roadmap、milestone 和 release 文档同步，避免功能请求继续落到过时 backlog 上。
+
+## 相关文档
+
+- [Release Notes](docs/releases/README.zh-CN.md)
+- [支持生命周期](docs/support-lifecycle.zh-CN.md)

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+[English](./README.md) · [简体中文](./README.zh-CN.md)
+
+Release notes are the historical record of shipped changes. Use them with [CHANGELOG.md](../../CHANGELOG.md) for version-by-version review, and use [Roadmap](../../ROADMAP.md) for current planning.
+
+## Latest
+
+- [v1.2.49](./v1.2.49.md)
+
+## Recent Releases
+
+- [v1.2.48](./v1.2.48.md)
+- [v1.2.47](./v1.2.47.md)
+- [v1.2.46](./v1.2.46.md)
+
+## Maintainer Release Docs
+
+- [Release Checklist](../release-checklist.md)
+- [Release Artifacts](../release-artifacts.md)
+- [Support Lifecycle](../support-lifecycle.md)
+
+For the full published archive, use [GitHub Releases](https://github.com/X-PG13/ainews-open/releases).

--- a/docs/releases/README.zh-CN.md
+++ b/docs/releases/README.zh-CN.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+[English](./README.md) · [简体中文](./README.zh-CN.md)
+
+Release notes 是已经发布内容的历史记录。逐版本审查时同时参考 [CHANGELOG.md](../../CHANGELOG.md)；当前规划请看 [路线图](../../ROADMAP.zh-CN.md)。
+
+## 最新版本
+
+- [v1.2.49](./v1.2.49.md)
+
+## 近期版本
+
+- [v1.2.48](./v1.2.48.md)
+- [v1.2.47](./v1.2.47.md)
+- [v1.2.46](./v1.2.46.md)
+
+## 维护者发版文档
+
+- [发版清单](../release-checklist.zh-CN.md)
+- [Release 产物校验](../release-artifacts.zh-CN.md)
+- [支持生命周期](../support-lifecycle.zh-CN.md)
+
+完整公开发布归档见 [GitHub Releases](https://github.com/X-PG13/ainews-open/releases)。

--- a/docs/support-lifecycle.md
+++ b/docs/support-lifecycle.md
@@ -83,4 +83,6 @@ If a deprecated behavior cannot remain in place because of security, safety, or 
 
 - [SUPPORT.md](../SUPPORT.md)
 - [Compatibility Contract](./compatibility.md)
+- [Roadmap](../ROADMAP.md)
+- [Release Notes](./releases/README.md)
 - [Release Checklist](./release-checklist.md)

--- a/docs/support-lifecycle.zh-CN.md
+++ b/docs/support-lifecycle.zh-CN.md
@@ -83,4 +83,6 @@ AI News Open 对当前稳定 major 线使用三种发布状态。
 
 - [SUPPORT.md](../SUPPORT.md)
 - [Compatibility Contract](./compatibility.md)
+- [路线图](../ROADMAP.zh-CN.md)
+- [Release Notes](./releases/README.zh-CN.md)
 - [Release Checklist](./release-checklist.md)


### PR DESCRIPTION
## Summary
- add a release notes index with recent release links and maintainer release docs
- make roadmap, support lifecycle, and release notes easier to find from the English and Chinese READMEs
- refresh roadmap status for `v1.2.50` and keep PyPI explicitly deferred
- link support lifecycle back to roadmap and release notes

## Validation
- `git diff --check`
- `./.venv-dev/bin/python -m pytest tests/test_docs_links.py`
- `make check PYTHON=./.venv-dev/bin/python`

Closes #93