### PR TITLE
fix: respect reduced motion preferences in console UI

### DIFF
--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -799,3 +799,17 @@ textarea:focus-visible {
     align-items: stretch;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .button:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Why
Make the console resilient for users who prefer reduced motion by avoiding long-lived transitions and hover transforms.

## Changes
- Add a  media query to the web console stylesheet.
- Disable hover movement and minimize animations/transitions in that mode.

## Validation
- make check PYTHON=./.venv-dev/bin/python