### PR TITLE
ci: update checkout action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
         language: ["python"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -23,7 +23,7 @@ jobs:
       AINEWS_LLM_MODEL: ${{ secrets.AINEWS_LLM_MODEL }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -27,7 +27,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/configure-pages@v6
         with:

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -19,7 +19,7 @@ jobs:
       AINEWS_SOURCE_RUNTIME_RETENTION_DAYS: ${{ vars.AINEWS_SOURCE_RUNTIME_RETENTION_DAYS }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
       url: https://pypi.org/p/ainews-open
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -35,7 +35,7 @@ jobs:
       AINEWS_HOME: ${{ github.workspace }}/.ainews-release-smoke
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         id: checkout
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,7 +21,7 @@ jobs:
       AINEWS_ADMIN_TOKEN: smoke-token
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- update all workflow uses of actions/checkout from v6 to v7
- keep the change as a human-authored review PR instead of directly merging Dependabot #218

## Verification
- rg -n "actions/checkout@v6" .github/workflows exits with no matches
- rg -n "actions/checkout@v7" .github/workflows
- make check PYTHON=./.venv-dev/bin/python

Supersedes Dependabot notification #218.