### PR TITLE
docs: document tag push API fallback

### DIFF
--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -70,6 +70,47 @@ git rev-parse "${TAG}^{commit}"
 
 If the local and remote tag targets differ, stop. Do not delete, move, or recreate the public tag without an explicit maintainer decision.
 
+## Tag Push Timed Out Before Release Creation
+
+Use this flow when `git push origin "${TAG}"` or `git push origin "refs/tags/${TAG}"` times out before the GitHub Release is created. Do not retry the push immediately; first prove whether the remote tag already exists.
+
+Verify the local tag target and remote state:
+
+```bash
+TAG=vX.Y.Z
+EXPECTED_COMMIT=$(git rev-parse "${TAG}^{commit}")
+git show --no-patch --decorate "${TAG}"
+git ls-remote --tags origin "refs/tags/${TAG}"
+gh api "repos/X-PG13/ainews-open/git/ref/tags/${TAG}" \
+  --jq '{ref,object}'
+```
+
+Use these decisions:
+
+- If the remote tag exists and points to `EXPECTED_COMMIT`, treat the push as successful. Fetch the tag, verify the release workflow, and continue with release asset checks.
+- If the remote tag exists but points anywhere else, stop. Do not delete, move, or recreate the public tag without an explicit maintainer decision.
+- If the remote tag is missing and the local tag points to the reviewed release commit, an API-created lightweight tag ref is acceptable for this repository because existing release tags are lightweight commit refs.
+- If a signed or annotated tag is required for the release, stop instead of using the lightweight-ref fallback.
+
+Create the missing lightweight tag ref only after the read-only checks prove it is absent:
+
+```bash
+gh api repos/X-PG13/ainews-open/git/refs \
+  -f "ref=refs/tags/${TAG}" \
+  -f "sha=${EXPECTED_COMMIT}"
+```
+
+Then verify the public tag before creating or editing the GitHub Release:
+
+```bash
+git ls-remote --tags origin "refs/tags/${TAG}"
+gh api "repos/X-PG13/ainews-open/git/ref/tags/${TAG}" \
+  --jq '{ref,object}'
+gh release view "${TAG}" --json tagName,targetCommitish,isDraft,isPrerelease,url
+```
+
+If the API call times out, repeat the read-only verification commands before retrying. Never issue a second tag-creation request until the remote tag is proven missing.
+
 ## Release Workflow Succeeded, Asset Smoke Needs Verification
 
 Confirm the release workflow, artifact smoke workflow, and published asset set:

--- a/docs/release-recovery.zh-CN.md
+++ b/docs/release-recovery.zh-CN.md
@@ -70,6 +70,47 @@ git rev-parse "${TAG}^{commit}"
 
 如果本地和远端 tag 目标不一致，立刻停下。没有明确维护者决策前，不要删除、移动或重建公开 tag。
 
+## Tag 推送超时，但 Release 尚未创建
+
+当 `git push origin "${TAG}"` 或 `git push origin "refs/tags/${TAG}"` 在创建 GitHub Release 之前超时时，使用这条流程。不要立刻重试 push；先证明远端 tag 是否已经存在。
+
+验证本地 tag 目标和远端状态：
+
+```bash
+TAG=vX.Y.Z
+EXPECTED_COMMIT=$(git rev-parse "${TAG}^{commit}")
+git show --no-patch --decorate "${TAG}"
+git ls-remote --tags origin "refs/tags/${TAG}"
+gh api "repos/X-PG13/ainews-open/git/ref/tags/${TAG}" \
+  --jq '{ref,object}'
+```
+
+按以下规则决策：
+
+- 如果远端 tag 存在且指向 `EXPECTED_COMMIT`，把这次 push 视为成功。fetch 该 tag，验证 release workflow，然后继续 release 产物检查。
+- 如果远端 tag 存在但指向其他 commit，立刻停下。没有明确维护者决策前，不要删除、移动或重建公开 tag。
+- 如果远端 tag 不存在，并且本地 tag 指向已经审过的 release commit，可以用 GitHub API 创建 lightweight tag ref；本仓库现有 release tag 就是 lightweight commit ref，因此这个 fallback 可接受。
+- 如果这次 release 要求 signed 或 annotated tag，停下，不要使用 lightweight-ref fallback。
+
+只有只读检查证明远端 tag 不存在后，才创建缺失的 lightweight tag ref：
+
+```bash
+gh api repos/X-PG13/ainews-open/git/refs \
+  -f "ref=refs/tags/${TAG}" \
+  -f "sha=${EXPECTED_COMMIT}"
+```
+
+创建或编辑 GitHub Release 前，再验证公开 tag：
+
+```bash
+git ls-remote --tags origin "refs/tags/${TAG}"
+gh api "repos/X-PG13/ainews-open/git/ref/tags/${TAG}" \
+  --jq '{ref,object}'
+gh release view "${TAG}" --json tagName,targetCommitish,isDraft,isPrerelease,url
+```
+
+如果 API 调用也超时，先重复只读验证命令，再决定是否重试。除非已经证明远端 tag 仍不存在，否则不要发第二次 tag 创建请求。
+
 ## Release workflow 成功，但还需要验证 asset smoke
 
 确认 release workflow、artifact smoke workflow 和已发布资产：

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -201,6 +201,24 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         self.assertIn("Trigger artifact smoke", release_workflow)
         self.assertIn("Publish GitHub Release", release_workflow)
 
+    def test_release_recovery_documents_tag_push_api_fallback(self) -> None:
+        recovery_docs = _read_text("docs/release-recovery.md")
+        recovery_docs_zh = _read_text("docs/release-recovery.zh-CN.md")
+
+        self.assertIn("Tag Push Timed Out Before Release Creation", recovery_docs)
+        self.assertIn("git ls-remote --tags origin \"refs/tags/${TAG}\"", recovery_docs)
+        self.assertIn("git/ref/tags/${TAG}", recovery_docs)
+        self.assertIn("refs/tags/${TAG}", recovery_docs)
+        self.assertIn("lightweight tag ref", recovery_docs)
+        self.assertIn("Never issue a second tag-creation request", recovery_docs)
+
+        self.assertIn("Tag 推送超时，但 Release 尚未创建", recovery_docs_zh)
+        self.assertIn("git ls-remote --tags origin \"refs/tags/${TAG}\"", recovery_docs_zh)
+        self.assertIn("git/ref/tags/${TAG}", recovery_docs_zh)
+        self.assertIn("refs/tags/${TAG}", recovery_docs_zh)
+        self.assertIn("lightweight tag ref", recovery_docs_zh)
+        self.assertIn("不要发第二次 tag 创建请求", recovery_docs_zh)
+
     def test_readmes_expose_release_maintenance_entry_points(self) -> None:
         expected_readme_links = {
             "docs/releases/README.md",


### PR DESCRIPTION
## Summary
- add a tag-push timeout recovery flow to the release recovery docs
- document read-only verification before retrying or creating a lightweight tag ref through the GitHub API
- add Simplified Chinese coverage and a regression test for the recovery contract

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #124