### PR TITLE
fix: keep fallback extractor robust to generic selector tokens

### DIFF
--- a/src/ainews/content_extractor.py
+++ b/src/ainews/content_extractor.py
@@ -2510,12 +2510,24 @@ class ArticleContentExtractor:
 
     def _host_drop_tokens(self, host: str) -> tuple[str, ...]:
         tokens: List[str] = []
+        ignored_tokens = {"group", "data", "module"}
         for selector in self._host_values(host, HOST_DROP_SELECTORS):
             selector_text = str(selector).lower().strip()
             tail = re.split(r"\s*[>+~]\s*|\s+", selector_text)[-1]
-            cleaned = re.sub(r"[^a-z0-9_-]+", " ", tail).split()
-            tokens.extend(cleaned)
-        return tuple(tokens)
+            selector_tokens: List[str] = []
+            selector_tokens.extend(re.findall(r"\.([a-z0-9_-]+)", tail))
+            selector_tokens.extend(re.findall(r"#([a-z0-9_-]+)", tail))
+            selector_tokens.extend(
+                re.findall(r"\[[^\]=]+\s*=\s*['\"]?([a-z0-9_-]+)['\"]?\]", tail)
+            )
+            if selector_tokens:
+                tokens.extend(selector_tokens)
+                continue
+            tokens.extend(re.sub(r"[^a-z0-9_-]+", " ", tail).split())
+
+        return tuple(
+            token for token in tokens if token and token not in ignored_tokens and len(token) > 1
+        )
 
     def _fallback_extract_from_html(self, raw_html: str, *, url: str = "") -> ExtractedContent:
         host = self._normalize_host(url)

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -2299,6 +2299,22 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertNotIn("Back to Articles", content.text)
         self.assertNotIn("Follow", content.text)
 
+    def test_host_drop_tokens_ignores_generic_group_selector_tokens(self) -> None:
+        extractor = ArticleContentExtractor(timeout=10, user_agent="test-agent", text_limit=5000)
+        with patch("ainews.content_extractor.BeautifulSoup", None):
+            content = extractor.extract_from_html(
+                _fixture("cnbc-article.html"),
+                url="https://www.cnbc.com/2026/04/09/ai-operating-discipline-becomes-board-topic.html",
+            )
+
+        self.assertIn("AI operating discipline is becoming a board-level topic", content.text)
+        self.assertIn("Technology leaders are being asked", content.text)
+        self.assertIn("kill switches", content.text)
+        self.assertNotIn("Subscribe to CNBC PRO", content.text)
+        self.assertNotIn("Related Tags", content.text)
+        self.assertNotIn("Watch: Why AI spending is accelerating again", content.text)
+        self.assertNotIn("group", extractor._host_drop_tokens("cnbc.com"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Harden fallback selector token extraction so host selectors no longer emit generic tokens such as group from selectors like .group[data-module='recirc']. This restores CNBC fixture extraction when BeautifulSoup is unavailable and adds a regression test for the scenario.