### PR TITLE
test: guard release asset naming

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -42,31 +42,57 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      - name: Define expected release assets
+        run: |
+          case "${RELEASE_TAG}" in
+            v*) ;;
+            *)
+              echo "RELEASE_TAG must start with v: ${RELEASE_TAG}" >&2
+              exit 1
+              ;;
+          esac
+
+          VERSION="${RELEASE_TAG#v}"
+          {
+            echo "RELEASE_VERSION=${VERSION}"
+            echo "WHEEL_ASSET=ainews_open-${VERSION}-py3-none-any.whl"
+            echo "SDIST_ASSET=ainews_open-${VERSION}.tar.gz"
+            echo "CHECKSUMS_ASSET=sha256sums.txt"
+            echo "SBOM_ASSET=v${VERSION}-sbom.json"
+          } >> "${GITHUB_ENV}"
+
       - name: Download release assets
         run: |
           mkdir -p release-assets
           gh release download "${RELEASE_TAG}" \
             --dir release-assets \
-            --pattern "*.whl" \
-            --pattern "*.tar.gz" \
-            --pattern "sha256sums.txt"
+            --pattern "${WHEEL_ASSET}" \
+            --pattern "${SDIST_ASSET}" \
+            --pattern "${CHECKSUMS_ASSET}" \
+            --pattern "${SBOM_ASSET}"
           ls -la release-assets
+
+      - name: Verify expected release assets
+        run: |
+          for asset in "${WHEEL_ASSET}" "${SDIST_ASSET}" "${CHECKSUMS_ASSET}" "${SBOM_ASSET}"; do
+            test -f "release-assets/${asset}"
+          done
 
       - name: Verify release checksums
         working-directory: release-assets
-        run: sha256sum -c sha256sums.txt
+        run: sha256sum -c "${CHECKSUMS_ASSET}"
 
       - name: Install artifact
         run: |
           case "${{ matrix.artifact }}" in
             wheel)
-              ARTIFACT_PATH="$(find release-assets -maxdepth 1 -type f -name '*.whl' | head -n 1)"
+              ARTIFACT_PATH="release-assets/${WHEEL_ASSET}"
               ;;
             sdist)
-              ARTIFACT_PATH="$(find release-assets -maxdepth 1 -type f -name '*.tar.gz' | head -n 1)"
+              ARTIFACT_PATH="release-assets/${SDIST_ASSET}"
               ;;
           esac
-          test -n "${ARTIFACT_PATH}"
+          test -f "${ARTIFACT_PATH}"
           python -m pip install --upgrade pip
           python -m pip install "${ARTIFACT_PATH}"
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -5,6 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 PROJECT_VERSION_RE = re.compile(r'^version = "([^"]+)"$', re.MULTILINE)
+PROJECT_NAME_RE = re.compile(r'^name = "([^"]+)"$', re.MULTILINE)
 RUNTIME_VERSION_RE = re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE)
 CHANGELOG_RELEASE_RE = re.compile(
     r"^## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}$",
@@ -27,6 +28,24 @@ def _match_required(pattern: re.Pattern[str], text: str, label: str) -> str:
 
 def _project_version() -> str:
     return _match_required(PROJECT_VERSION_RE, _read_text("pyproject.toml"), "project.version")
+
+
+def _project_name() -> str:
+    return _match_required(PROJECT_NAME_RE, _read_text("pyproject.toml"), "project.name")
+
+
+def _distribution_name() -> str:
+    return re.sub(r"[-_.]+", "_", _project_name()).lower()
+
+
+def _expected_release_asset_names(version: str) -> tuple[str, str, str, str]:
+    distribution = _distribution_name()
+    return (
+        f"{distribution}-{version}-py3-none-any.whl",
+        f"{distribution}-{version}.tar.gz",
+        "sha256sums.txt",
+        f"v{version}-sbom.json",
+    )
 
 
 def _markdown_section(text: str, heading: str) -> str:
@@ -76,6 +95,53 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         release_index_zh = _read_text("docs/releases/README.zh-CN.md")
         self.assertIn(release_link, _markdown_section(release_index, "Latest"))
         self.assertIn(release_link, _markdown_section(release_index_zh, LATEST_HEADING_ZH))
+
+    def test_release_asset_names_match_current_package_version(self) -> None:
+        version = _project_version()
+
+        self.assertEqual(
+            _expected_release_asset_names(version),
+            (
+                f"ainews_open-{version}-py3-none-any.whl",
+                f"ainews_open-{version}.tar.gz",
+                "sha256sums.txt",
+                f"v{version}-sbom.json",
+            ),
+        )
+
+    def test_release_asset_contract_is_documented_and_enforced(self) -> None:
+        distribution = _distribution_name()
+        templated_asset_names = (
+            f"{distribution}-${{VERSION}}-py3-none-any.whl",
+            f"{distribution}-${{VERSION}}.tar.gz",
+            "sha256sums.txt",
+            "v${VERSION}-sbom.json",
+        )
+        release_docs = _read_text("docs/release-artifacts.md")
+        release_docs_zh = _read_text("docs/release-artifacts.zh-CN.md")
+
+        for asset_name in templated_asset_names:
+            self.assertIn(asset_name, release_docs)
+            self.assertIn(asset_name, release_docs_zh)
+
+        release_workflow = _read_text(".github/workflows/release.yml")
+        self.assertIn("for artifact in *.whl *.tar.gz; do", release_workflow)
+        self.assertIn('-o "dist/${GITHUB_REF_NAME}-sbom.json"', release_workflow)
+        self.assertIn('gh release create "${TAG}" dist/*', release_workflow)
+
+        smoke_workflow = _read_text(".github/workflows/release-artifact-smoke.yml")
+        self.assertIn('VERSION="${RELEASE_TAG#v}"', smoke_workflow)
+        self.assertIn(
+            f'echo "WHEEL_ASSET={distribution}-${{VERSION}}-py3-none-any.whl"',
+            smoke_workflow,
+        )
+        self.assertIn(f'echo "SDIST_ASSET={distribution}-${{VERSION}}.tar.gz"', smoke_workflow)
+        self.assertIn('echo "CHECKSUMS_ASSET=sha256sums.txt"', smoke_workflow)
+        self.assertIn('echo "SBOM_ASSET=v${VERSION}-sbom.json"', smoke_workflow)
+
+        for asset_variable in ("WHEEL_ASSET", "SDIST_ASSET", "CHECKSUMS_ASSET", "SBOM_ASSET"):
+            self.assertIn(f'--pattern "${{{asset_variable}}}"', smoke_workflow)
+            self.assertIn(f'"${{{asset_variable}}}"', smoke_workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- derive expected release asset names from package metadata in the release metadata tests
- assert the wheel, source archive, checksum file, and SBOM naming contract stays aligned across docs and workflows
- make release artifact smoke download exact expected asset names instead of broad globs, including the SBOM

## Why
Release follow-up depends on a stable asset set. This adds a local offline guard so asset naming drift is caught before release prep or post-release smoke.

Closes #110.

## Validation
- `./.venv-dev/bin/python -m unittest tests.test_release_metadata -v`
- `./.venv-dev/bin/python -m ruff check tests/test_release_metadata.py`
- `git diff --check`
- `make check PYTHON=./.venv-dev/bin/python`