### PR TITLE
docs: modernize maintainer status snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@
 
 ## Maintainer Status Snapshot
 
-- Latest release and release notes: [Release Notes](docs/releases/README.md)
-- Current planning: [Roadmap](ROADMAP.md)
-- Current open maintenance milestone list: [open milestones](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
-- Latest patch target from docs: [release notes index](docs/releases/README.md)
-- Deferred engineering work: [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+### Current Signals
+
+- **Release status**: read from [release notes index](docs/releases/README.md) (source of truth for latest patch level)
+- **Current planning**: [Roadmap](ROADMAP.md)
+- **Open maintenance milestones**: [open milestones](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
+- **Deferred engineering**: [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+
+### Maintainer Rhythm
+
+- Before opening follow-up work, confirm the latest release notes entry and align updates to the active milestone.
+- Before each milestone closeout, verify release assets and release docs using [release checklist](docs/release-checklist.md).
 
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)
 ![AI News Open Operations Overview](docs/assets/operations-panel-preview.svg)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,11 +18,17 @@
 
 ## 维护状态快照
 
-- 最新发布与发布说明： [发布说明索引](docs/releases/README.zh-CN.md)
-- 当前规划入口： [路线图](ROADMAP.zh-CN.md)
-- 当前开放里程碑列表： [进行中的里程碑](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
-- 最新 patch 以发布说明索引为准：[发布说明索引](docs/releases/README.zh-CN.md)
-- 延期工程项： [Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+### 当前运维信号
+
+- **发布状态**：以 [发布说明索引](docs/releases/README.zh-CN.md) 为准（最新补丁版本来源）
+- **当前规划**：[路线图](ROADMAP.zh-CN.md)
+- **开放中的维护里程碑**：[进行中的里程碑](https://github.com/X-PG13/ainews-open/milestones?q=is%3Aopen+is%3Amilestone)
+- **延期项**：[Deferred: PyPI](https://github.com/X-PG13/ainews-open/milestone/3)
+
+### 维护节奏
+
+- 在提交新后续项之前，先确认发布说明索引里的最新补丁版本，并对齐到当前开放里程碑。
+- 在里程碑收口前，按[发版清单](docs/release-checklist.md)核对发布产物与相关文档齐备性。
 
 ![AI News Open Real Console Screenshot](docs/assets/console-real.png)
 ![AI News Open Operations Overview](docs/assets/operations-panel-preview.svg)


### PR DESCRIPTION
## Summary\n- Keep README maintainer status block aligned to release notes as source of truth.\n- Add explicit maintainer rhythm notes for milestone/asset checklist alignment.\n- Mirror these updates in Chinese README.\n\nCloses #181