### PR TITLE
docs: add release recovery quick reference

### DIFF
--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -12,6 +12,19 @@ Use these notes when a release or PR closeout action may have changed GitHub sta
 - Do not move or recreate a public tag unless the tag points to the wrong commit and the maintainer explicitly accepts the compatibility risk.
 - Keep PyPI recovery out of this flow. If PyPI is disabled or deferred, leave it in its own milestone.
 
+## Quick Reference
+
+Start here when a release closeout step times out or leaves local state unclear.
+
+| Symptom | First safe check | Detailed flow |
+| --- | --- | --- |
+| PR merge command timed out | `gh pr view 123 --json state,merged,mergeCommit` | [PR Merge Succeeded, Local Fast-Forward Failed](#pr-merge-succeeded-local-fast-forward-failed) |
+| Local `main` cannot fast-forward after a merged PR | `git status --short --branch` and `git ls-remote origin refs/heads/main` | [PR Merge Succeeded, Local Fast-Forward Failed](#pr-merge-succeeded-local-fast-forward-failed) |
+| Tag exists on GitHub but local fetch failed | `git ls-remote --tags origin "refs/tags/${TAG}"` | [Tag Created, Local Fetch Failed](#tag-created-local-fetch-failed) |
+| Tag push timed out before Release creation | `git ls-remote --tags origin "refs/tags/${TAG}"` | [Tag Push Timed Out Before Release Creation](#tag-push-timed-out-before-release-creation) |
+| Release workflow finished but assets need confirmation | `gh release view "${TAG}" --json assets,isDraft,isPrerelease,url` | [Release Workflow Succeeded, Asset Smoke Needs Verification](#release-workflow-succeeded-asset-smoke-needs-verification) |
+| Workflow dispatch, issue update, or branch deletion timed out | Re-run the matching read-only command from the timeout table | [Network Timeout After A Remote Action](#network-timeout-after-a-remote-action) |
+
 ## PR Merge Succeeded, Local Fast-Forward Failed
 
 First confirm whether the PR actually merged:

--- a/docs/release-recovery.zh-CN.md
+++ b/docs/release-recovery.zh-CN.md
@@ -12,6 +12,19 @@
 - 除非公开 tag 指向了错误 commit，并且维护者明确接受兼容性风险，否则不要移动或重建公开 tag。
 - PyPI 恢复不要混进这条流程。如果 PyPI 当前禁用或延期，继续把它留在独立 milestone。
 
+## 快速索引
+
+当 release 收尾步骤超时，或本地状态不确定时，先从这里判断该看哪条详细流程。
+
+| 症状 | 第一个安全检查 | 详细流程 |
+| --- | --- | --- |
+| PR 合并命令超时 | `gh pr view 123 --json state,merged,mergeCommit` | [PR 已合并，但本地快进失败](#pr-已合并但本地快进失败) |
+| PR 已合并，但本地 `main` 不能 fast-forward | `git status --short --branch` 和 `git ls-remote origin refs/heads/main` | [PR 已合并，但本地快进失败](#pr-已合并但本地快进失败) |
+| GitHub 上已有 tag，但本地 fetch 失败 | `git ls-remote --tags origin "refs/tags/${TAG}"` | [Tag 已创建，但本地 fetch 失败](#tag-已创建但本地-fetch-失败) |
+| 创建 Release 前推送 tag 超时 | `git ls-remote --tags origin "refs/tags/${TAG}"` | [推送 tag 超时，但尚未创建 Release](#推送-tag-超时但尚未创建-release) |
+| Release workflow 已完成，但还要确认资产 | `gh release view "${TAG}" --json assets,isDraft,isPrerelease,url` | [Release workflow 成功，但还需要验证 asset smoke](#release-workflow-成功但还需要验证-asset-smoke) |
+| 触发 workflow、更新 issue 或删除分支超时 | 重跑超时表中对应的只读命令 | [远端操作后网络超时](#远端操作后网络超时) |
+
 ## PR 已合并，但本地快进失败
 
 先确认 PR 是否真的已经合并：

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -201,6 +201,28 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         self.assertIn("Trigger artifact smoke", release_workflow)
         self.assertIn("Publish GitHub Release", release_workflow)
 
+    def test_release_recovery_docs_include_quick_reference(self) -> None:
+        release_recovery = _read_text("docs/release-recovery.md")
+        release_recovery_zh = _read_text("docs/release-recovery.zh-CN.md")
+
+        for expected in (
+            "## Quick Reference",
+            "PR merge command timed out",
+            "Tag push timed out before Release creation",
+            "Release workflow finished but assets need confirmation",
+            "Network Timeout After A Remote Action",
+        ):
+            self.assertIn(expected, release_recovery)
+
+        for expected in (
+            "## 快速索引",
+            "PR 合并命令超时",
+            "创建 Release 前推送 tag 超时",
+            "Release workflow 已完成，但还要确认资产",
+            "远端操作后网络超时",
+        ):
+            self.assertIn(expected, release_recovery_zh)
+
     def test_readmes_expose_release_maintenance_entry_points(self) -> None:
         expected_readme_links = {
             "docs/releases/README.md",


### PR DESCRIPTION
## Summary
- add a top-level release recovery quick reference table
- link common interrupted release closeout symptoms to the detailed recovery flows
- keep English and Simplified Chinese recovery docs aligned and add metadata coverage

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #132