### PR TITLE
docs: add proxy fallback guidance in maintainer bootstrap

### DIFF
--- a/docs/maintainer-bootstrap.md
+++ b/docs/maintainer-bootstrap.md
@@ -92,6 +92,19 @@ Use this checklist when a dependency or GitHub Actions update is desired:
 
 This keeps dependency upgrades reviewable while avoiding bot-authored commits on the default branch.
 
+## Network Timeout and Recovery Commanding
+
+When maintainer commands timeout during setup, release closeout, or dependency review, first run read-only checks before rerunning writes.
+
+For intermittent HTTPS blocking, you can temporarily retry GitHub commands with your local proxy:
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 \
+  gh pr view --state all --limit 10
+```
+
+Use this only as a temporary workaround. Once network is stable, remove the proxy prefix and continue with the normal recovery flow in [Release Recovery Notes](./release-recovery.md).
+
 ## Maintainer Audit Checklist
 
 - `Settings` -> `Pages` uses `GitHub Actions` as the source.

--- a/docs/maintainer-bootstrap.zh-CN.md
+++ b/docs/maintainer-bootstrap.zh-CN.md
@@ -90,6 +90,19 @@ Dependabot PR 只作为升级通知，不视为可以直接合并的维护者提
 
 这样可以保留依赖升级的可审查性，同时避免默认分支出现 bot-authored commits。
 
+## 网络超时与恢复操作
+
+在初始化、release 收口、依赖审核时如果命令超时，先跑只读校验再决定是否重试写操作。
+
+若本地网络出口不稳定，可在重试前临时给 GitHub 命令加上本地代理：
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 \
+  gh pr view --state all --limit 10
+```
+
+该代理前缀仅作过渡兜底。网络恢复后立即去掉代理，按 [Release 恢复说明](./release-recovery.zh-CN.md)走正常流程。
+
 ## 维护者快速自检
 
 - `Settings` -> `Pages` 的 `Source` 已经是 `GitHub Actions`


### PR DESCRIPTION
## Why
Maintainers asked for a practical way to handle intermittent GitHub network timeout paths during review/closeout flows.

## What changed
- Added a short proxy fallback snippet in  and Chinese version.
- Documented when to use proxy fallback and when to return to normal recovery flow.

## Cross-links
- See matching recovery notes in  for read-only-first recovery sequence.