### PR TITLE
feat: add console auto-refresh toggle

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -5,7 +5,11 @@ const state = {
   currentArticles: [],
   selectedDigestId: null,
   editorActor: localStorage.getItem("ainews_digest_editor_actor") || "",
+  autoRefreshEnabled: localStorage.getItem("ainews_auto_refresh") === "1",
 };
+
+let autoRefreshTimer = null;
+const AUTO_REFRESH_INTERVAL_MS = 30000;
 
 const refs = {
   adminToken: document.getElementById("adminToken"),
@@ -71,6 +75,8 @@ const refs = {
   heroBuildVersion: document.getElementById("heroBuildVersion"),
   heroGeneratedAt: document.getElementById("heroGeneratedAt"),
   heroDataAge: document.getElementById("heroDataAge"),
+  autoRefreshCheckbox: document.getElementById("autoRefreshCheckbox"),
+  autoRefreshStatus: document.getElementById("autoRefreshStatus"),
 };
 
 refs.adminToken.value = state.token;
@@ -1526,6 +1532,33 @@ async function refreshPublications() {
   await loadStats();
 }
 
+function setAutoRefreshStatus(enabled) {
+  if (!refs.autoRefreshStatus) return;
+  refs.autoRefreshStatus.textContent = enabled ? "自动刷新开启" : "自动刷新关闭";
+}
+
+function stopAutoRefresh() {
+  if (autoRefreshTimer) {
+    clearInterval(autoRefreshTimer);
+    autoRefreshTimer = null;
+  }
+}
+
+function startAutoRefresh(enabled) {
+  state.autoRefreshEnabled = Boolean(enabled);
+  localStorage.setItem("ainews_auto_refresh", state.autoRefreshEnabled ? "1" : "0");
+  if (!state.autoRefreshEnabled) {
+    stopAutoRefresh();
+    setAutoRefreshStatus(false);
+    return;
+  }
+  setAutoRefreshStatus(true);
+  stopAutoRefresh();
+  autoRefreshTimer = setInterval(() => {
+    refreshAll().catch((error) => logJob("auto refresh failed", { error: error.message }));
+  }, AUTO_REFRESH_INTERVAL_MS);
+}
+
 async function refreshAll() {
   try {
     await Promise.all([
@@ -1875,6 +1908,12 @@ refs.extractionErrorCategoryFilter.addEventListener("change", () =>
 refs.extractionDueOnlyCheckbox.addEventListener("change", () =>
   loadExtractionOps().catch((error) => logJob("load extraction ops failed", { error: error.message }))
 );
+if (refs.autoRefreshCheckbox) {
+  refs.autoRefreshCheckbox.checked = state.autoRefreshEnabled;
+  refs.autoRefreshCheckbox.addEventListener("change", () =>
+    startAutoRefresh(refs.autoRefreshCheckbox.checked)
+  );
+}
 
 refs.articlesList.addEventListener("click", async (event) => {
   const button = event.target.closest("button[data-action]");
@@ -1983,4 +2022,6 @@ refs.extractionOpsList.addEventListener("click", async (event) => {
 });
 
 setSelectedDigestId(null);
+setAutoRefreshStatus(state.autoRefreshEnabled);
+startAutoRefresh(state.autoRefreshEnabled);
 refreshAll();

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -90,6 +90,13 @@
             <p class="eyebrow">Operations</p>
             <h2>运维总览</h2>
           </div>
+          <div class="toolbar-row">
+            <label class="check-label compact-toggle">
+              <input id="autoRefreshCheckbox" type="checkbox" />
+              自动刷新（30s）
+            </label>
+            <span id="autoRefreshStatus" class="muted">自动刷新关闭</span>
+          </div>
         </div>
         <p class="muted">
           把 `/health`、最近 pipeline、冷却来源、来源告警和发布失败收成一屏。细节操作仍保留在下方来源与抽取面板里。

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -473,6 +473,21 @@ textarea {
   margin: 0;
 }
 
+.compact-toggle {
+  width: auto;
+  padding: 8px 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.compact-toggle input {
+  accent-color: var(--accent-deep);
+}
+
+#autoRefreshStatus {
+  font-size: 12px;
+}
+
 .terminal {
   margin: 14px 0 0;
   min-height: 140px;


### PR DESCRIPTION
## Why
Operators often keep the admin console open while waiting for async operations. A lightweight auto-refresh mode helps monitor status without repeated manual clicks.

## What changed
- Added a 30s auto-refresh toggle in the Operations panel header.
- Added a visible status hint that shows whether auto-refresh is enabled.
- Remembered toggle preference in localStorage so it persists across reloads.
- Periodically re-runs the same dashboard refresh path used by the manual Refresh All button.

Closes #168