### PR TITLE
fix: stabilize web console file-mode asset loading

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,8 +57,9 @@ Checks:
 - Open the page via one of the supported paths:
   - `http://127.0.0.1:8000/` (served app)
   - `src/ainews/web/index.html` for quick static preview
-- In DevTools, confirm CSS/JS requests for `assets/styles.css` and `assets/app.js` return 200.
-- If you open by file protocol, fallback to same-folder `styles.css` / `app.js` is built in, so it should still render after one refresh.
+- In DevTools, confirm CSS/JS requests return 200:
+  - For service mode (`http://127.0.0.1:8000/`): `assets/styles.css`, `assets/app.js`.
+  - For local file mode (`file://.../src/ainews/web/index.html`): `styles.css`, `app.js`.
 - If you still only see raw tags/text, check the page source for unresolved merge markers like `<<<<<<< HEAD` `=======` `>>>>>>>`.
 - Clear browser cache / open an in-private window after fixing merge conflicts, then refresh once with hard reload.
 

--- a/docs/troubleshooting.zh-CN.md
+++ b/docs/troubleshooting.zh-CN.md
@@ -22,8 +22,9 @@
 - 使用以下任一方式打开：
   - `http://127.0.0.1:8000/`（服务方式）
   - 直接打开 `src/ainews/web/index.html`（本地静态快速查看）
-- 在浏览器控制台确认 `assets/styles.css` 与 `assets/app.js` 的资源请求返回 200，且未出现 404。
-- file 协议打开时会自动回退到当前目录下 `styles.css` / `app.js`，通常能直接恢复样式与交互。
+- 在浏览器控制台确认 `styles.css` / `app.js` 与 `assets/styles.css` / `assets/app.js` 资源请求返回 200（按打开方式对照）：
+  - 服务方式（`http://127.0.0.1:8000/`）：优先检查 `assets/styles.css`、`assets/app.js`。
+  - file 协议（`file://.../src/ainews/web/index.html`）：优先检查同目录的 `styles.css`、`app.js`。
 - 若仍然只有裸文本，请检查页面源码里是否存在未清理的 `<<<<<<< HEAD` `=======` `>>>>>>>` 合并标记。
 - 若已合并冲突且仍无样式，清理缓存或无痕窗口后强制刷新一次。
 

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -14,10 +14,10 @@
       (function () {
         const isFileProtocol = window.location.protocol === "file:";
         const cssCandidates = isFileProtocol
-          ? ["assets/styles.css", "styles.css"]
+          ? ["styles.css", "assets/styles.css"]
           : ["/assets/styles.css", "assets/styles.css", "styles.css"];
         const jsCandidates = isFileProtocol
-          ? ["assets/app.js", "app.js"]
+          ? ["app.js", "assets/app.js"]
           : ["/assets/app.js", "assets/app.js", "app.js"];
 
         const dedup = (items) =>
@@ -47,24 +47,32 @@
           document.head.appendChild(element);
         };
 
-        loadWithFallback(
-          (href) => {
-            const link = document.createElement("link");
-            link.rel = "stylesheet";
-            link.href = href;
-            return link;
-          },
-          cssCandidates,
-        );
-        loadWithFallback(
-          (src) => {
-            const script = document.createElement("script");
-            script.defer = true;
-            script.src = src;
-            return script;
-          },
-          jsCandidates,
-        );
+        const loadAssets = () => {
+          loadWithFallback(
+            (href) => {
+              const link = document.createElement("link");
+              link.rel = "stylesheet";
+              link.href = href;
+              return link;
+            },
+            cssCandidates,
+          );
+          loadWithFallback(
+            (src) => {
+              const script = document.createElement("script");
+              script.defer = true;
+              script.src = src;
+              return script;
+            },
+            jsCandidates,
+          );
+        };
+
+        if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", loadAssets, { once: true });
+        } else {
+          loadAssets();
+        }
       })();
     </script>
   </head>


### PR DESCRIPTION
## Summary\n- Make local file-mode web console asset loading more robust by preferring same-directory assets first in file:// mode.\n- Delay dynamic asset injection until DOMContentLoaded so admin UI JS initializes after DOM exists.\n- Clarify troubleshooting docs for file-mode vs service-mode asset check paths (EN/CN).\n\n## Verification\n- ./venv-dev/bin/python -m pytest tests/test_docs_links.py