### PR TITLE
docs: clarify release milestone rollover ownership

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -84,6 +84,15 @@ Use this order after the release page, assets, and smoke workflows are verified:
 4. Close the release milestone only after every remaining open item has either shipped, moved, or been explicitly deferred.
 5. Create the next `v1.2.x` milestone before opening follow-up maintenance issues, so new work does not accumulate against a closed release.
 
+### Milestone Rollover Ownership
+
+The maintainer who merges the release PR or publishes the tag owns milestone rollover unless another maintainer explicitly takes it over.
+
+- Before closing the release milestone, verify it has `0` open issues and that every deferred item has moved out of the release milestone.
+- Create the next `v1.2.x` milestone before opening or moving follow-up maintenance issues.
+- Keep issue `#86` in `Deferred: PyPI` unless the maintainer explicitly decides to start PyPI publishing work.
+- If rollover is handed off, leave a note in the release PR or milestone closeout issue naming the next owner and remaining checks.
+
 ### Published Tag And Release Page
 
 - [ ] The release page is published, not a draft, and not marked as a prerelease unless that was intentional.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -84,6 +84,15 @@ python -m ainews --help
 4. 只有当所有剩余 open item 都已经发布、移动或明确延期后，才关闭 release milestone。
 5. 开始后续维护 issue 前，先创建下一个 `v1.2.x` milestone，避免新工作继续堆到已经关闭的 release 上。
 
+### Milestone rollover 责任
+
+除非另一位维护者明确接手，否则合并 release PR 或发布 tag 的维护者负责完成 milestone rollover。
+
+- 关闭 release milestone 前，确认它的 open issue 数为 `0`，并且所有延期事项都已经移出本次 release milestone。
+- 开始创建或移动后续维护 issue 前，先创建下一个 `v1.2.x` milestone。
+- 除非维护者明确决定开始处理 PyPI 发布，否则 issue `#86` 继续留在 `Deferred: PyPI`。
+- 如果 rollover 交给其他维护者，在 release PR 或 milestone closeout issue 里留下说明，写清下一位负责人和剩余检查。
+
 ### 已发布 tag 和 Release 页面
 
 - [ ] Release 页面已经发布，不是 draft；除非本次有意发 prerelease，否则不能标成 prerelease。

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -349,19 +349,25 @@ class ReleaseMetadataTestCase(unittest.TestCase):
 
         for expected in (
             "### Release Closeout Sequence",
+            "### Milestone Rollover Ownership",
             "release notes index",
             "active GitHub milestone",
             "Move deferred work, including PyPI trusted publishing",
             "Create the next `v1.2.x` milestone",
+            "The maintainer who merges the release PR or publishes the tag owns milestone rollover",
+            "Keep issue `#86` in `Deferred: PyPI`",
         ):
             self.assertIn(expected, release_checklist)
 
         for expected in (
             "### Release 收尾顺序",
+            "### Milestone rollover 责任",
             "release notes 索引",
             "活跃的 GitHub milestone",
             "包括 PyPI trusted publishing",
             "创建下一个 `v1.2.x` milestone",
+            "合并 release PR 或发布 tag 的维护者负责完成 milestone rollover",
+            "issue `#86` 继续留在 `Deferred: PyPI`",
         ):
             self.assertIn(expected, release_checklist_zh)
 


### PR DESCRIPTION
## Summary
- document that the maintainer who merges the release PR or publishes the tag owns milestone rollover
- require the next v1.2.x milestone before follow-up maintenance work accumulates
- keep #86 in Deferred: PyPI unless PyPI publishing is explicitly selected

## Validation
- ./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v
- git diff --check
- make check PYTHON=./.venv-dev/bin/python

Closes #141