### PR TITLE
feat: improve operator status rail accessibility

### DIFF
--- a/docs/operator-console-walkthrough.md
+++ b/docs/operator-console-walkthrough.md
@@ -121,6 +121,16 @@ For triage:
 - If `构建版本` stays at `未知` for multiple refresh cycles, open a debug run and
   confirm the pipeline metadata is being reported.
 
+The card content also exposes localized status hints for assistive tools, so the
+first read should answer:
+
+- Can we trust system health right now?
+- Is the schema/build pair aligned with the currently deployed backend?
+- Is the data snapshot fresh enough for safe manual action?
+
+If these hints stay unknown for several refresh cycles, pause non-essential
+operator actions and open a service-side health dump before running ingest/extract.
+
 ## 4. Ingest A Small Candidate Pool
 
 In the console:

--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -83,6 +83,10 @@ const refs = {
   heroRailSchema: document.getElementById("heroRailSchema"),
   heroRailBuild: document.getElementById("heroRailBuild"),
   heroRailAge: document.getElementById("heroRailAge"),
+  heroRailHealthHint: document.getElementById("heroRailHealthHint"),
+  heroRailSchemaHint: document.getElementById("heroRailSchemaHint"),
+  heroRailBuildHint: document.getElementById("heroRailBuildHint"),
+  heroRailAgeHint: document.getElementById("heroRailAgeHint"),
   autoRefreshCheckbox: document.getElementById("autoRefreshCheckbox"),
   autoRefreshStatus: document.getElementById("autoRefreshStatus"),
 };
