### PR TITLE
docs: document security response flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ Before publishing the repository, still confirm two things:
 1. Your private security reporting channel is configured in GitHub Security Advisories.
 2. The organization name, repository URLs, and maintainer metadata in `README.md` and `pyproject.toml` match your real public values.
 
+Security reports, maintainer triage, and disclosure expectations are documented
+in [SECURITY.md](SECURITY.md). Support boundaries are documented in
+[SUPPORT.md](SUPPORT.md) and [Support Lifecycle](docs/support-lifecycle.md).
+
 If you are preparing a GitHub launch, you can reuse:
 
 - `docs/github-launch-kit.md`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,6 +100,7 @@ make check
 - [路线图](ROADMAP.zh-CN.md)
 - [支持生命周期](docs/support-lifecycle.zh-CN.md)
 - [PR 审核约定](docs/pr-review-policy.zh-CN.md)
+- [安全策略](SECURITY.md)
 - [Release Notes](docs/releases/README.zh-CN.md)
 - [Release 产物校验](docs/release-artifacts.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,9 @@
 ## Supported Versions
 
 Only the latest released minor version is considered actively supported for security fixes.
+The immediately previous minor may receive security guidance, but fixes should
+target the latest minor first unless the maintainer explicitly decides to
+backport a severe issue.
 
 ## Reporting A Vulnerability
 
@@ -23,6 +26,58 @@ Preferred reporting channel for this repository:
 - GitHub Security Advisories: `https://github.com/X-PG13/ainews-open/security/advisories/new`
 
 If a dedicated security mailbox is added later, it can be listed here as a secondary contact path.
+
+## Private Disclosure Expectations
+
+Keep security reports private until a fix and disclosure plan are agreed.
+
+- Do not post exploit details, credentials, private logs, or proof-of-concept payloads in public issues, pull requests, discussions, or release comments.
+- Share only the minimum reproduction details needed for maintainers to confirm impact.
+- Redact API keys, admin tokens, webhook secrets, database paths, and production hostnames before attaching logs.
+- If a report affects a third-party platform, coordinate disclosure with that platform before making the issue public.
+
+Maintainers may move a public report into a private advisory and redact public
+comments if a vulnerability is accidentally disclosed in the open.
+
+## Maintainer Triage Flow
+
+Use this flow for incoming security reports:
+
+1. Acknowledge receipt privately and keep discussion in the GitHub Security Advisory thread.
+2. Confirm the affected version, deployment mode, credentials involved, and whether the issue is reproducible on `main`.
+3. Classify impact and severity:
+   - `Critical`: unauthenticated remote code execution, credential exfiltration, or default-token bypass.
+   - `High`: authenticated privilege escalation, stored secret exposure, or broad data disclosure.
+   - `Medium`: denial of service, limited data exposure, or bypass that requires unusual deployment choices.
+   - `Low`: hardening gaps, misleading errors, or issues with minimal practical impact.
+4. Decide whether the fix can be developed publicly without exposing exploit details. Use a private advisory branch when public work would reveal the vulnerability.
+5. Record the expected fix vehicle: patch release, documentation advisory, configuration mitigation, or no-code clarification.
+6. Keep the reporter updated when the impact assessment, fix plan, or disclosure timeline changes.
+
+## Fix And Release Checklist
+
+For confirmed vulnerabilities:
+
+1. Write the smallest safe fix and include a regression test when practical.
+2. Run `make check PYTHON=./.venv-dev/bin/python`.
+3. Update `CHANGELOG.md` and release notes with user-facing impact and mitigation details that do not include exploit instructions.
+4. Prepare a patch release from a maintainer-authored branch.
+5. Publish the GitHub Release and confirm release assets, checksums, SBOM, and release artifact smoke checks.
+6. Update the GitHub Security Advisory with affected versions, patched version, impact, workaround, and credits if the reporter wants attribution.
+7. Close or convert any related public issue only after the patched release is available.
+
+If an immediate code fix is not available, publish a mitigation advisory that
+documents safe configuration changes, credential rotation, or feature disablement
+steps.
+
+## Public Disclosure
+
+Public disclosure should happen after the patched release or mitigation advisory
+is available.
+
+- Keep exploit payloads and secret values out of release notes.
+- Credit reporters only with explicit permission.
+- If the issue has no practical impact, document the reasoning in the advisory and close it without a release.
 
 ## Response Expectations
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,7 +14,7 @@ See `docs/support-lifecycle.md` for the full minor-release support window and de
 ## Where To Ask For Help
 
 - Bugs: open a GitHub issue with the bug template.
-- Security: use GitHub Security Advisories, not public issues.
+- Security: use GitHub Security Advisories, not public issues; see `SECURITY.md` for reporting, triage, and disclosure expectations.
 - Feature requests: use the feature request template once the request is concrete enough to track as implementation work.
 - Usage questions, early ideas, showcase posts, and design discussion: use GitHub Discussions. See `docs/community-triage.md` for the issue-vs-discussion split.
 

--- a/docs/support-lifecycle.md
+++ b/docs/support-lifecycle.md
@@ -82,6 +82,7 @@ If a deprecated behavior cannot remain in place because of security, safety, or 
 ## Related Docs
 
 - [SUPPORT.md](../SUPPORT.md)
+- [Security Policy](../SECURITY.md)
 - [Compatibility Contract](./compatibility.md)
 - [Roadmap](../ROADMAP.md)
 - [Release Notes](./releases/README.md)

--- a/docs/support-lifecycle.zh-CN.md
+++ b/docs/support-lifecycle.zh-CN.md
@@ -82,6 +82,7 @@ AI News Open 对当前稳定 major 线使用三种发布状态。
 ## 相关文档
 
 - [SUPPORT.md](../SUPPORT.md)
+- [安全策略](../SECURITY.md)
 - [Compatibility Contract](./compatibility.md)
 - [路线图](../ROADMAP.zh-CN.md)
 - [Release Notes](./releases/README.zh-CN.md)


### PR DESCRIPTION
## Summary
- expand `SECURITY.md` with private disclosure expectations, maintainer triage, fix/release checklist, and public disclosure guidance
- clarify security support scope for latest and previous minor versions
- link the security policy from README, SUPPORT, and support lifecycle docs

## Why
Open-source users need a clear private reporting path and maintainers need a lightweight process for triage, fixes, release follow-up, and disclosure without exposing exploit details publicly.

Closes #104.

## Validation
- `./.venv-dev/bin/python -m unittest tests.test_docs_links -v`
- `make check PYTHON=./.venv-dev/bin/python`