### PR TITLE
test: lock web-console file-mode DOMContentLoaded loading behavior

### DIFF
--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -179,6 +179,10 @@ class WebConsoleTestCase(unittest.TestCase):
             '"app.js"',
             "loadWithFallback(",
             "dedup(candidates);",
+            "const loadAssets = () => {",
+            'document.readyState === "loading"',
+            "document.addEventListener(\"DOMContentLoaded\", loadAssets, { once: true })",
+            "loadAssets();",
         )
         for expected in expected_snippets:
             self.assertIn(expected, index)


### PR DESCRIPTION
## Summary\n- Add a lightweight console asset-loading regression assertion for  mode initialization timing.\n- Ensure future edits keep DOMContentLoaded-driven asset loading instead of immediate head injection.\n\n## Verification\n- ./.venv-dev/bin/python -m pytest tests/test_web_console.py