### PR TITLE
feat: color-code operator status rail cards

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -75,6 +75,10 @@ const refs = {
   heroBuildVersion: document.getElementById("heroBuildVersion"),
   heroGeneratedAt: document.getElementById("heroGeneratedAt"),
   heroDataAge: document.getElementById("heroDataAge"),
+  heroRailHealthCard: document.getElementById("heroRailHealthCard"),
+  heroRailSchemaCard: document.getElementById("heroRailSchemaCard"),
+  heroRailBuildCard: document.getElementById("heroRailBuildCard"),
+  heroRailAgeCard: document.getElementById("heroRailAgeCard"),
   heroRailHealth: document.getElementById("heroRailHealth"),
   heroRailSchema: document.getElementById("heroRailSchema"),
   heroRailBuild: document.getElementById("heroRailBuild"),
@@ -228,33 +232,51 @@ function updateHeroOperationStatus(payload) {
   const schemaVersion = health.schema_version || stats.schema_version || "unknown";
   const buildVersion = metrics.build_version || "unknown";
   const generatedAt = payload.generated_at || null;
+  const buildDisplay = buildVersion === "unknown" ? "未知" : `v${buildVersion}`;
+  const schemaDisplay = schemaVersion === "unknown" ? "未知" : schemaVersion;
+  const ageDisplay = formatDataAge(generatedAt);
+  const ageClass = generatedAt ? "good" : "status-unknown";
+  const schemaClass = schemaVersion === "unknown" ? "status-unknown" : "good";
+  const buildClass = buildVersion === "unknown" ? "status-unknown" : "good";
   if (refs.heroHealthBadge) {
     refs.heroHealthBadge.textContent = `系统状态：${statusText}`;
     refs.heroHealthBadge.className = `chip status-chip ${statusClass}`.trim();
   }
   if (refs.heroSchemaVersion) {
-    refs.heroSchemaVersion.textContent = `schema：${schemaVersion}`;
+    refs.heroSchemaVersion.textContent = `schema：${schemaDisplay}`;
   }
   if (refs.heroBuildVersion) {
-    refs.heroBuildVersion.textContent = `build：v${buildVersion}`;
+    refs.heroBuildVersion.textContent = `build：${buildDisplay}`;
   }
   if (refs.heroGeneratedAt) {
     refs.heroGeneratedAt.textContent = `最后数据：${formatDisplayTime(generatedAt)}`;
   }
   if (refs.heroDataAge) {
-    refs.heroDataAge.textContent = `数据时效：${formatDataAge(generatedAt)}`;
+    refs.heroDataAge.textContent = `数据时效：${ageDisplay}`;
   }
   if (refs.heroRailHealth) {
     refs.heroRailHealth.textContent = statusText;
   }
+  if (refs.heroRailHealthCard) {
+    refs.heroRailHealthCard.className = `status-rail-item ${statusClass || "status-unknown"}`;
+  }
   if (refs.heroRailSchema) {
-    refs.heroRailSchema.textContent = schemaVersion;
+    refs.heroRailSchema.textContent = schemaDisplay;
+  }
+  if (refs.heroRailSchemaCard) {
+    refs.heroRailSchemaCard.className = `status-rail-item ${schemaClass}`;
   }
   if (refs.heroRailBuild) {
-    refs.heroRailBuild.textContent = `v${buildVersion}`;
+    refs.heroRailBuild.textContent = buildDisplay;
+  }
+  if (refs.heroRailBuildCard) {
+    refs.heroRailBuildCard.className = `status-rail-item ${buildClass}`;
   }
   if (refs.heroRailAge) {
-    refs.heroRailAge.textContent = formatDataAge(generatedAt);
+    refs.heroRailAge.textContent = ageDisplay;
+  }
+  if (refs.heroRailAgeCard) {
+    refs.heroRailAgeCard.className = `status-rail-item ${ageClass}`;
   }
   if (refs.operationsStatusStrip) {
     refs.operationsStatusStrip.classList.add("loaded");

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -43,19 +43,19 @@
             <span id="heroDataAge">数据时效：--</span>
           </div>
           <div id="heroStatusRail" class="hero-status-rail" aria-live="polite">
-            <article class="status-rail-item">
+            <article id="heroRailHealthCard" class="status-rail-item">
               <p>运行健康</p>
               <h3 id="heroRailHealth">未采样</h3>
             </article>
-            <article class="status-rail-item">
+            <article id="heroRailSchemaCard" class="status-rail-item">
               <p>Schema</p>
               <h3 id="heroRailSchema">--</h3>
             </article>
-            <article class="status-rail-item">
+            <article id="heroRailBuildCard" class="status-rail-item">
               <p>构建版本</p>
               <h3 id="heroRailBuild">--</h3>
             </article>
-            <article class="status-rail-item">
+            <article id="heroRailAgeCard" class="status-rail-item">
               <p>数据时效</p>
               <h3 id="heroRailAge">--</h3>
             </article>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -141,6 +141,26 @@ button {
   line-height: 1.2;
 }
 
+.status-rail-item.status-good {
+  border-left: 4px solid rgba(46, 110, 61, 0.6);
+  box-shadow: 0 10px 22px rgba(58, 132, 77, 0.14);
+}
+
+.status-rail-item.status-pending {
+  border-left: 4px solid rgba(184, 140, 50, 0.72);
+  box-shadow: 0 10px 22px rgba(184, 140, 50, 0.14);
+}
+
+.status-rail-item.status-warn {
+  border-left: 4px solid rgba(219, 61, 27, 0.76);
+  box-shadow: 0 10px 22px rgba(219, 61, 27, 0.16);
+}
+
+.status-rail-item.status-unknown {
+  border-left: 4px solid rgba(23, 23, 23, 0.2);
+  opacity: 0.83;
+}
+
 .hero-copy,
 .muted {
   color: var(--muted);

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -42,6 +42,10 @@ class WebConsoleTestCase(unittest.TestCase):
 
         for expected in (
             'id="heroStatusRail"',
+            'id="heroRailHealthCard"',
+            'id="heroRailSchemaCard"',
+            'id="heroRailBuildCard"',
+            'id="heroRailAgeCard"',
             "status-rail-item",
             "heroRailHealth",
             "heroRailSchema",
@@ -56,11 +60,19 @@ class WebConsoleTestCase(unittest.TestCase):
             "heroRailBuild",
             "heroRailAge",
             "refs.heroRailHealth",
+            "heroRailHealthCard",
+            "heroRailSchemaCard",
+            "heroRailBuildCard",
+            "heroRailAgeCard",
             "refs.heroRailSchema",
             "refs.heroRailBuild",
             "refs.heroRailAge",
-            "refs.heroRailHealth.textContent = statusText",
-            "refs.heroRailBuild.textContent = `v${buildVersion}`",
+            "statusClass",
+            "refs.heroRailHealthCard.className",
+            "schemaDisplay",
+            "buildDisplay",
+            "ageDisplay",
+            "refs.heroRailAgeCard.className",
             "formatDataAge(generatedAt)",
         ):
             self.assertIn(expected, app)
@@ -70,6 +82,10 @@ class WebConsoleTestCase(unittest.TestCase):
             ".status-rail-item",
             ".status-rail-item p",
             ".status-rail-item h3",
+            ".status-rail-item.status-good",
+            ".status-rail-item.status-pending",
+            ".status-rail-item.status-warn",
+            ".status-rail-item.status-unknown",
             "grid-template-columns: repeat(2, minmax(0, 1fr));",
         ):
             self.assertIn(expected, styles)


### PR DESCRIPTION
## What Changed
- Add status card IDs on the operator status rail.
- Color-code each status rail card with `status-good`, `status-pending`, `status-warn`, and `status-unknown` classes.
- Fallback missing build/schema/age metrics to `未知` and keep the state explicit.
- Extend web console static tests to lock the status-rail contract.

Closes #189.
