### PR TITLE
test: guard README release doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ make check
 - [PR Review Policy](docs/pr-review-policy.md)
 - [Release Notes](docs/releases/README.md)
 - [Release Artifacts](docs/release-artifacts.md)
+- [Release Recovery Notes](docs/release-recovery.md)
 - [Use Cases](docs/use-cases.md)
 - [Community Triage](docs/community-triage.md)
 - [Contributor Playbook](docs/contributor-playbook.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,6 +103,7 @@ make check
 - [安全策略](SECURITY.md)
 - [Release Notes](docs/releases/README.zh-CN.md)
 - [Release 产物校验](docs/release-artifacts.zh-CN.md)
+- [Release 恢复说明](docs/release-recovery.zh-CN.md)
 - [使用场景](docs/use-cases.zh-CN.md)
 - [社区分流规范](docs/community-triage.zh-CN.md)
 - [贡献者手册](docs/contributor-playbook.md)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -11,6 +11,7 @@ CHANGELOG_RELEASE_RE = re.compile(
     r"^## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}$",
     re.MULTILINE,
 )
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]\n]+\]\(([^)\n]+)\)")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 LATEST_HEADING_ZH = "\u6700\u65b0\u7248\u672c"
 
@@ -59,6 +60,15 @@ def _markdown_section(text: str, heading: str) -> str:
     if next_heading is None:
         return text[content_start:]
     return text[content_start : content_start + next_heading.start()]
+
+
+def _markdown_link_targets(relative_path: str) -> set[str]:
+    targets: set[str] = set()
+    for target in MARKDOWN_LINK_RE.findall(_read_text(relative_path)):
+        path_target = target.split("#", 1)[0].strip()
+        if path_target:
+            targets.add(path_target)
+    return targets
 
 
 class ReleaseMetadataTestCase(unittest.TestCase):
@@ -142,6 +152,25 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         for asset_variable in ("WHEEL_ASSET", "SDIST_ASSET", "CHECKSUMS_ASSET", "SBOM_ASSET"):
             self.assertIn(f'--pattern "${{{asset_variable}}}"', smoke_workflow)
             self.assertIn(f'"${{{asset_variable}}}"', smoke_workflow)
+
+    def test_readmes_expose_release_maintenance_entry_points(self) -> None:
+        expected_readme_links = {
+            "docs/releases/README.md",
+            "docs/release-artifacts.md",
+            "docs/release-recovery.md",
+            "docs/release-checklist.md",
+            "docs/support-lifecycle.md",
+        }
+        expected_readme_zh_links = {
+            "docs/releases/README.zh-CN.md",
+            "docs/release-artifacts.zh-CN.md",
+            "docs/release-recovery.zh-CN.md",
+            "docs/release-checklist.zh-CN.md",
+            "docs/support-lifecycle.zh-CN.md",
+        }
+
+        self.assertLessEqual(expected_readme_links, _markdown_link_targets("README.md"))
+        self.assertLessEqual(expected_readme_zh_links, _markdown_link_targets("README.zh-CN.md"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add README links to the release recovery notes in English and Simplified Chinese
- add an offline release metadata regression test that guards README release-maintenance entry points
- keep the check focused on navigation targets, not README prose

## Why
Release documentation now spans notes, artifacts, recovery, checklist, and support lifecycle pages. The README should continue exposing that maintenance path from the top-level project entry points.

Closes #117.

## Validation
- `./.venv-dev/bin/python -m unittest tests.test_release_metadata tests.test_docs_links -v`
- `./.venv-dev/bin/python -m ruff check tests/test_release_metadata.py`
- `git diff --check`
- `make check PYTHON=./.venv-dev/bin/python`
