### PR TITLE
docs: add release post-publish evidence checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -84,6 +84,18 @@ Use this order after the release page, assets, and smoke workflows are verified:
 4. Close the release milestone only after every remaining open item has either shipped, moved, or been explicitly deferred.
 5. Create the next `v1.2.x` milestone before opening follow-up maintenance issues, so new work does not accumulate against a closed release.
 
+### Post-Publish Evidence Snapshot
+
+Record this compact evidence set in the release PR, milestone closeout note, or maintainer handoff before closing the release:
+
+- Release URL: the published GitHub Release page for `vX.Y.Z`.
+- Tag commit: the `git rev-list -n 1 vX.Y.Z` commit, and whether it matches the intended `main` commit.
+- Assets present: wheel, source archive, `sha256sums.txt`, and `vX.Y.Z-sbom.json`.
+- Verification anchor: the [release artifact verification flow](./release-artifacts.md#copy-paste-verification-flow), not a duplicated checklist.
+- Release workflow: the successful `Release` workflow run URL for the tag.
+- Artifact smoke: the successful `Release Artifact Smoke` workflow run URL for the tag.
+- Deferred work: confirmation that PyPI publishing remains in `Deferred: PyPI` unless this release explicitly enabled it.
+
 ### Milestone Rollover Ownership
 
 The maintainer who merges the release PR or publishes the tag owns milestone rollover unless another maintainer explicitly takes it over.

--- a/docs/release-checklist.zh-CN.md
+++ b/docs/release-checklist.zh-CN.md
@@ -84,6 +84,18 @@ python -m ainews --help
 4. 只有当所有剩余 open item 都已经发布、移动或明确延期后，才关闭 release milestone。
 5. 开始后续维护 issue 前，先创建下一个 `v1.2.x` milestone，避免新工作继续堆到已经关闭的 release 上。
 
+### 发布后证据快照
+
+关闭 release 前，在 release PR、milestone 收尾记录或维护者交接说明里保留这组紧凑证据：
+
+- Release URL：已经发布的 `vX.Y.Z` GitHub Release 页面。
+- Tag commit：`git rev-list -n 1 vX.Y.Z` 对应的 commit，并确认它是否等于预期的 `main` commit。
+- 已发布资产：wheel、source archive、`sha256sums.txt` 和 `vX.Y.Z-sbom.json`。
+- 校验入口：引用 [Release 产物校验](./release-artifacts.zh-CN.md#copy-paste-verification-flow)，不要在这里重复完整 checklist。
+- Release workflow：该 tag 对应的成功 `Release` workflow run URL。
+- Artifact smoke：该 tag 对应的成功 `Release Artifact Smoke` workflow run URL。
+- 延期事项：确认除非本次明确启用 PyPI 发布，否则 PyPI publishing 仍留在 `Deferred: PyPI`。
+
 ### Milestone rollover 责任
 
 除非另一位维护者明确接手，否则合并 release PR 或发布 tag 的维护者负责完成 milestone rollover。

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -378,11 +378,17 @@ class ReleaseMetadataTestCase(unittest.TestCase):
 
         for expected in (
             "### Release Closeout Sequence",
+            "### Post-Publish Evidence Snapshot",
             "### Milestone Rollover Ownership",
             "release notes index",
             "active GitHub milestone",
             "Move deferred work, including PyPI trusted publishing",
             "Create the next `v1.2.x` milestone",
+            "Release URL",
+            "Tag commit",
+            "Assets present",
+            "Release workflow",
+            "Artifact smoke",
             "The maintainer who merges the release PR or publishes the tag owns milestone rollover",
             "Keep issue `#86` in `Deferred: PyPI`",
         ):
@@ -390,11 +396,17 @@ class ReleaseMetadataTestCase(unittest.TestCase):
 
         for expected in (
             "### Release 收尾顺序",
+            "### 发布后证据快照",
             "### Milestone rollover 责任",
             "release notes 索引",
             "活跃的 GitHub milestone",
             "包括 PyPI trusted publishing",
             "创建下一个 `v1.2.x` milestone",
+            "Release URL",
+            "Tag commit",
+            "已发布资产",
+            "Release workflow",
+            "Artifact smoke",
             "合并 release PR 或发布 tag 的维护者负责完成 milestone rollover",
             "issue `#86` 继续留在 `Deferred: PyPI`",
         ):


### PR DESCRIPTION
## Summary
- add a compact post-publish evidence snapshot to the English release checklist
- add the matching Simplified Chinese release evidence checklist
- extend release metadata tests so the evidence fields stay documented

## Verification
- ./.venv-dev/bin/python -m unittest tests/test_release_metadata.py tests/test_docs_links.py -q
- make check PYTHON=./.venv-dev/bin/python

Closes #225.