@@ -179,15 +183,15 @@ function operationStatusClass(status) {
 function operationStatusLabelAndClass(status) {
   const normalized = String(status || "unknown");
   if (normalized === "ok" || normalized === "ready") {
-    return ["正常", "good"];
+    return ["正常", "good", "健康检查通过，后台主要链路可继续执行。"];
   }
   if (normalized === "degraded" || normalized === "pending" || normalized === "partial_error") {
-    return ["降级", "pending"];
+    return ["降级", "pending", "出现部分退化，建议查看 Operations 健康检查的 degraded reasons。"];
   }
   if (normalized === "error" || normalized === "blocked") {
-    return ["异常", "warn"];
+    return ["异常", "warn", "检测到异常状态，建议暂停发布动作并先排查告警与失败队列。"];
   }
-  return ["未采样", ""];
+  return ["未采样", "unknown", "尚未拉取到最新状态，建议刷新运维面板确认 /admin/operations 可访问。"];
 }
 
 function formatDisplayTime(value) {
@@ -228,7 +232,7 @@ function updateHeroOperationStatus(payload) {
   const stats = payload.stats || {};
   const metrics = payload.metrics || {};
   const status = health.status || "unknown";
-  const [statusText, statusClass] = operationStatusLabelAndClass(status);
+  const [statusText, statusClass, statusHint] = operationStatusLabelAndClass(status);
   const schemaVersion = health.schema_version || stats.schema_version || "unknown";
   const buildVersion = metrics.build_version || "unknown";
   const generatedAt = payload.generated_at || null;
@@ -238,6 +242,10 @@ function updateHeroOperationStatus(payload) {
   const ageClass = generatedAt ? "good" : "status-unknown";
   const schemaClass = schemaVersion === "unknown" ? "status-unknown" : "good";
   const buildClass = buildVersion === "unknown" ? "status-unknown" : "good";
+  const ageHint = generatedAt ? "数据时效正常，继续观察发布链路波动。" : "未拿到时间戳时请先检查 /admin/operations 与服务访问权限。";
+  const healthHint = statusHint || "尚未拿到运行健康状态。";
+  const schemaHint = `Schema ${schemaDisplay}`;
+  const buildHint = `构建 ${buildDisplay}`;
   if (refs.heroHealthBadge) {
     refs.heroHealthBadge.textContent = `系统状态：${statusText}`;
     refs.heroHealthBadge.className = `chip status-chip ${statusClass}`.trim();
@@ -254,29 +262,45 @@ function updateHeroOperationStatus(payload) {
   if (refs.heroDataAge) {
     refs.heroDataAge.textContent = `数据时效：${ageDisplay}`;
   }
+  if (refs.heroRailHealthCard) {
+    refs.heroRailHealthCard.className = `status-rail-item ${statusClass || "status-unknown"}`;
+    refs.heroRailHealthCard.setAttribute("aria-label", `运行健康状态 ${statusText}。${healthHint}`);
+  }
   if (refs.heroRailHealth) {
     refs.heroRailHealth.textContent = statusText;
   }
-  if (refs.heroRailHealthCard) {
-    refs.heroRailHealthCard.className = `status-rail-item ${statusClass || "status-unknown"}`;
+  if (refs.heroRailHealthHint) {
+    refs.heroRailHealthHint.textContent = healthHint;
   }
   if (refs.heroRailSchema) {
     refs.heroRailSchema.textContent = schemaDisplay;
   }
   if (refs.heroRailSchemaCard) {
     refs.heroRailSchemaCard.className = `status-rail-item ${schemaClass}`;
+    refs.heroRailSchemaCard.setAttribute("aria-label", `Schema 状态 ${schemaDisplay}。${schemaHint}`);
   }
   if (refs.heroRailBuild) {
     refs.heroRailBuild.textContent = buildDisplay;
   }
   if (refs.heroRailBuildCard) {
     refs.heroRailBuildCard.className = `status-rail-item ${buildClass}`;
+    refs.heroRailBuildCard.setAttribute("aria-label", `构建版本 ${buildDisplay}。${buildHint}`);
   }
   if (refs.heroRailAge) {
     refs.heroRailAge.textContent = ageDisplay;
   }
   if (refs.heroRailAgeCard) {
     refs.heroRailAgeCard.className = `status-rail-item ${ageClass}`;
+    refs.heroRailAgeCard.setAttribute("aria-label", `数据时效 ${ageDisplay}。${ageHint}`);
+  }
+  if (refs.heroRailSchemaHint) {
+    refs.heroRailSchemaHint.textContent = schemaHint;
+  }
+  if (refs.heroRailBuildHint) {
+    refs.heroRailBuildHint.textContent = buildHint;
+  }
+  if (refs.heroRailAgeHint) {
+    refs.heroRailAgeHint.textContent = ageHint;
   }
   if (refs.operationsStatusStrip) {
     refs.operationsStatusStrip.classList.add("loaded");

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -42,22 +42,26 @@
             <span id="heroGeneratedAt">最后数据：--</span>
             <span id="heroDataAge">数据时效：--</span>
           </div>
-          <div id="heroStatusRail" class="hero-status-rail" aria-live="polite">
-            <article id="heroRailHealthCard" class="status-rail-item">
+          <div id="heroStatusRail" class="hero-status-rail" role="list" aria-label="运营状态速览" aria-live="polite">
+            <article id="heroRailHealthCard" class="status-rail-item" role="listitem" aria-describedby="heroRailHealthHint">
               <p>运行健康</p>
               <h3 id="heroRailHealth">未采样</h3>
+              <p id="heroRailHealthHint" class="sr-only">运行健康状态用于快速判断，异常时先看 Operations 面板里的健康检查列表。</p>
             </article>
-            <article id="heroRailSchemaCard" class="status-rail-item">
+            <article id="heroRailSchemaCard" class="status-rail-item" role="listitem" aria-describedby="heroRailSchemaHint">
               <p>Schema</p>
               <h3 id="heroRailSchema">--</h3>
+              <p id="heroRailSchemaHint" class="sr-only">Schema 用于确认后台与前端约定未发生版本漂移。</p>
             </article>
-            <article id="heroRailBuildCard" class="status-rail-item">
+            <article id="heroRailBuildCard" class="status-rail-item" role="listitem" aria-describedby="heroRailBuildHint">
               <p>构建版本</p>
               <h3 id="heroRailBuild">--</h3>
+              <p id="heroRailBuildHint" class="sr-only">构建版本用于核对发布件与服务实例是否匹配。</p>
             </article>
-            <article id="heroRailAgeCard" class="status-rail-item">
+            <article id="heroRailAgeCard" class="status-rail-item" role="listitem" aria-describedby="heroRailAgeHint">
               <p>数据时效</p>
               <h3 id="heroRailAge">--</h3>
+              <p id="heroRailAgeHint" class="sr-only">数据时效超过 1 小时通常表示运维层采集或 pipeline 刷新异常。</p>
             </article>
           </div>
           <div class="start-cues" aria-label="首次运行建议">

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -118,12 +118,26 @@ button {
 }
 
 .status-rail-item {
+  position: relative;
   display: grid;
   gap: 4px;
   border: 1px solid rgba(23, 23, 23, 0.16);
   border-radius: 12px;
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.55);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .status-rail-item p {

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -46,11 +46,17 @@ class WebConsoleTestCase(unittest.TestCase):
             'id="heroRailSchemaCard"',
             'id="heroRailBuildCard"',
             'id="heroRailAgeCard"',
+            'id="heroRailHealthHint"',
+            'id="heroRailSchemaHint"',
+            'id="heroRailBuildHint"',
+            'id="heroRailAgeHint"',
             "status-rail-item",
             "heroRailHealth",
             "heroRailSchema",
             "heroRailBuild",
             "heroRailAge",
+            'role="list"',
+            'role="listitem"',
         ):
             self.assertIn(expected, index)
 
@@ -67,13 +73,20 @@ class WebConsoleTestCase(unittest.TestCase):
             "refs.heroRailSchema",
             "refs.heroRailBuild",
             "refs.heroRailAge",
+            "refs.heroRailHealthHint",
+            "refs.heroRailSchemaHint",
+            "refs.heroRailBuildHint",
+            "refs.heroRailAgeHint",
             "statusClass",
             "refs.heroRailHealthCard.className",
+            "refs.heroRailHealthCard.setAttribute",
+            "refs.heroRailAgeCard.setAttribute",
             "schemaDisplay",
             "buildDisplay",
             "ageDisplay",
             "refs.heroRailAgeCard.className",
             "formatDataAge(generatedAt)",
+            "operationStatusLabelAndClass",
         ):
             self.assertIn(expected, app)
 
@@ -86,6 +99,7 @@ class WebConsoleTestCase(unittest.TestCase):
             ".status-rail-item.status-pending",
             ".status-rail-item.status-warn",
             ".status-rail-item.status-unknown",
+            ".sr-only",
             "grid-template-columns: repeat(2, minmax(0, 1fr));",
         ):
             self.assertIn(expected, styles)


### PR DESCRIPTION
## Summary
- Add ARIA/list semantics and hint bindings to the operator status rail cards.
- Add per-card assistive-only explanations and live status descriptions for each metric.
- Keep hints in sync in JS by updating status rail card text + aria-labels together with rendering logic.
- Add docs quick-triage guidance for status rail semantics.
- Add unit-style web-console assertions for new IDs, roles, and selector coverage.

## Validation
- PYTHONPATH=src python3 -m unittest tests/test_web_console.py -v
- PYTHONPATH=src python3 -m unittest tests/test_docs_links.py tests/test_release_metadata.py -v