### PR TITLE
docs: add release failure recovery notes

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -42,6 +42,7 @@ Confirm:
 
 Release is not considered complete until `Release Artifact Smoke` passes for the published tag.
 The standard release flow now dispatches that smoke workflow automatically after publishing the GitHub Release.
+If a merge, tag, release, or workflow command times out after it may have changed GitHub state, use the [release recovery notes](./release-recovery.md) before retrying the mutating command.
 
 ## GitHub Release
 
@@ -103,6 +104,8 @@ Run the post-release smoke checklist before announcing the release or closing it
 - [ ] Leave deferred work in a separate milestone instead of carrying it inside the closed release milestone.
 
 ## Post-Release Failure Triage
+
+Use the [release recovery notes](./release-recovery.md) for command-level recovery when GitHub network calls time out or local refs need repair.
 
 - Missing or partial release assets: confirm the tag points to the intended commit, then re-run the `Release` workflow. Do not move or recreate a public tag unless the published tag itself points to the wrong commit and the maintainer explicitly accepts the compatibility risk.
 - Failed `Release Artifact Smoke`: inspect whether the failure is checksum, wheel install, source archive install, CLI startup, or `/health` startup. Fix the release workflow or package issue in a follow-up PR, then publish a new patch tag if the released assets are already public.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -42,6 +42,7 @@ make check
 
 如果已发布 tag 对应的 `Release Artifact Smoke` 还没通过，这次 release 就不算完成。
 标准 release 流程现在会在 GitHub Release 发布后自动触发这条 smoke workflow。
+如果 merge、tag、release 或 workflow 命令超时，而且它可能已经改动 GitHub 状态，重试写操作前先按 [Release 恢复说明](./release-recovery.zh-CN.md) 验证远端状态。
 
 ## GitHub Release
 
@@ -103,6 +104,8 @@ python -m ainews --help
 - [ ] 延期事项放到单独 milestone，不要留在已经关闭的 release milestone 里。
 
 ## 发版后失败分流
