### PR TITLE
ui: improve admin console information architecture

### DIFF
--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -22,6 +22,11 @@
           <p class="hero-copy">
             采集、翻译、摘要、日报生成都在一个页面里完成。前端直接调用当前服务，不需要额外构建。
           </p>
+          <div class="hero-pills" aria-label="控制台能力">
+            <span>Zero-build admin</span>
+            <span>Runtime-aware</span>
+            <span>Publish-ready</span>
+          </div>
         </div>
         <div class="token-box">
           <label for="adminToken">Admin Token</label>
@@ -30,6 +35,38 @@
             <button id="saveTokenButton" class="button ghost">保存</button>
           </div>
           <p class="muted">所有管理操作都会自动带上 `X-Admin-Token`。</p>
+        </div>
+      </section>
+
+      <section class="workflow-map panel" aria-labelledby="workflowMapTitle">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Operator Workflow</p>
+            <h2 id="workflowMapTitle">从线索到发布的闭环</h2>
+          </div>
+          <p class="workflow-note">首屏先给维护者一张地图：哪里进稿、哪里清洗、哪里编辑、哪里发布、哪里恢复。</p>
+        </div>
+        <div class="workflow-steps">
+          <article class="workflow-step">
+            <span class="step-index">01</span>
+            <h3>采集线索</h3>
+            <p>按区域、时间窗口和单源上限抓取国内外 AI 新闻，快速确认新闻池规模。</p>
+          </article>
+          <article class="workflow-step">
+            <span class="step-index">02</span>
+            <h3>抽取与恢复</h3>
+            <p>跟踪正文抽取、来源冷却、重试窗口和来源级告警，避免坏来源拖慢整条流水线。</p>
+          </article>
+          <article class="workflow-step">
+            <span class="step-index">03</span>
+            <h3>选稿与编辑</h3>
+            <p>查看入选、压制、重复簇和 ranked-out 原因，冻结编辑稿后再发布。</p>
+          </article>
+          <article class="workflow-step">
+            <span class="step-index">04</span>
+            <h3>多渠道发布</h3>
+            <p>面向 Telegram、飞书、公众号草稿和静态站点发布，并在发布历史里跟踪失败。</p>
+          </article>
         </div>
       </section>
 

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -108,6 +108,23 @@ button {
   color: var(--muted);
 }
 
+.hero-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.hero-pills span {
+  border: 1px solid rgba(23, 23, 23, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--accent-deep);
+  font: 700 12px/1 "JetBrains Mono", monospace;
+  letter-spacing: 0.02em;
+  padding: 8px 11px;
+}
+
 .token-box,
 .form-grid label {
   display: grid;
@@ -185,6 +202,72 @@ textarea {
 .controls-grid,
 .content-grid {
   grid-template-columns: 1.25fr 0.95fr;
+}
+
+.workflow-map {
+  margin-bottom: 18px;
+  overflow: hidden;
+  position: relative;
+}
+
+.workflow-map::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 12% 10%, rgba(219, 61, 27, 0.11), transparent 30%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.65), transparent 52%);
+  pointer-events: none;
+}
+
+.workflow-map > * {
+  position: relative;
+}
+
+.workflow-note {
+  max-width: 420px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+  text-align: right;
+}
+
+.workflow-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.workflow-step {
+  min-height: 180px;
+  border: 1px solid rgba(23, 23, 23, 0.1);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.54);
+  padding: 16px;
+}
+
+.workflow-step h3 {
+  margin-top: 18px;
+  font-size: 22px;
+  letter-spacing: -0.03em;
+}
+
+.workflow-step p {
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--ink);
+  color: #fff8ee;
+  font: 800 13px/1 "Space Grotesk", sans-serif;
 }
 
 .operations-panel {
@@ -492,11 +575,17 @@ textarea {
 
 @media (max-width: 1100px) {
   .hero,
+  .workflow-steps,
   .operations-grid,
   .controls-grid,
   .content-grid,
   .stats-grid {
     grid-template-columns: 1fr;
+  }
+
+  .workflow-note {
+    max-width: none;
+    text-align: left;
   }
 }
 

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_text(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+class WebConsoleTestCase(unittest.TestCase):
+    def test_console_exposes_operator_workflow_map(self) -> None:
+        index = _read_text("src/ainews/web/index.html")
+        styles = _read_text("src/ainews/web/styles.css")
+
+        for expected in (
+            'class="workflow-map panel"',
+            "Operator Workflow",
+            "从线索到发布的闭环",
+            "采集线索",
+            "抽取与恢复",
+            "选稿与编辑",
+            "多渠道发布",
+            "Zero-build admin",
+            "Runtime-aware",
+            "Publish-ready",
+        ):
+            self.assertIn(expected, index)
+
+        for expected in (
+            ".workflow-map",
+            ".workflow-steps",
+            ".workflow-step",
+            ".hero-pills",
+        ):
+            self.assertIn(expected, styles)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a first-screen operator workflow map to the zero-build admin console
- add hero capability pills for zero-build, runtime-aware, publish-ready positioning
- add regression coverage for the workflow overview markup and styles

## Validation
- `./.venv-dev/bin/python -m unittest tests.test_web_console -v`
- `./.venv-dev/bin/python -m unittest tests.test_docs_links tests.test_release_metadata -v`
- `node --check src/ainews/web/app.js`
- `git diff --check`
- `make check PYTHON=./.venv-dev/bin/python`
- Browser desktop check at `http://127.0.0.1:8000/`

Closes #145
