### PR TITLE
docs: keep roadmap release status current

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,11 +7,11 @@ This roadmap tracks current maintainer priorities. Release notes remain the hist
 ## Current Status
 
 - Stable line: `v1.2.x`
-- Latest release: `v1.2.49`
-- Current open milestone: `v1.2.50`
+- Latest patch release: see the [release notes index](docs/releases/README.md)
+- Current open milestone: see the active GitHub milestone for the next `v1.2.x` maintenance release
 - Deferred release-engineering item: trusted PyPI publishing bootstrap and the first package publish
 
-## In Progress: v1.2.50 Maintenance
+## In Progress: v1.2.x Maintenance
 
 - Improve release verification and post-release smoke documentation.
 - Keep roadmap, support lifecycle, and release notes easier to discover from primary docs entry points.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -7,11 +7,11 @@
 ## 当前状态
 
 - 稳定版本线：`v1.2.x`
-- 最新 release：`v1.2.49`
-- 当前开启的 milestone：`v1.2.50`
+- 最新 patch release：见 [release notes 索引](docs/releases/README.zh-CN.md)
+- 当前开启的 milestone：见下一个 `v1.2.x` 维护版本对应的 GitHub milestone
 - 延期的 release engineering 项：PyPI trusted publishing 初始化和首次发包
 
-## 进行中：v1.2.50 维护事项
+## 进行中：v1.2.x 维护事项
 
 - 改进 release 校验和发版后 smoke 文档。
 - 让 roadmap、支持生命周期和 release notes 更容易从主要文档入口发现。

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -27,6 +27,7 @@ make check
 2. Update the version in `src/ainews/__init__.py`.
 3. Add the release section to `CHANGELOG.md`.
 4. Add or update `docs/releases/vX.Y.Z.md`.
+5. Confirm `ROADMAP.md` and `ROADMAP.zh-CN.md` still point readers to the release notes index for the latest patch release instead of hard-coding a stale patch number.
 
 ## Release Automation Readiness
 

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -27,6 +27,7 @@ make check
 2. 更新 `src/ainews/__init__.py` 中的版本号。
 3. 在 `CHANGELOG.md` 中增加本次版本条目。
 4. 新增或更新 `docs/releases/vX.Y.Z.md`。
+5. 确认 `ROADMAP.md` 和 `ROADMAP.zh-CN.md` 仍然把最新 patch release 指向 release notes 索引，而不是硬编码一个容易过期的 patch 号。
 
 ## 发布自动化检查
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -220,6 +220,26 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         self.assertLessEqual(expected_readme_links, _markdown_link_targets("README.md"))
         self.assertLessEqual(expected_readme_zh_links, _markdown_link_targets("README.zh-CN.md"))
 
+    def test_roadmap_status_defers_latest_patch_to_release_index(self) -> None:
+        roadmap = _read_text("ROADMAP.md")
+        roadmap_zh = _read_text("ROADMAP.zh-CN.md")
+        release_checklist = _read_text("docs/release-checklist.md")
+        release_checklist_zh = _read_text("docs/release-checklist.zh-CN.md")
+
+        self.assertIn("[release notes index](docs/releases/README.md)", roadmap)
+        self.assertIn("[release notes 索引](docs/releases/README.zh-CN.md)", roadmap_zh)
+        self.assertIn("In Progress: v1.2.x Maintenance", roadmap)
+        self.assertIn("进行中：v1.2.x 维护事项", roadmap_zh)
+        self.assertNotRegex(roadmap, r"Latest release:\s*`v\d+\.\d+\.\d+`")
+        self.assertNotRegex(roadmap, r"Current open milestone:\s*`v\d+\.\d+\.\d+`")
+        self.assertNotRegex(roadmap_zh, r"最新 release：\s*`v\d+\.\d+\.\d+`")
+        self.assertNotRegex(roadmap_zh, r"当前开启的 milestone：\s*`v\d+\.\d+\.\d+`")
+
+        self.assertIn("ROADMAP.md", release_checklist)
+        self.assertIn("hard-coding a stale patch number", release_checklist)
+        self.assertIn("ROADMAP.zh-CN.md", release_checklist_zh)
+        self.assertIn("硬编码一个容易过期的 patch 号", release_checklist_zh)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- stop hard-coding the latest patch release and current patch milestone in the English and Chinese roadmaps
- point roadmap readers to the release notes index for the latest patch release
- add release-checklist guidance and a regression test so roadmap status does not drift from release notes again

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #128