### PR TITLE
docs: remove hard-coded release version in artifact examples

### DIFF
--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -24,7 +24,7 @@ For tags created through `.github/workflows/release.yml`, the smoke workflow is 
 Set `VERSION` to the release tag without the leading `v`, then download the release assets into a clean directory:
 
 ```bash
-export VERSION=1.2.49
+export VERSION=<your-release-tag-without-v>
 export REPO=X-PG13/ainews-open
 mkdir -p "ainews-open-${VERSION}-release"
 cd "ainews-open-${VERSION}-release"

--- a/docs/release-artifacts.zh-CN.md
+++ b/docs/release-artifacts.zh-CN.md
@@ -24,7 +24,7 @@
 把 `VERSION` 设置为不带前导 `v` 的 release tag，然后把 release 资产下载到一个干净目录：
 
 ```bash
-export VERSION=1.2.49
+export VERSION=<your-release-tag-without-v>
 export REPO=X-PG13/ainews-open
 mkdir -p "ainews-open-${VERSION}-release"
 cd "ainews-open-${VERSION}-release"


### PR DESCRIPTION
## Why
Keep release verification documentation stable across patch releases by avoiding stale numeric placeholders.

## Changes
- Replace hard-coded example release versions in release artifact check docs (EN and zh-CN) with a placeholder.

## Validation
- make check PYTHON=./.venv-dev/bin/python