### PR TITLE
fix: improve console focus-visible affordances

### DIFF
--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -248,6 +248,15 @@ textarea {
   transform: translateY(-1px);
 }
 
+.button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid rgba(23, 23, 23, 0.86);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(219, 61, 27, 0.18);
+}
+
 .button.primary {
   background: var(--ink);
   color: #fff8ee;
@@ -462,6 +471,13 @@ textarea {
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.52);
   padding: 12px 14px;
+}
+
+.check-label:focus-within {
+  outline: 2px solid rgba(23, 23, 23, 0.86);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(219, 61, 27, 0.18);
+  border-color: rgba(23, 23, 23, 0.28);
 }
 
 .check-label.wide {


### PR DESCRIPTION
## Why
Improve keyboard accessibility for web console interactive controls by adding explicit focus-visible styles.

## Changes
- Add focus-visible outline/shadow states for buttons, inputs, selects, textareas.
- Add focus-within highlight states for checkbox-style labels.

## Validation
- make check PYTHON=./.venv-dev/bin/python