### PR TITLE
docs: switch network proxy fallback to exported env vars

### DIFF
--- a/docs/contributor-playbook.md
+++ b/docs/contributor-playbook.md
@@ -45,8 +45,14 @@ When GitHub commands time out during branch review or merge closeout, always che
 If you need a temporary workaround for unstable outbound access, use your local proxy for the retried command:
 
 ```bash
-HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 \
-  gh pr view --state all --limit 10
+export HTTPS_PROXY=http://127.0.0.1:7897
+export HTTP_PROXY=http://127.0.0.1:7897
+export https_proxy=$HTTPS_PROXY
+export http_proxy=$HTTP_PROXY
+
+gh pr view --state all --limit 10
+
+unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy
 ```
 
 Remove the proxy prefix once the network stabilizes and continue with the normal recovery flow in [Release Recovery Notes](./release-recovery.md).

--- a/docs/maintainer-bootstrap.md
+++ b/docs/maintainer-bootstrap.md
@@ -99,8 +99,14 @@ When maintainer commands timeout during setup, release closeout, or dependency r
 For intermittent HTTPS blocking, you can temporarily retry GitHub commands with your local proxy:
 
 ```bash
-HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 \
-  gh pr view --state all --limit 10
+export HTTPS_PROXY=http://127.0.0.1:7897
+export HTTP_PROXY=http://127.0.0.1:7897
+export https_proxy=$HTTPS_PROXY
+export http_proxy=$HTTP_PROXY
+
+gh pr view --state all --limit 10
+
+unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy
 ```
 
 Use this only as a temporary workaround. Once network is stable, remove the proxy prefix and continue with the normal recovery flow in [Release Recovery Notes](./release-recovery.md).

--- a/docs/maintainer-bootstrap.zh-CN.md
+++ b/docs/maintainer-bootstrap.zh-CN.md
@@ -97,8 +97,14 @@ Dependabot PR 只作为升级通知，不视为可以直接合并的维护者提
 若本地网络出口不稳定，可在重试前临时给 GitHub 命令加上本地代理：
 
 ```bash
-HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 \
-  gh pr view --state all --limit 10
+export HTTPS_PROXY=http://127.0.0.1:7897
+export HTTP_PROXY=http://127.0.0.1:7897
+export https_proxy=$HTTPS_PROXY
+export http_proxy=$HTTP_PROXY
+
+gh pr view --state all --limit 10
+
+unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy
 ```
 
 该代理前缀仅作过渡兜底。网络恢复后立即去掉代理，按 [Release 恢复说明](./release-recovery.zh-CN.md)走正常流程。

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -18,7 +18,16 @@ Use these notes when a release or PR closeout action may have changed GitHub sta
 - Example:
 
 ```bash
-https_proxy=http://127.0.0.1:7897 http_proxy=http://127.0.0.1:7897 gh pr view --state all --limit 10
+export HTTPS_PROXY=http://127.0.0.1:7897
+export HTTP_PROXY=http://127.0.0.1:7897
+
+# Compatibility aliases for tools that only honor lowercase env vars
+export https_proxy=$HTTPS_PROXY
+export http_proxy=$HTTP_PROXY
+
+gh pr view --state all --limit 10
+
+unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy
 ```
 
 Once the command succeeds, continue with the normal read-only verification flow and remove the proxy once the network is stable again.

--- a/docs/release-recovery.zh-CN.md
+++ b/docs/release-recovery.zh-CN.md
@@ -18,7 +18,16 @@
 - 示例：
 
 ```bash
-https_proxy=http://127.0.0.1:7897 http_proxy=http://127.0.0.1:7897 gh pr view --state all --limit 10
+export HTTPS_PROXY=http://127.0.0.1:7897
+export HTTP_PROXY=http://127.0.0.1:7897
+
+# 某些工具仍旧只识别小写环境变量，保留兼容别名
+export https_proxy=$HTTPS_PROXY
+export http_proxy=$HTTP_PROXY
+
+gh pr view --state all --limit 10
+
+unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy
 ```
 
 命令在代理下成功后，继续按原有只读核对流程走完整链路，并在网络恢复后移除代理参数。


### PR DESCRIPTION
## Why

Network instability is usually transient. During recovery, keeping proxy environment variables exported is easier to reuse for multiple retry commands than one-off inline prefixes.

## What this PR changes
- Update release recovery, maintainer bootstrap, and contributor docs to use explicit `export` for proxy variables.
- Add compatibility aliases (`https_proxy`, `http_proxy`) for tooling that still reads lowercase variables.
- Add explicit cleanup (`unset`) after temporary retry commands.
