### PR TITLE
chore: add contributor checklist reminder in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 
 - [ ] `python -m unittest discover -s tests -v`
 - [ ] `python -m ruff check src tests`
+- [ ] `make contributors` output attached for release-attribution checks when this PR is release-adjacent
 - [ ] Relevant manual verification completed
 
 ## Checklist


### PR DESCRIPTION
## Summary
- Add a PR template reminder to include  output when reviewing release-attribution context.

## Validation
- Manual diff review only (template-only change).