### PR TITLE
docs: improve milestone and roadmap closeout checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -74,6 +74,16 @@ python -m ainews --help
 
 Run the post-release smoke checklist before announcing the release or closing its milestone.
 
+### Release Closeout Sequence
+
+Use this order after the release page, assets, and smoke workflows are verified:
+
+1. Confirm `CHANGELOG.md`, `docs/releases/vX.Y.Z.md`, and the release notes index all describe the published tag.
+2. Confirm `ROADMAP.md` and `ROADMAP.zh-CN.md` still point readers to the release notes index for the latest patch release and to the active GitHub milestone for current work.
+3. Move deferred work, including PyPI trusted publishing, into a separate deferred milestone or the next maintenance milestone before closing the release milestone.
+4. Close the release milestone only after every remaining open item has either shipped, moved, or been explicitly deferred.
+5. Create the next `v1.2.x` milestone before opening follow-up maintenance issues, so new work does not accumulate against a closed release.
+
 ### Published Tag And Release Page
 
 - [ ] The release page is published, not a draft, and not marked as a prerelease unless that was intentional.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -74,6 +74,16 @@ python -m ainews --help
 
 对外公告 release 或关闭 milestone 前，先完成这份发版后 smoke checklist。
 
+### Release 收尾顺序
+
+确认 Release 页面、制品和 smoke workflows 都通过后，按这个顺序收尾：
+
+1. 确认 `CHANGELOG.md`、`docs/releases/vX.Y.Z.md` 和 release notes 索引都描述的是已经发布的 tag。
+2. 确认 `ROADMAP.md` 和 `ROADMAP.zh-CN.md` 仍然把最新 patch release 指向 release notes 索引，并把当前工作指向活跃的 GitHub milestone。
+3. 关闭 release milestone 前，先把延期事项，包括 PyPI trusted publishing，移到单独的 deferred milestone 或下一个维护 milestone。
+4. 只有当所有剩余 open item 都已经发布、移动或明确延期后，才关闭 release milestone。
+5. 开始后续维护 issue 前，先创建下一个 `v1.2.x` milestone，避免新工作继续堆到已经关闭的 release 上。
+
 ### 已发布 tag 和 Release 页面
 
 - [ ] Release 页面已经发布，不是 draft；除非本次有意发 prerelease，否则不能标成 prerelease。

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -277,6 +277,28 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         self.assertIn("ROADMAP.zh-CN.md", release_checklist_zh)
         self.assertIn("硬编码一个容易过期的 patch 号", release_checklist_zh)
 
+    def test_release_checklist_documents_milestone_closeout_sequence(self) -> None:
+        release_checklist = _read_text("docs/release-checklist.md")
+        release_checklist_zh = _read_text("docs/release-checklist.zh-CN.md")
+
+        for expected in (
+            "### Release Closeout Sequence",
+            "release notes index",
+            "active GitHub milestone",
+            "Move deferred work, including PyPI trusted publishing",
+            "Create the next `v1.2.x` milestone",
+        ):
+            self.assertIn(expected, release_checklist)
+
+        for expected in (
+            "### Release 收尾顺序",
+            "release notes 索引",
+            "活跃的 GitHub milestone",
+            "包括 PyPI trusted publishing",
+            "创建下一个 `v1.2.x` milestone",
+        ):
+            self.assertIn(expected, release_checklist_zh)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a release closeout sequence for roadmap, milestone, and release notes verification
- clarify that deferred work, including PyPI trusted publishing, must move before closing a release milestone
- keep the Simplified Chinese checklist aligned and add metadata coverage for the closeout contract

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #133