### PR TITLE
fix: load web console assets via relative paths

### DIFF
--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -10,7 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/assets/styles.css" />
+    <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>
     <div class="background-grid" aria-hidden="true"></div>
@@ -460,6 +460,6 @@
         <div id="articlesList" class="articles-list"></div>
       </section>
     </main>
-    <script src="/assets/app.js" defer></script>
+    <script src="assets/app.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Why
The web console opened via file:// was missing styles and JS because asset paths started with , which resolves to filesystem root instead of the local project directory.

## What changed
- Use relative asset paths for console CSS/JS:
  -  -> 
  -  -> 
- Keep server behavior unchanged for normal deployments while enabling local file-open preview.

## Testing
- 
- 