### PR TITLE
docs: add human-only contributors troubleshooting guidance

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -251,6 +251,19 @@ Checks:
 - confirm commit email matches a verified GitHub email
 - wait for GitHub contributor stats to finish recomputing after force-push or history rewrite
 
+If bot accounts (for example, Dependabot or CI users) are showing unexpectedly:
+
+- GitHub contributor badges and charts are recomputed asynchronously and can include automated accounts.
+- For a human-only local view, run:
+
+```bash
+git shortlog -sne --all --no-merges |
+  grep -Ev "(bot|dependabot\[bot\]|github-actions\[bot\])" | sed -n '1,30p'
+```
+
+- If a bot commit should be excluded from release notes or maintainer attribution,
+  keep that context in the human authorship notes section of the release PR.
+
 ## How to verify database migration state
 
 Run:

--- a/docs/troubleshooting.zh-CN.md
+++ b/docs/troubleshooting.zh-CN.md
@@ -253,6 +253,18 @@ python -m ainews publish --digest-id 1 --target static_site --force-republish
 - commit email 是否与 GitHub 已验证邮箱一致
 - force push 或历史重写后，GitHub 统计是否还在重算
 
+如果出现了 Bot 账号（如 Dependabot、CI）导致统计异常：
+
+- GitHub 的 contributor 统计是异步计算的，并且可能会把自动化账号列出来。
+- 只看人工贡献者可用本地命令：
+
+```bash
+git shortlog -sne --all --no-merges |
+  grep -Ev "(bot|dependabot\[bot\]|github-actions\[bot\])" | sed -n '1,30p'
+```
+
+- 如果某次发布说明里不希望出现 bot 归属，建议在发布 PR 的作者说明里补充人类归属备注。
+
 ## 如何确认数据库迁移状态
 
 执行：


### PR DESCRIPTION
When GitHub contributor stats show bot names, this adds a local, repeatable check for human-only contributors in troubleshooting docs (EN + zh) and suggests keeping bot-attribution context in release PR notes.
