### PR TITLE
docs: add maintainer status snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
   </p>
 </div>
 
+## Maintainer Status Snapshot
+
+- Latest release and release notes: [Release Notes](docs/releases/README.md)
+- Current planning: [Roadmap](ROADMAP.md)
+- Current open maintenance milestone: [v1.2.61](https://github.com/X-PG13/ainews-open/milestone/15)
+- Deferred engineering work: [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)
 ![AI News Open Operations Overview](docs/assets/operations-panel-preview.svg)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,13 @@
   </p>
 </div>
 
+## 维护状态快照
+
+- 最新发布与发布说明： [发布说明索引](docs/releases/README.zh-CN.md)
+- 当前规划入口： [路线图](ROADMAP.zh-CN.md)
+- 当前开放维护里程碑： [v1.2.61](https://github.com/X-PG13/ainews-open/milestone/15)
+- 延期工程项： [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)
 ![AI News Open Operations Overview](docs/assets/operations-panel-preview.svg)
 


### PR DESCRIPTION
## Summary
- Add a short maintainer status snapshot block to README and README.zh-CN.
- Link current release notes index, roadmap, current v1.2.61 milestone, and Deferred: PyPI milestone.

## Validation
- make check PYTHON=./.venv-dev/bin/python

## Notes
- Small docs-only visibility improvement for operators and contributors.
