### PR TITLE
docs: add release contributor attribution attribution hygiene

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -117,6 +117,18 @@ The maintainer who merges the release PR or publishes the tag owns milestone rol
 - [ ] `python -m ainews stats` runs from the clean install.
 - [ ] Package metadata on GitHub and PyPI looks correct if PyPI publication is enabled for this release.
 
+### Release Attribution Hygiene
+
+- [ ] Run a human-visible contributor summary before closing the release:
+
+```bash
+git log --format="%an <%ae>" "${PREVIOUS_TAG}..${TAG}" \
+  | sort -u \
+  | grep -Ev 'dependabot\\[bot\\]|github-actions\\[bot\\]|renovate\\[bot\\]|actions-user'
+```
+
+- [ ] Keep any bot noise out of the handoff summary you send to maintainers; if bot accounts appear, note that the human-authored PRs for dependency/workflow upgrades are tracked in the release PR body and close comments.
+
 ### Closeout
 
 - [ ] Close the release milestone only after the release page, assets, and smoke workflows are verified.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -117,6 +117,18 @@ python -m ainews --help
 - [ ] 在干净安装环境里 `python -m ainews stats` 可以运行。
 - [ ] 如果本次 release 启用了 PyPI 发布，确认 GitHub 和 PyPI 上的包元信息都正确。
 
+### 维护者贡献可见性检查
+
+- [ ] 在关闭 milestone 前，补充一次人工维护者贡献检查：
+
+```bash
+git log --format="%an <%ae>" "${PREVIOUS_TAG}..${TAG}" \
+  | sort -u \
+  | grep -Ev 'dependabot\\[bot\\]|github-actions\\[bot\\]|renovate\\[bot\\]|actions-user'
+```
+
+- [ ] 如果结果里有 bot 账号噪音，在交付简报里说明并标注本次依赖/动作升级是否走了人工 PR 流程（原 Dependabot PR 在合并后已闭环）。
+
 ### 收尾
 
 - [ ] 只有在 Release 页面、制品和 smoke workflows 都确认后，才关闭 release milestone。


### PR DESCRIPTION
## Summary
- Add a release closeout checklist step for human-only contributor attribution review.
- Add a reusable `git log` one-liner in both EN and 中文 checklists, with bot account filtering.
- Note in the checklist that bot noise should be documented in release handoff if it appears.

Closes #175
