### PR TITLE
docs: add maintainer status snapshot checklist

### DIFF
--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -25,6 +25,29 @@ Start here when a release closeout step times out or leaves local state unclear.
 | Release workflow finished but assets need confirmation | `gh release view "${TAG}" --json assets,isDraft,isPrerelease,url` | [Release Workflow Succeeded, Asset Smoke Needs Verification](#release-workflow-succeeded-asset-smoke-needs-verification) |
 | Workflow dispatch, issue update, or branch deletion timed out | Re-run the matching read-only command from the timeout table | [Network Timeout After A Remote Action](#network-timeout-after-a-remote-action) |
 
+## Maintainer Status Snapshot
+
+Use this read-only snapshot when you need to report current repository progress after a release, PR merge, or interrupted network command:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main main
+gh release view --json tagName,targetCommitish,isDraft,isPrerelease,publishedAt
+gh api repos/X-PG13/ainews-open/git/ref/tags/vX.Y.Z --jq '{ref,sha:.object.sha,type:.object.type}'
+gh run list --limit 10 --json databaseId,name,status,conclusion,headBranch,headSha,event,createdAt,updatedAt
+gh api repos/X-PG13/ainews-open/milestones --jq '.[] | {number,title,state,open_issues,closed_issues}'
+gh issue view 86 --json state,milestone,title
+```
+
+Read the snapshot in this order:
+
+1. Local `main`, `origin/main`, and `HEAD` should point to the same commit before starting new work.
+2. The latest GitHub Release should be published, not a draft, and not a prerelease unless that was intentional.
+3. The release tag should point to the same commit as the release prep merge commit.
+4. Release, artifact smoke, CI, Smoke, and CodeQL runs should be completed successfully for the release tag or commit.
+5. The completed release milestone should have `0` open issues before it is closed.
+6. Issue `#86` should remain in the `Deferred: PyPI` milestone unless the maintainer explicitly decides to work on PyPI.
+
 ## PR Merge Succeeded, Local Fast-Forward Failed
 
 First confirm whether the PR actually merged:

--- a/docs/release-recovery.zh-CN.md
+++ b/docs/release-recovery.zh-CN.md
@@ -25,6 +25,29 @@
 | Release workflow 已完成，但还要确认资产 | `gh release view "${TAG}" --json assets,isDraft,isPrerelease,url` | [Release workflow 成功，但还需要验证 asset smoke](#release-workflow-成功但还需要验证-asset-smoke) |
 | 触发 workflow、更新 issue 或删除分支超时 | 重跑超时表中对应的只读命令 | [远端操作后网络超时](#远端操作后网络超时) |
 
+## 维护者状态快照
+
+当你需要在 release、PR 合并或网络命令中断后汇报仓库当前进度时，先跑这组只读检查：
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main main
+gh release view --json tagName,targetCommitish,isDraft,isPrerelease,publishedAt
+gh api repos/X-PG13/ainews-open/git/ref/tags/vX.Y.Z --jq '{ref,sha:.object.sha,type:.object.type}'
+gh run list --limit 10 --json databaseId,name,status,conclusion,headBranch,headSha,event,createdAt,updatedAt
+gh api repos/X-PG13/ainews-open/milestones --jq '.[] | {number,title,state,open_issues,closed_issues}'
+gh issue view 86 --json state,milestone,title
+```
+
+按这个顺序阅读快照：
+
+1. 开始新工作前，本地 `main`、`origin/main` 和 `HEAD` 应该指向同一个 commit。
+2. GitHub 最新 Release 应该已经发布；除非本次有意发 prerelease，否则不能是 draft 或 prerelease。
+3. release tag 应该指向 release prep merge commit。
+4. Release、artifact smoke、CI、Smoke 和 CodeQL 应该在 release tag 或 release commit 上成功完成。
+5. 关闭已完成的 release milestone 前，确认它的 open issue 数为 `0`。
+6. 除非维护者明确决定开始处理 PyPI，否则 issue `#86` 应该继续留在 `Deferred: PyPI` milestone。
+
 ## PR 已合并，但本地快进失败
 
 先确认 PR 是否真的已经合并：

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -280,6 +280,30 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         ):
             self.assertIn(expected, release_recovery_zh)
 
+    def test_release_recovery_docs_include_status_snapshot(self) -> None:
+        release_recovery = _read_text("docs/release-recovery.md")
+        release_recovery_zh = _read_text("docs/release-recovery.zh-CN.md")
+
+        for expected in (
+            "## Maintainer Status Snapshot",
+            "git status --short --branch",
+            "gh release view --json tagName,targetCommitish,isDraft,isPrerelease,publishedAt",
+            "gh run list --limit 10",
+            "gh issue view 86 --json state,milestone,title",
+            "Deferred: PyPI",
+        ):
+            self.assertIn(expected, release_recovery)
+
+        for expected in (
+            "## 维护者状态快照",
+            "git status --short --branch",
+            "gh release view --json tagName,targetCommitish,isDraft,isPrerelease,publishedAt",
+            "gh run list --limit 10",
+            "gh issue view 86 --json state,milestone,title",
+            "Deferred: PyPI",
+        ):
+            self.assertIn(expected, release_recovery_zh)
+
     def test_readmes_expose_release_maintenance_entry_points(self) -> None:
         expected_readme_links = {
             "docs/releases/README.md",


### PR DESCRIPTION
## Summary
- add a read-only maintainer status snapshot to the release recovery docs
- include checks for local main alignment, latest release, tag target, workflow runs, milestones, and #86 Deferred: PyPI status
- keep the English and Simplified Chinese docs aligned and add release metadata coverage

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #139