### PR TITLE
docs: make maintainer status snapshot resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 
 - Latest release and release notes: [Release Notes](docs/releases/README.md)
 - Current planning: [Roadmap](ROADMAP.md)
-- Current open maintenance milestone: [v1.2.61](https://github.com/X-PG13/ainews-open/milestone/15)
+- Current open maintenance milestone list: [open milestones](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
+- Latest patch target from docs: [release notes index](docs/releases/README.md)
 - Deferred engineering work: [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
 
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,8 @@
 
 - 最新发布与发布说明： [发布说明索引](docs/releases/README.zh-CN.md)
 - 当前规划入口： [路线图](ROADMAP.zh-CN.md)
-- 当前开放维护里程碑： [v1.2.61](https://github.com/X-PG13/ainews-open/milestone/15)
+- 当前开放里程碑列表： [进行中的里程碑](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
+- 最新 patch 以发布说明索引为准：[发布说明索引](docs/releases/README.zh-CN.md)
 - 延期工程项： [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
 
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)


### PR DESCRIPTION
## Summary
- Keep README status block source-of-truth aligned with release notes index.
- Replace hard-coded milestone link with open-milestones view to avoid stale patch references.
- Add explicit note that latest patch is tracked in release notes index.

## Validation
- make check PYTHON=./.venw-dev/bin/python
