### PR TITLE
docs: clarify file-protocol web console preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Open the console at:
 http://127.0.0.1:8000/
 ```
 
+For local visual checks, you can also open `src/ainews/web/index.html` directly as a file. The console now uses relative asset paths so style and behavior render correctly in `file:///` mode.
+
 If you prefer to start the API directly:
 
 ```bash


### PR DESCRIPTION
## Why
When opening `src/ainews/web/index.html` directly from the file browser (`file:///.../index.html`), some users only saw plain text because browser path resolution can break absolute asset URLs.

## What changed
- Add a brief README note that the console now supports direct file-protocol preview.
- Mention the expected commandless check: open `src/ainews/web/index.html` directly for quick UI smoke checks.

## Testing
- `python3 -m unittest tests/test_docs_links.py -v`
