### PR TITLE
test: guard release notes fallback behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,11 @@ jobs:
           if [ -f "${NOTES_FILE}" ]; then
             cp "${NOTES_FILE}" /tmp/release-notes.md
           else
-            printf 'Release %s\n' "${TAG}" > /tmp/release-notes.md
+            {
+              printf 'Release %s\n\n' "${TAG}"
+              printf 'Release notes file missing: `%s`.\n' "${NOTES_FILE}"
+              printf 'Maintainers should add this file before publishing final release notes.\n'
+            } > /tmp/release-notes.md
           fi
 
       - name: Publish GitHub release

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -201,6 +201,21 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         self.assertIn("Trigger artifact smoke", release_workflow)
         self.assertIn("Publish GitHub Release", release_workflow)
 
+    def test_release_workflow_documents_release_notes_fallback(self) -> None:
+        release_workflow = _read_text(".github/workflows/release.yml")
+
+        self.assertIn('TAG="${GITHUB_REF_NAME}"', release_workflow)
+        self.assertIn('NOTES_FILE="docs/releases/${TAG}.md"', release_workflow)
+        self.assertIn('if [ -f "${NOTES_FILE}" ]; then', release_workflow)
+        self.assertIn('cp "${NOTES_FILE}" /tmp/release-notes.md', release_workflow)
+        self.assertIn("Release notes file missing:", release_workflow)
+        self.assertIn("printf 'Release notes file missing: `%s`.", release_workflow)
+        self.assertIn('"${NOTES_FILE}"', release_workflow)
+        self.assertIn(
+            "Maintainers should add this file before publishing final release notes.",
+            release_workflow,
+        )
+
     def test_release_recovery_docs_include_quick_reference(self) -> None:
         release_recovery = _read_text("docs/release-recovery.md")
         release_recovery_zh = _read_text("docs/release-recovery.zh-CN.md")


### PR DESCRIPTION
## Summary
- make the release workflow fallback notes point maintainers to the missing release notes file
- add a release metadata test that guards the fallback contract

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #134