### PR TITLE
docs: surface maintainer status in support entrypoints

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -18,6 +18,13 @@ See `docs/support-lifecycle.md` for the full minor-release support window and de
 - Feature requests: use the feature request template once the request is concrete enough to track as implementation work.
 - Usage questions, early ideas, showcase posts, and design discussion: use GitHub Discussions. See `docs/community-triage.md` for the issue-vs-discussion split.
 
+## Maintainer Status Snapshot
+
+- Current release and release notes: [Release Notes](docs/releases/README.md)
+- Current roadmap priorities: [Roadmap](ROADMAP.md)
+- Current open maintenance milestones: [open milestones](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
+- Deferred release engineering work: [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+
 ## Discussions Categories
 
 - `Q&A`: installation, configuration, publishing, and upgrade help.

--- a/docs/support-lifecycle.md
+++ b/docs/support-lifecycle.md
@@ -87,3 +87,4 @@ If a deprecated behavior cannot remain in place because of security, safety, or 
 - [Roadmap](../ROADMAP.md)
 - [Release Notes](./releases/README.md)
 - [Release Checklist](./release-checklist.md)
+- [SUPPORT.md](../SUPPORT.md)


### PR DESCRIPTION
## Summary
- Add a maintainer status snapshot section in SUPPORT.md.
- Add SUPPORT.md as a related doc link in docs/support-lifecycle.md.

## Validation
- make check PYTHON=./.venv-dev/bin/python

Closes #164.