+
+当 GitHub 网络调用超时，或本地 ref 需要修复时，按 [Release 恢复说明](./release-recovery.zh-CN.md) 做命令级恢复。
 
 - Release 制品缺失或不完整：先确认 tag 指向预期 commit，再重跑 `Release` workflow。除非公开 tag 本身指错 commit，并且维护者明确接受兼容性风险，否则不要移动或重建公开 tag。
 - `Release Artifact Smoke` 失败：先判断失败点是 checksum、wheel 安装、source archive 安装、CLI 启动，还是 `/health` 启动。通过后续 PR 修复 release workflow 或打包问题；如果资产已经公开，修复后应发新的 patch tag。

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -1,0 +1,121 @@
+# Release Recovery Notes
+
+[English](./release-recovery.md) · [简体中文](./release-recovery.zh-CN.md)
+
+Use these notes when a release or PR closeout action may have changed GitHub state, but the local command failed, timed out, or left local refs inconsistent. This page covers the GitHub release channel only. PyPI recovery stays separate.
+
+## Recovery Rules
+
+- Verify remote state before retrying any mutating command.
+- Treat `git fetch`, `git merge --ff-only`, `git status`, `git ls-remote`, `gh pr view`, `gh release view`, `gh run list`, and GitHub API `GET` requests as safe to rerun.
+- If a `git push`, `gh api` `POST`, `PUT`, or `DELETE` times out, assume it may have succeeded until a read-only check proves otherwise.
+- Do not move or recreate a public tag unless the tag points to the wrong commit and the maintainer explicitly accepts the compatibility risk.
+- Keep PyPI recovery out of this flow. If PyPI is disabled or deferred, leave it in its own milestone.
+
+## PR Merge Succeeded, Local Fast-Forward Failed
+
+First confirm whether the PR actually merged:
+
+```bash
+PR=123
+gh pr view "${PR}" --json state,merged,mergeCommit,headRefName,baseRefName,url
+gh api "repos/X-PG13/ainews-open/pulls/${PR}" \
+  --jq '{state,merged,merge_commit_sha,head:.head.ref,base:.base.ref}'
+```
+
+If `merged` is true, recover local `main` with a fast-forward only:
+
+```bash
+git fetch --prune origin main
+git switch main
+git merge --ff-only origin/main
+git status --short --branch
+```
+
+If `git fetch` failed after damaging the local remote-tracking ref, verify the remote `main` commit before repairing the ref:
+
+```bash
+REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+git update-ref refs/remotes/origin/main "${REMOTE_MAIN}"
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+git merge --ff-only origin/main
+```
+
+Do not create a local merge commit and do not push local `main` as a workaround. The goal is to mirror the already-merged GitHub state.
+
+## Tag Created, Local Fetch Failed
+
+First confirm the remote tag and release state:
+
+```bash
+TAG=vX.Y.Z
+git ls-remote --tags origin "refs/tags/${TAG}"
+gh release view "${TAG}" --json tagName,targetCommitish,isDraft,isPrerelease,url
+```
+
+If the tag exists remotely, fetch only that tag and verify its target:
+
+```bash
+git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+git rev-parse "${TAG}^{commit}"
+git show --no-patch --decorate "${TAG}"
+```
+
+If a local tag already exists, compare it before doing anything else:
+
+```bash
+git show-ref --tags "${TAG}"
+git rev-parse "${TAG}^{commit}"
+```
+
+If the local and remote tag targets differ, stop. Do not delete, move, or recreate the public tag without an explicit maintainer decision.
+
+## Release Workflow Succeeded, Asset Smoke Needs Verification
+
+Confirm the release workflow, artifact smoke workflow, and published asset set:
+
+```bash
+TAG=vX.Y.Z
+VERSION=${TAG#v}
+gh run list --workflow release.yml --limit 10
+gh run list --workflow release-artifact-smoke.yml --limit 10
+gh release view "${TAG}" --json assets,isDraft,isPrerelease,isLatest,url
+```
+
+Download the expected assets into a scratch directory:
+
+```bash
+WORKDIR=$(mktemp -d)
+gh release download "${TAG}" \
+  --dir "${WORKDIR}" \
+  --pattern "ainews_open-${VERSION}-py3-none-any.whl" \
+  --pattern "ainews_open-${VERSION}.tar.gz" \
+  --pattern "sha256sums.txt" \
+  --pattern "${TAG}-sbom.json"
+```
+
+Run the checksum and install smoke checks:
+
+```bash
+(cd "${WORKDIR}" && sha256sum -c sha256sums.txt)
+python -m pip install "${WORKDIR}/ainews_open-${VERSION}-py3-none-any.whl"
+python -m ainews --help
+```
+
+For the full wheel, source archive, checksum, and SBOM path, use the [release artifact verification flow](./release-artifacts.md#copy-paste-verification-flow).
+
+## Network Timeout After A Remote Action
+
+When a mutating network call times out, read state first and retry only if the read proves the action did not happen.
+
+| Interrupted action | Safe verification command |
+| --- | --- |
+| PR creation | `gh pr list --head review/example --state all` |
+| PR merge | `gh pr view 123 --json state,merged,mergeCommit` |
+| Review branch deletion | `git ls-remote --heads origin review/example` |
+| Tag push | `git ls-remote --tags origin refs/tags/vX.Y.Z` |
+| Release create or upload | `gh release view vX.Y.Z --json assets,isDraft,isPrerelease,url` |
+| Workflow dispatch | `gh run list --workflow release-artifact-smoke.yml --limit 10` |
+| Issue or milestone update | `gh issue view 123 --json state,milestone,closedAt` |
+
+Retrying read-only commands is safe. Retrying `POST`, `PUT`, `DELETE`, or `git push` is only safe after the verification command shows the remote action is still missing.

--- a/docs/release-recovery.zh-CN.md
+++ b/docs/release-recovery.zh-CN.md
@@ -1,0 +1,121 @@
+# Release 恢复说明
+
+[English](./release-recovery.md) · [简体中文](./release-recovery.zh-CN.md)
+
+当 release 或 PR 收尾操作可能已经改动 GitHub 远端状态，但本地命令失败、超时，或导致本地 ref 不一致时，用这份说明恢复。本文只覆盖 GitHub release 渠道。PyPI 恢复流程保持独立。
+
+## 恢复规则
+
+- 重试任何会改远端状态的命令前，先读取远端状态。
+- `git fetch`、`git merge --ff-only`、`git status`、`git ls-remote`、`gh pr view`、`gh release view`、`gh run list` 和 GitHub API `GET` 请求可以安全重跑。
+- 如果 `git push`、`gh api` 的 `POST`、`PUT` 或 `DELETE` 超时，先假设远端操作可能已经成功，直到只读检查证明没有成功。
+- 除非公开 tag 指向了错误 commit，并且维护者明确接受兼容性风险，否则不要移动或重建公开 tag。
+- PyPI 恢复不要混进这条流程。如果 PyPI 当前禁用或延期，继续把它留在独立 milestone。
+
+## PR 已合并，但本地快进失败
+
+先确认 PR 是否真的已经合并：
+
+```bash
+PR=123
+gh pr view "${PR}" --json state,merged,mergeCommit,headRefName,baseRefName,url
+gh api "repos/X-PG13/ainews-open/pulls/${PR}" \
+  --jq '{state,merged,merge_commit_sha,head:.head.ref,base:.base.ref}'
+```
+
+如果 `merged` 为 true，只用 fast-forward 恢复本地 `main`：
+
+```bash
+git fetch --prune origin main
+git switch main
+git merge --ff-only origin/main
+git status --short --branch
+```
+
+如果 `git fetch` 中途失败并破坏了本地 remote-tracking ref，先验证远端 `main` commit，再修复本地 ref：
+
+```bash
+REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+git update-ref refs/remotes/origin/main "${REMOTE_MAIN}"
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+git merge --ff-only origin/main
+```
+
+不要为了绕过问题创建本地 merge commit，也不要 push 本地 `main`。目标是让本地状态镜像 GitHub 上已经合并的状态。
+
+## Tag 已创建，但本地 fetch 失败
+
+先确认远端 tag 和 release 状态：
+
+```bash
+TAG=vX.Y.Z
+git ls-remote --tags origin "refs/tags/${TAG}"
+gh release view "${TAG}" --json tagName,targetCommitish,isDraft,isPrerelease,url
+```
+
+如果远端 tag 存在，只 fetch 这个 tag 并验证目标 commit：
+
+```bash
+git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+git rev-parse "${TAG}^{commit}"
+git show --no-patch --decorate "${TAG}"
+```
+
+如果本地已经有同名 tag，先比较它，再做下一步：
+
+```bash
+git show-ref --tags "${TAG}"
+git rev-parse "${TAG}^{commit}"
+```
+
+如果本地和远端 tag 目标不一致，立刻停下。没有明确维护者决策前，不要删除、移动或重建公开 tag。
+
+## Release workflow 成功，但还需要验证 asset smoke
+
+确认 release workflow、artifact smoke workflow 和已发布资产：
+
+```bash
+TAG=vX.Y.Z
+VERSION=${TAG#v}
+gh run list --workflow release.yml --limit 10
+gh run list --workflow release-artifact-smoke.yml --limit 10
+gh release view "${TAG}" --json assets,isDraft,isPrerelease,isLatest,url
+```
+
+把预期资产下载到临时目录：
+
+```bash
+WORKDIR=$(mktemp -d)
+gh release download "${TAG}" \
+  --dir "${WORKDIR}" \
+  --pattern "ainews_open-${VERSION}-py3-none-any.whl" \
+  --pattern "ainews_open-${VERSION}.tar.gz" \
+  --pattern "sha256sums.txt" \
+  --pattern "${TAG}-sbom.json"
+```
+
+执行 checksum 和安装烟测：
+
+```bash
+(cd "${WORKDIR}" && sha256sum -c sha256sums.txt)
+python -m pip install "${WORKDIR}/ainews_open-${VERSION}-py3-none-any.whl"
+python -m ainews --help
+```
+
+完整的 wheel、source archive、checksum 和 SBOM 校验路径见 [Release 产物校验流程](./release-artifacts.zh-CN.md#copy-paste-verification-flow)。
+
+## 远端操作后网络超时
+
+如果一个会改远端状态的网络调用超时，先读取状态；只有只读检查证明操作没有发生时，才重试写操作。
+
+| 中断的操作 | 安全验证命令 |
+| --- | --- |
+| 创建 PR | `gh pr list --head review/example --state all` |
+| 合并 PR | `gh pr view 123 --json state,merged,mergeCommit` |
+| 删除 review 分支 | `git ls-remote --heads origin review/example` |
+| 推送 tag | `git ls-remote --tags origin refs/tags/vX.Y.Z` |
+| 创建或上传 Release | `gh release view vX.Y.Z --json assets,isDraft,isPrerelease,url` |
+| 触发 workflow | `gh run list --workflow release-artifact-smoke.yml --limit 10` |
+| 更新 issue 或 milestone | `gh issue view 123 --json state,milestone,closedAt` |
+
+只读命令可以安全重跑。`POST`、`PUT`、`DELETE` 或 `git push` 只有在验证命令显示远端操作仍然不存在时，才应该重试。

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -18,6 +18,7 @@ Release notes are the historical record of shipped changes. Use them with [CHANG
 
 - [Release Checklist](../release-checklist.md)
 - [Release Artifacts](../release-artifacts.md)
+- [Release Recovery Notes](../release-recovery.md)
 - [Support Lifecycle](../support-lifecycle.md)
 
 For the full published archive, use [GitHub Releases](https://github.com/X-PG13/ainews-open/releases).

--- a/docs/releases/README.zh-CN.md
+++ b/docs/releases/README.zh-CN.md
@@ -18,6 +18,7 @@ Release notes 是已经发布内容的历史记录。逐版本审查时同时参
 
 - [发版清单](../release-checklist.zh-CN.md)
 - [Release 产物校验](../release-artifacts.zh-CN.md)
+- [Release 恢复说明](../release-recovery.zh-CN.md)
 - [支持生命周期](../support-lifecycle.zh-CN.md)
 
 完整公开发布归档见 [GitHub Releases](https://github.com/X-PG13/ainews-open/releases)。


### PR DESCRIPTION
## Summary
- add English and Chinese release recovery notes for interrupted GitHub release operations
- cover PR merge fast-forward recovery, tag fetch recovery, asset smoke verification, and network timeouts after remote actions
- link the recovery notes from release checklists and release notes indexes

## Why
The release checklist covered the happy path, but maintainers also need safe, repeatable commands when GitHub network calls time out after remote state may already have changed.

Closes #111.

## Validation
- `./.venv-dev/bin/python -m unittest tests.test_docs_links -v`
- `git diff --check`
- `make check PYTHON=./.venv-dev/bin/python`