### PR TITLE
docs: add dependency update review checklist

### DIFF
--- a/docs/contributor-playbook.md
+++ b/docs/contributor-playbook.md
@@ -24,6 +24,20 @@
 4. Add tests for success, platform error, and missing credential cases.
 5. Document required configuration variables in `docs/configuration.md` and `README.md`.
 
+## Update Dependencies Or GitHub Actions
+
+Dependabot PRs are notifications only. Do not directly merge a Dependabot PR into
+`main`.
+
+1. Review the Dependabot PR for scope, release notes, security context, and compatibility risk.
+2. Create a human-authored review branch from `main`.
+3. Manually apply the dependency or GitHub Actions upgrade on that branch.
+4. Run `make check PYTHON=./.venv-dev/bin/python`.
+5. Open a maintainer-authored PR and mention the original Dependabot PR.
+6. After the human-authored PR merges, close the original Dependabot PR.
+
+For the full maintainer checklist, see [Maintainer Bootstrap](./maintainer-bootstrap.md#dependency-update-policy).
+
 ## Validate Before Opening A PR
 
 - `make lint`

--- a/docs/maintainer-bootstrap.md
+++ b/docs/maintainer-bootstrap.md
@@ -74,13 +74,21 @@ Notes:
 
 Dependabot PRs are upgrade notifications, not merge-ready maintainer commits.
 
-Maintainers should not directly merge Dependabot PRs into `main`. When a dependency or GitHub Actions update is desired:
+Maintainers should not directly merge Dependabot PRs into `main`. Do not use the
+GitHub merge button on a Dependabot PR, and do not cherry-pick bot-authored
+commits onto the default branch.
 
-1. Review the Dependabot PR for scope, release notes, and compatibility risk.
-2. Create a human-authored review branch from `main`.
-3. Apply the same dependency update on that branch and run the normal checks.
-4. Open and merge the human-authored PR.
-5. Close the original Dependabot PR after the human-authored PR merges.
+Use this checklist when a dependency or GitHub Actions update is desired:
+
+1. Treat the Dependabot PR as a notification only. Read the changed package or action, release notes, security context, and compatibility risk.
+2. Create a human-authored review branch from the current `main`, for example `review/deps-<package>` or `review/actions-<action-name>`.
+3. Apply the same upgrade manually on that branch:
+   - Python dependency updates: edit the relevant dependency metadata such as `pyproject.toml`, keeping version bounds intentional.
+   - GitHub Actions updates: edit the relevant workflow action references, keeping permissions and triggers unchanged unless the upgrade requires a documented change.
+4. Run `make check PYTHON=./.venv-dev/bin/python`. If the change affects documentation links, also run `./.venv-dev/bin/python -m unittest tests.test_docs_links -v` before opening the PR.
+5. Open a maintainer-authored PR from the review branch. Mention the original Dependabot PR in the body so reviewers can compare the notification with the manual change.
+6. Merge the maintainer-authored PR after review and green checks.
+7. Close the original Dependabot PR after the human-authored PR merges, leaving a short comment that points to the merged maintainer PR.
 
 This keeps dependency upgrades reviewable while avoiding bot-authored commits on the default branch.
 

--- a/docs/maintainer-bootstrap.zh-CN.md
+++ b/docs/maintainer-bootstrap.zh-CN.md
@@ -74,13 +74,19 @@
 
 Dependabot PR 只作为升级通知，不视为可以直接合并的维护者提交。
 
-维护者不应把 Dependabot PR 直接 merge 到 `main`。如果确认需要升级某个依赖或 GitHub Actions：
+维护者不应把 Dependabot PR 直接 merge 到 `main`。不要在 Dependabot PR 上点 GitHub 的 merge 按钮，也不要把 bot-authored commits cherry-pick 到默认分支。
 
-1. 先阅读 Dependabot PR，确认升级范围、release notes 和兼容性风险。
-2. 从 `main` 新建一个由维护者提交的 review 分支。
-3. 在这个分支上应用同样的依赖升级，并运行常规检查。
-4. 开启并合并这个由维护者提交的 PR。
-5. 人工 PR 合并后，关闭原来的 Dependabot PR。
+如果确认需要升级某个依赖或 GitHub Actions，按下面的 checklist 处理：
+
+1. 只把 Dependabot PR 当作通知。先阅读被改动的 package 或 action、release notes、安全上下文和兼容性风险。
+2. 从当前 `main` 新建一个由维护者提交的 review 分支，例如 `review/deps-<package>` 或 `review/actions-<action-name>`。
+3. 在这个分支上手动应用同样的升级：
+   - Python 依赖升级：编辑相关依赖元数据，例如 `pyproject.toml`，并确保版本边界是有意设置的。
+   - GitHub Actions 升级：编辑相关 workflow 里的 action 引用；除非升级说明明确要求，否则不要顺手改 permissions 和 triggers。
+4. 运行 `make check PYTHON=./.venv-dev/bin/python`。如果改动影响文档链接，再额外运行 `./.venv-dev/bin/python -m unittest tests.test_docs_links -v`。
+5. 从 review 分支开启一个由维护者提交的 PR。在 PR 描述里提到原 Dependabot PR，方便 reviewer 对照通知和人工改动。
+6. 等 review 和 checks 都通过后，合并这个人工 PR。
+7. 人工 PR 合并后，关闭原来的 Dependabot PR，并留一句简短评论指向已合并的维护者 PR。
 
 这样可以保留依赖升级的可审查性，同时避免默认分支出现 bot-authored commits。
 


### PR DESCRIPTION
## Summary
- expand the maintainer dependency update policy into a concrete manual review checklist
- document separate handling for Python dependency updates and GitHub Actions updates
- add the same process entry point to the contributor playbook
- clarify that Dependabot PRs are notifications only and should be closed after the human-authored PR merges

## Why
Dependabot PRs should not be merged directly into `main`. This documents the maintainer-owned branch and PR flow so dependency upgrades remain reviewable without adding bot-authored commits to the default branch.

Closes #103.

## Validation
- `./.venv-dev/bin/python -m unittest tests.test_docs_links -v`
- `make check PYTHON=./.venv-dev/bin/python`