### PR TITLE
feat: add operator console status rail

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -75,6 +75,10 @@ const refs = {
   heroBuildVersion: document.getElementById("heroBuildVersion"),
   heroGeneratedAt: document.getElementById("heroGeneratedAt"),
   heroDataAge: document.getElementById("heroDataAge"),
+  heroRailHealth: document.getElementById("heroRailHealth"),
+  heroRailSchema: document.getElementById("heroRailSchema"),
+  heroRailBuild: document.getElementById("heroRailBuild"),
+  heroRailAge: document.getElementById("heroRailAge"),
   autoRefreshCheckbox: document.getElementById("autoRefreshCheckbox"),
   autoRefreshStatus: document.getElementById("autoRefreshStatus"),
 };
@@ -239,6 +243,18 @@ function updateHeroOperationStatus(payload) {
   }
   if (refs.heroDataAge) {
     refs.heroDataAge.textContent = `数据时效：${formatDataAge(generatedAt)}`;
+  }
+  if (refs.heroRailHealth) {
+    refs.heroRailHealth.textContent = statusText;
+  }
+  if (refs.heroRailSchema) {
+    refs.heroRailSchema.textContent = schemaVersion;
+  }
+  if (refs.heroRailBuild) {
+    refs.heroRailBuild.textContent = `v${buildVersion}`;
+  }
+  if (refs.heroRailAge) {
+    refs.heroRailAge.textContent = formatDataAge(generatedAt);
   }
   if (refs.operationsStatusStrip) {
     refs.operationsStatusStrip.classList.add("loaded");

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -35,12 +35,30 @@
             <button id="saveTokenButton" class="button ghost">保存</button>
           </div>
           <p class="muted">所有管理操作都会自动带上 `X-Admin-Token`。</p>
-          <div id="operationsStatusStrip" class="operations-status-strip" aria-live="polite">
+        <div id="operationsStatusStrip" class="operations-status-strip" aria-live="polite">
             <span id="heroHealthBadge" class="chip status-chip">系统状态：加载中</span>
             <span id="heroSchemaVersion">schema：未同步</span>
             <span id="heroBuildVersion">build：未同步</span>
             <span id="heroGeneratedAt">最后数据：--</span>
             <span id="heroDataAge">数据时效：--</span>
+          </div>
+          <div id="heroStatusRail" class="hero-status-rail" aria-live="polite">
+            <article class="status-rail-item">
+              <p>运行健康</p>
+              <h3 id="heroRailHealth">未采样</h3>
+            </article>
+            <article class="status-rail-item">
+              <p>Schema</p>
+              <h3 id="heroRailSchema">--</h3>
+            </article>
+            <article class="status-rail-item">
+              <p>构建版本</p>
+              <h3 id="heroRailBuild">--</h3>
+            </article>
+            <article class="status-rail-item">
+              <p>数据时效</p>
+              <h3 id="heroRailAge">--</h3>
+            </article>
           </div>
           <div class="start-cues" aria-label="首次运行建议">
             <span>1 保存 Token</span>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -110,6 +110,37 @@ button {
   font-size: 14px;
 }
 
+.hero-status-rail {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.status-rail-item {
+  display: grid;
+  gap: 4px;
+  border: 1px solid rgba(23, 23, 23, 0.16);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.status-rail-item p {
+  margin: 0;
+  font: 700 11px/1 "JetBrains Mono", monospace;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.status-rail-item h3 {
+  margin: 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
 .hero-copy,
 .muted {
   color: var(--muted);
@@ -776,6 +807,10 @@ textarea:focus-visible {
 
   .operations-status-strip {
     grid-template-columns: 1fr;
+  }
+
+  .hero-status-rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .token-row {


### PR DESCRIPTION
## What Changed
- Add a compact operator status rail in web console hero area with 4 live cards: health, schema, build version, and data age.
- Bind values to existing /admin/operations payload to keep single-source updates.
- Add responsive styling for desktop and mobile layouts.

Closes #185.