### PR TITLE
feat: add operation status strip to web console

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -65,6 +65,12 @@ const refs = {
   operationsPublicationFailures: document.getElementById("operationsPublicationFailures"),
   publishTargetInputs: Array.from(document.querySelectorAll(".publish-target")),
   wechatSubmitCheckbox: document.getElementById("wechatSubmitCheckbox"),
+  operationsStatusStrip: document.getElementById("operationsStatusStrip"),
+  heroHealthBadge: document.getElementById("heroHealthBadge"),
+  heroSchemaVersion: document.getElementById("heroSchemaVersion"),
+  heroBuildVersion: document.getElementById("heroBuildVersion"),
+  heroGeneratedAt: document.getElementById("heroGeneratedAt"),
+  heroDataAge: document.getElementById("heroDataAge"),
 };
 
 refs.adminToken.value = state.token;
@@ -154,6 +160,83 @@ function operationStatusClass(status) {
   if (status === "degraded" || status === "pending" || status === "partial_error") return "pending";
   if (status === "error" || status === "blocked") return "warn";
   return "";
+}
+
+function operationStatusLabelAndClass(status) {
+  const normalized = String(status || "unknown");
+  if (normalized === "ok" || normalized === "ready") {
+    return ["正常", "good"];
+  }
+  if (normalized === "degraded" || normalized === "pending" || normalized === "partial_error") {
+    return ["降级", "pending"];
+  }
+  if (normalized === "error" || normalized === "blocked") {
+    return ["异常", "warn"];
+  }
+  return ["未采样", ""];
+}
+
+function formatDisplayTime(value) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "未记录";
+  }
+  return parsed.toLocaleString("zh-CN");
+}
+
+function formatDataAge(value) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "未知";
+  }
+  const delta = Date.now() - parsed.getTime();
+  if (delta < 0) {
+    return "刚刚";
+  }
+  const second = Math.floor(delta / 1000);
+  if (second < 60) {
+    return "小于 1 分钟";
+  }
+  const minute = Math.floor(second / 60);
+  if (minute < 60) {
+    return `${minute} 分钟前`;
+  }
+  const hour = Math.floor(minute / 60);
+  if (hour < 24) {
+    return `${hour} 小时前`;
+  }
+  const day = Math.floor(hour / 24);
+  return `${day} 天前`;
+}
+
+function updateHeroOperationStatus(payload) {
+  const health = payload.health || {};
+  const stats = payload.stats || {};
+  const metrics = payload.metrics || {};
+  const status = health.status || "unknown";
+  const [statusText, statusClass] = operationStatusLabelAndClass(status);
+  const schemaVersion = health.schema_version || stats.schema_version || "unknown";
+  const buildVersion = metrics.build_version || "unknown";
+  const generatedAt = payload.generated_at || null;
+  if (refs.heroHealthBadge) {
+    refs.heroHealthBadge.textContent = `系统状态：${statusText}`;
+    refs.heroHealthBadge.className = `chip status-chip ${statusClass}`.trim();
+  }
+  if (refs.heroSchemaVersion) {
+    refs.heroSchemaVersion.textContent = `schema：${schemaVersion}`;
+  }
+  if (refs.heroBuildVersion) {
+    refs.heroBuildVersion.textContent = `build：v${buildVersion}`;
+  }
+  if (refs.heroGeneratedAt) {
+    refs.heroGeneratedAt.textContent = `最后数据：${formatDisplayTime(generatedAt)}`;
+  }
+  if (refs.heroDataAge) {
+    refs.heroDataAge.textContent = `数据时效：${formatDataAge(generatedAt)}`;
+  }
+  if (refs.operationsStatusStrip) {
+    refs.operationsStatusStrip.classList.add("loaded");
+  }
 }
 
 function summarizePairs(payload) {
@@ -395,6 +478,7 @@ function renderOperationsPublicationFailures(failures, pending) {
 }
 
 function renderOperations(payload) {
+  updateHeroOperationStatus(payload);
   renderOperationsSummary(payload);
   renderOperationsHealth(payload);
   renderOperationsPipelineRuns(payload.pipeline_runs || []);

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -35,6 +35,13 @@
             <button id="saveTokenButton" class="button ghost">保存</button>
           </div>
           <p class="muted">所有管理操作都会自动带上 `X-Admin-Token`。</p>
+          <div id="operationsStatusStrip" class="operations-status-strip" aria-live="polite">
+            <span id="heroHealthBadge" class="chip status-chip">系统状态：加载中</span>
+            <span id="heroSchemaVersion">schema：未同步</span>
+            <span id="heroBuildVersion">build：未同步</span>
+            <span id="heroGeneratedAt">最后数据：--</span>
+            <span id="heroDataAge">数据时效：--</span>
+          </div>
           <div class="start-cues" aria-label="首次运行建议">
             <span>1 保存 Token</span>
             <span>2 抓取新闻</span>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -147,6 +147,59 @@ button {
   padding: 8px 10px;
 }
 
+.operations-status-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px;
+  border-radius: 14px;
+  border: 1px dashed rgba(23, 23, 23, 0.22);
+  background: rgba(255, 255, 255, 0.56);
+  align-items: center;
+  opacity: 0.9;
+}
+
+.operations-status-strip .status-chip {
+  justify-self: start;
+}
+
+.operations-status-strip span {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  color: var(--muted);
+  font: 600 12px/1.3 "JetBrains Mono", monospace;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.operations-status-strip span:first-child {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.operations-status-strip.loaded {
+  opacity: 1;
+}
+
+.status-chip.good {
+  background: rgba(58, 132, 77, 0.16);
+  color: #1f6b34;
+}
+
+.status-chip.pending {
+  background: rgba(184, 140, 50, 0.16);
+  color: #7b5a14;
+}
+
+.status-chip.warn {
+  background: rgba(219, 61, 27, 0.16);
+  color: var(--accent-deep);
+}
+
 .token-box,
 .form-grid label {
   display: grid;
@@ -688,6 +741,10 @@ textarea {
 
   .hero-pills span {
     max-width: 100%;
+  }
+
+  .operations-status-strip {
+    grid-template-columns: 1fr;
   }
 
   .token-row {


### PR DESCRIPTION
## Why
This improves the operator console by exposing at-a-glance runtime health in the hero area, reducing context switches during on-call checks.

## Summary
- Added an operation status strip in the admin console hero card with:
  - live system health status
  - schema version
  - build version
  - latest data timestamp
  - data age indicator
- Reused the existing /admin/operations payload without adding backend endpoints.
- Added color chips for status states (good / pending / warn).

Closes #166