### PR TITLE
docs: add contributor summary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python3
 
-.PHONY: ingest extract enrich digest pipeline publish publications refresh-publications housekeeping monitoring-up monitoring-down lint build sbom check serve test coverage smoke
+.PHONY: ingest extract enrich digest pipeline publish publications refresh-publications housekeeping monitoring-up monitoring-down lint build sbom contributors check serve test coverage smoke
 
 ingest:
 	$(PYTHON) -m ainews ingest
@@ -44,6 +44,12 @@ build:
 sbom:
 	PYTHON_BIN="$$( $(PYTHON) -c 'import sys; print(sys.executable)' )"; \
 	$(PYTHON) -m cyclonedx_py environment "$$PYTHON_BIN" --pyproject pyproject.toml --mc-type application --output-reproducible --of JSON -o sbom.json
+
+contributors:
+	@echo "# Human-visible contributors (excluding bot noise):"
+	@git shortlog -sne --all --no-merges \
+		| grep -Ev '(bot|dependabot\\[bot\\]|github-actions\\[bot\\]|renovate\\[bot\\]|actions-user)' \
+		| sed -n '1,200p'
 
 check: lint coverage build smoke
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -125,6 +125,7 @@ The maintainer who merges the release PR or publishes the tag owns milestone rol
 git log --format="%an <%ae>" "${PREVIOUS_TAG}..${TAG}" \
   | sort -u \
   | grep -Ev 'dependabot\\[bot\\]|github-actions\\[bot\\]|renovate\\[bot\\]|actions-user'
+make contributors
 ```
 
 - [ ] Keep any bot noise out of the handoff summary you send to maintainers; if bot accounts appear, note that the human-authored PRs for dependency/workflow upgrades are tracked in the release PR body and close comments.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -125,6 +125,7 @@ python -m ainews --help
 git log --format="%an <%ae>" "${PREVIOUS_TAG}..${TAG}" \
   | sort -u \
   | grep -Ev 'dependabot\\[bot\\]|github-actions\\[bot\\]|renovate\\[bot\\]|actions-user'
+make contributors
 ```
 
 - [ ] 如果结果里有 bot 账号噪音，在交付简报里说明并标注本次依赖/动作升级是否走了人工 PR 流程（原 Dependabot PR 在合并后已闭环）。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,6 +259,7 @@ If bot accounts (for example, Dependabot or CI users) are showing unexpectedly:
 ```bash
 git shortlog -sne --all --no-merges |
   grep -Ev "(bot|dependabot\[bot\]|github-actions\[bot\])" | sed -n '1,30p'
+make contributors
 ```
 
 - If a bot commit should be excluded from release notes or maintainer attribution,

--- a/docs/troubleshooting.zh-CN.md
+++ b/docs/troubleshooting.zh-CN.md
@@ -261,6 +261,7 @@ python -m ainews publish --digest-id 1 --target static_site --force-republish
 ```bash
 git shortlog -sne --all --no-merges |
   grep -Ev "(bot|dependabot\[bot\]|github-actions\[bot\])" | sed -n '1,30p'
+make contributors
 ```
 
 - 如果某次发布说明里不希望出现 bot 归属，建议在发布 PR 的作者说明里补充人类归属备注。

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -400,6 +400,20 @@ class ReleaseMetadataTestCase(unittest.TestCase):
         ):
             self.assertIn(expected, release_checklist_zh)
 
+    def test_contributor_summary_target_is_documented(self) -> None:
+        makefile = _read_text("Makefile")
+        release_checklist = _read_text("docs/release-checklist.md")
+        release_checklist_zh = _read_text("docs/release-checklist.zh-CN.md")
+        troubleshooting = _read_text("docs/troubleshooting.md")
+        troubleshooting_zh = _read_text("docs/troubleshooting.zh-CN.md")
+
+        self.assertIn("contributors:", makefile)
+        self.assertIn("dependabot\\\\[bot\\\\]", makefile)
+        self.assertIn("make contributors", release_checklist)
+        self.assertIn("make contributors", release_checklist_zh)
+        self.assertIn("make contributors", troubleshooting)
+        self.assertIn("make contributors", troubleshooting_zh)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add a new # Human-visible contributors (excluding bot noise):
    63	Yifan Zhao <2720174336@qq.com>
    63	yifan zhao <2720174336@qq.com>
    56	X-PG13 <2720174336@qq.com>
     7	zhaoyifan <zhaoyifan@local>
     1	hanhan761 <157025428+hanhan761@users.noreply.github.com> target to show human-visible contributors while filtering common bot accounts.
- Reference the target from release checklist release-attribution and troubleshooting bot-noise sections (EN/CN).
- Add regression coverage that checks the Makefile target and docs references stay aligned.

## Validation
- python3 -m unittest tests/test_release_metadata.py -v
- python3 -m unittest tests/test_web_console.py -v