### PR TITLE
feat: show console auto-refresh countdown

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -6,10 +6,13 @@ const state = {
   selectedDigestId: null,
   editorActor: localStorage.getItem("ainews_digest_editor_actor") || "",
   autoRefreshEnabled: localStorage.getItem("ainews_auto_refresh") === "1",
+  nextAutoRefreshAt: null,
 };
 
 let autoRefreshTimer = null;
+let autoRefreshCountdownTimer = null;
 const AUTO_REFRESH_INTERVAL_MS = 30000;
+const AUTO_REFRESH_TICK_MS = 1000;
 
 const refs = {
   adminToken: document.getElementById("adminToken"),
@@ -91,6 +94,7 @@ const refs = {
   heroRailAgeHint: document.getElementById("heroRailAgeHint"),
   autoRefreshCheckbox: document.getElementById("autoRefreshCheckbox"),
   autoRefreshStatus: document.getElementById("autoRefreshStatus"),
+  heroAutoRefreshCountdown: document.getElementById("heroAutoRefreshCountdown"),
 };
 
 refs.adminToken.value = state.token;
@@ -1626,11 +1630,47 @@ function setAutoRefreshStatus(enabled) {
   refs.autoRefreshStatus.textContent = enabled ? "自动刷新开启" : "自动刷新关闭";
 }
 
+function formatCountdown(seconds) {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(0, Math.round(seconds)) : 0;
+  if (safeSeconds <= 5) {
+    return "即将刷新";
+  }
+  if (safeSeconds < 60) {
+    return `${safeSeconds} 秒`;
+  }
+  const minute = Math.floor(safeSeconds / 60);
+  const second = safeSeconds % 60;
+  return `${minute} 分 ${String(second).padStart(2, "0")} 秒`;
+}
+
+function updateAutoRefreshCountdown() {
+  if (!refs.heroAutoRefreshCountdown) {
+    return;
+  }
+
+  if (!state.autoRefreshEnabled || !state.nextAutoRefreshAt) {
+    refs.heroAutoRefreshCountdown.textContent = "自动刷新：未开启";
+    return;
+  }
+
+  const now = Date.now();
+  const remainingMs = Math.max(0, state.nextAutoRefreshAt - now);
+  refs.heroAutoRefreshCountdown.textContent = `自动刷新：${formatCountdown(
+    Math.floor(remainingMs / 1000),
+  )}`;
+}
+
 function stopAutoRefresh() {
   if (autoRefreshTimer) {
     clearInterval(autoRefreshTimer);
     autoRefreshTimer = null;
   }
+  if (autoRefreshCountdownTimer) {
+    clearInterval(autoRefreshCountdownTimer);
+    autoRefreshCountdownTimer = null;
+  }
+  state.nextAutoRefreshAt = null;
+  updateAutoRefreshCountdown();
 }
 
 function startAutoRefresh(enabled) {
@@ -1643,9 +1683,14 @@ function startAutoRefresh(enabled) {
   }
   setAutoRefreshStatus(true);
   stopAutoRefresh();
+  state.nextAutoRefreshAt = Date.now() + AUTO_REFRESH_INTERVAL_MS;
   autoRefreshTimer = setInterval(() => {
     refreshAll().catch((error) => logJob("auto refresh failed", { error: error.message }));
   }, AUTO_REFRESH_INTERVAL_MS);
+  autoRefreshCountdownTimer = setInterval(() => {
+    updateAutoRefreshCountdown();
+  }, AUTO_REFRESH_TICK_MS);
+  updateAutoRefreshCountdown();
 }
 
 async function refreshAll() {
@@ -1662,6 +1707,11 @@ async function refreshAll() {
     ]);
   } catch (error) {
     logJob("refresh failed", { error: error.message });
+  } finally {
+    if (state.autoRefreshEnabled) {
+      state.nextAutoRefreshAt = Date.now() + AUTO_REFRESH_INTERVAL_MS;
+      updateAutoRefreshCountdown();
+    }
   }
 }
 

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -41,6 +41,7 @@
             <span id="heroBuildVersion">build：未同步</span>
             <span id="heroGeneratedAt">最后数据：--</span>
             <span id="heroDataAge">数据时效：--</span>
+            <span id="heroAutoRefreshCountdown">自动刷新：--</span>
           </div>
           <div id="heroVersionPulse" class="hero-version-pulse" aria-live="polite">
             <p class="version-kicker">版本脉搏</p>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -214,7 +214,7 @@ button {
 
 .operations-status-strip {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
   margin-top: 12px;
   padding: 10px;

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -52,12 +52,14 @@ class WebConsoleTestCase(unittest.TestCase):
             'id="heroRailAgeHint"',
             'id="heroReleaseVersion"',
             'id="heroDataWindow"',
+            'id="heroAutoRefreshCountdown"',
             'id="heroVersionPulse"',
             "status-rail-item",
             "heroRailHealth",
             "heroRailSchema",
             "heroRailBuild",
             "heroRailAge",
+            "heroAutoRefreshCountdown",
             'role="list"',
             'role="listitem"',
         ):
@@ -80,10 +82,15 @@ class WebConsoleTestCase(unittest.TestCase):
             "refs.heroRailSchemaHint",
             "refs.heroRailBuildHint",
             "refs.heroRailAgeHint",
+            "refs.heroAutoRefreshCountdown",
             "refs.heroReleaseVersion",
             "refs.heroDataWindow",
             "heroReleaseVersion",
             "heroDataWindow",
+            "updateAutoRefreshCountdown",
+            "formatCountdown",
+            "autoRefreshCountdownTimer",
+            "AUTO_REFRESH_TICK_MS",
             "describeDataWindow",
             "statusClass",
             "refs.heroRailHealthCard.className",
@@ -113,6 +120,7 @@ class WebConsoleTestCase(unittest.TestCase):
             ".version-kicker",
             ".sr-only",
             "grid-template-columns: repeat(2, minmax(0, 1fr));",
+            "grid-template-columns: repeat(3, minmax(0, 1fr));",
         ):
             self.assertIn(expected, styles)
 


### PR DESCRIPTION
## Why
Add a visible countdown for auto-refresh behavior on the web console to improve operator visibility on when the next automatic refresh will run.

## What changed
- Add auto-refresh countdown placeholder in hero status strip.
- Add countdown calculation and formatting helpers in frontend JS.
- Keep countdown synced by scheduling periodic updates when auto-refresh is enabled.
- Reset countdown after each manual or automatic refresh.
- Update console UI grid layout to fit the extra status chip.
- Keep existing behavior unchanged when auto-refresh is disabled.

## Testing
- 
- 