### PR TITLE
ui: add publish safety note in admin controls

### DIFF
--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -176,6 +176,9 @@
             <label class="check-label wide"><input id="wechatSubmitCheckbox" type="checkbox" /> 公众号草稿创建后直接提交发布</label>
           </div>
           <p class="muted">如果这里不勾选，系统会回退到服务端配置的 `AINEWS_PUBLISH_TARGETS` 默认发布目标。</p>
+          <p id="publishSafetyHint" class="publish-safety-note">
+            先通过“选稿预览”和“发布预览”确认内容。默认是“发送”型发布流程，只有静态站点输出属于本地预览产物，真实外发需手动勾选 Telegram、飞书或公众号并确认发布凭据已正确配置。
+          </p>
           <div class="action-row">
             <button id="ingestButton" class="button primary">抓取新闻</button>
             <button id="extractButton" class="button ghost">抓正文</button>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -258,6 +258,16 @@ textarea {
   text-align: right;
 }
 
+.publish-safety-note {
+  border-left: 3px solid rgba(23, 23, 23, 0.26);
+  border-radius: 0 14px 14px 0;
+  padding: 10px 12px;
+  margin: 8px 0 14px;
+  background: rgba(255, 255, 255, 0.48);
+  color: var(--muted);
+  line-height: 1.6;
+}
+
 .workflow-steps {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- Add an explicit publish-safety note to the admin console publish controls.
- Clarify that static_site outputs are local previews, while Telegram/Feishu/WeChat are outbound publish targets.
- Improve operator awareness before pressing publish in the console.

Refs #155.
Closes #155