### PR TITLE
web: harden web-console asset fallback for file/http views

### DIFF
--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -4,6 +4,81 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI News Open Console</title>
+    <style id="consoleFallbackStyles">
+      :root {
+        --bg: #f7f0e5;
+        --ink: #171717;
+        --muted: #6f665b;
+        --line: rgba(23, 23, 23, 0.12);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        min-height: 100%;
+        font-family: "Noto Sans SC", Arial, sans-serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at top left, rgba(219, 61, 27, 0.08), transparent 28%),
+          radial-gradient(circle at bottom right, rgba(184, 140, 50, 0.12), transparent 32%),
+          linear-gradient(180deg, #fbf5eb 0%, #f3ead8 100%);
+      }
+      .shell {
+        width: min(1400px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 24px 0 56px;
+      }
+      .panel {
+        background: rgba(255, 252, 245, 0.86);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: 0 24px 70px rgba(81, 51, 17, 0.08);
+        padding: 22px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.3fr 0.9fr;
+        gap: 24px;
+        margin-bottom: 18px;
+      }
+      .section-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: flex-start;
+      }
+      .toolbar-row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .button {
+        border: 1px solid rgba(23, 23, 23, 0.16);
+        border-radius: 999px;
+        padding: 8px 12px;
+      }
+      .muted {
+        color: var(--muted);
+        margin: 4px 0 0;
+      }
+      .hero-status-rail,
+      .workflow-steps,
+      .form-grid,
+      .action-row,
+      .publish-grid,
+      .publication-list {
+        display: grid;
+        gap: 10px;
+      }
+      .hero-status-rail {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -85,18 +85,94 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      id="consoleStylesheet"
-      href="assets/styles.css"
-      onerror="if (!this.dataset.fallback) { this.dataset.fallback='1'; this.href='styles.css'; }"
-    />
-    <script
-      defer
-      id="consoleAppScript"
-      src="assets/app.js"
-      onerror="if (!window.__ainewsAppScriptFallback) { window.__ainewsAppScriptFallback=true; const s=document.createElement('script'); s.defer=true; s.src='app.js'; document.head.appendChild(s); }"
-    ></script>
+    <script>
+      (function () {
+        const isFileProtocol = window.location.protocol === "file:";
+        const cssCandidates = isFileProtocol
+          ? ["styles.css", "assets/styles.css"]
+          : ["/assets/styles.css", "assets/styles.css", "styles.css"];
+        const jsCandidates = isFileProtocol
+          ? ["app.js", "assets/app.js"]
+          : ["/assets/app.js", "assets/app.js", "app.js"];
+        const LOAD_TIMEOUT_MS = 900;
+
+        const dedup = (items) => Array.from(new Set(items.filter((item) => typeof item === "string" && item)));
+
+        const waitForAssetLoad = (element) =>
+          new Promise((resolve, reject) => {
+            const timeout = window.setTimeout(() => {
+              reject(new Error("asset load timeout"));
+            }, LOAD_TIMEOUT_MS);
+            element.addEventListener(
+              "load",
+              () => {
+                clearTimeout(timeout);
+                resolve();
+              },
+              { once: true }
+            );
+            element.addEventListener(
+              "error",
+              () => {
+                clearTimeout(timeout);
+                reject(new Error("asset load error"));
+              },
+              { once: true }
+            );
+          });
+
+        const removeFailedAssetNode = (element) => {
+          if (element && element.parentNode) {
+            element.parentNode.removeChild(element);
+          }
+        };
+
+        const loadElementWithFallback = async (id, candidates, createNode) => {
+          const unique = dedup(candidates);
+          for (const candidate of unique) {
+            const element = createNode(candidate);
+            element.id = id;
+            element.setAttribute("data-console-asset", "bootstrap");
+            document.head.appendChild(element);
+            try {
+              await waitForAssetLoad(element);
+              return;
+            } catch (_error) {
+              removeFailedAssetNode(element);
+            }
+          }
+        };
+
+        const bootstrapConsoleAssets = () => {
+          loadElementWithFallback(
+            "consoleStylesheet",
+            cssCandidates,
+            (href) => {
+              const link = document.createElement("link");
+              link.rel = "stylesheet";
+              link.href = href;
+              return link;
+            }
+          ).catch(() => {});
+          loadElementWithFallback(
+            "consoleAppScript",
+            jsCandidates,
+            (src) => {
+              const script = document.createElement("script");
+              script.defer = true;
+              script.src = src;
+              return script;
+            }
+          ).catch(() => {});
+        };
+
+        if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", bootstrapConsoleAssets, { once: true });
+        } else {
+          bootstrapConsoleAssets();
+        }
+      })();
+    </script>
   </head>
   <body>
     <div class="background-grid" aria-hidden="true"></div>

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -194,6 +194,18 @@ class WebConsoleTestCase(unittest.TestCase):
         for expected in expected_app_snippets:
             self.assertIn(expected, app)
 
+    def test_console_includes_inline_fallback_styles_for_static_views(self) -> None:
+        index = _read_text("src/ainews/web/index.html")
+
+        for expected in (
+            '<style id="consoleFallbackStyles">',
+            ".hero-status-rail",
+            ".toolbar-row",
+            ".publication-list",
+            "background:",
+        ):
+            self.assertIn(expected, index)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -177,11 +177,20 @@ class WebConsoleTestCase(unittest.TestCase):
             "assets/app.js",
             "consoleStylesheet",
             "consoleAppScript",
-            "this.dataset.fallback",
-            "window.__ainewsAppScriptFallback",
+            "loadElementWithFallback",
+            "waitForAssetLoad",
+            "bootstrapConsoleAssets",
+            "LOAD_TIMEOUT_MS",
         )
         for expected in expected_snippets:
             self.assertIn(expected, index)
+
+        expected_absent_snippets = (
+            "this.dataset.fallback",
+            "window.__ainewsAppScriptFallback",
+        )
+        for expected in expected_absent_snippets:
+            self.assertNotIn(expected, index)
 
         expected_app_snippets = (
             "const IS_FILE_PROTOCOL = window.location.protocol === \"file:\";",


### PR DESCRIPTION
## Why
Some embedded/file-mode previews still render the web console with poor styling when asset loading fails silently.

## What changed
- Keep a compact inline fallback style block in `src/ainews/web/index.html` so static previews remain visually structured even if external assets fail.
- Replace the prior `onerror` fallback approach with a small bootstrap loader that:
  - selects candidates for file vs HTTP mode,
  - attempts multiple paths,
  - falls back to the next path when load fails or times out,
  - keeps JS loading independent of CSS loading.
- Remove brittle inline `onerror` flag state and assert the new bootstrap loader contract in tests.

## Validation
- `./.venv-dev/bin/python -m unittest tests/test_web_console.py -q`
- `make check PYTHON=./.venv-dev/bin/python`
