### PR TITLE
chore: add local unittest make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python3
 
-.PHONY: ingest extract enrich digest pipeline publish publications refresh-publications housekeeping monitoring-up monitoring-down lint build sbom contributors check serve test coverage smoke
+.PHONY: ingest extract enrich digest pipeline publish publications refresh-publications housekeeping monitoring-up monitoring-down lint build sbom contributors check serve test test-local coverage smoke
 
 ingest:
 	$(PYTHON) -m ainews ingest
@@ -58,6 +58,9 @@ serve:
 
 test:
 	$(PYTHON) -m unittest discover -s tests -v
+
+test-local:
+	PYTHONPATH="$(CURDIR)/src:$$PYTHONPATH" $(PYTHON) -m unittest discover -s tests -v
 
 coverage:
 	$(PYTHON) -m coverage run -m unittest discover -s tests -v

--- a/docs/contributor-playbook.md
+++ b/docs/contributor-playbook.md
@@ -60,7 +60,7 @@ Remove the proxy prefix once the network stabilizes and continue with the normal
 ## Validate Before Opening A PR
 
 - `make lint`
-- `make test`
+- `make test` (or `make test-local` for no-install local runs)
 - `make coverage`
 - `make build`
 


### PR DESCRIPTION
This adds an explicit PYTHONPATH="/Users/zhaoyifan/Desktop/news/src:$PYTHONPATH" python3 -m unittest discover -s tests -v target that runs unit tests from the local source tree using , so contributors can run tests immediately after checkout without pre-installing the package.