### PR TITLE
web: clarify console preview connection state

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -80,6 +80,9 @@ const refs = {
   publishTargetInputs: Array.from(document.querySelectorAll(".publish-target")),
   wechatSubmitCheckbox: document.getElementById("wechatSubmitCheckbox"),
   operationsStatusStrip: document.getElementById("operationsStatusStrip"),
+  previewModeStrip: document.getElementById("previewModeStrip"),
+  previewModeTitle: document.getElementById("previewModeTitle"),
+  previewModeDetail: document.getElementById("previewModeDetail"),
   heroHealthBadge: document.getElementById("heroHealthBadge"),
   heroSchemaVersion: document.getElementById("heroSchemaVersion"),
   heroBuildVersion: document.getElementById("heroBuildVersion"),
@@ -107,6 +110,7 @@ const refs = {
 
 refs.adminToken.value = state.token;
 refs.digestEditorActorInput.value = state.editorActor;
+setPreviewModeState(IS_FILE_PROTOCOL ? "file" : "http");
 
 function adminHeaders() {
   const headers = { "Content-Type": "application/json" };
@@ -245,7 +249,36 @@ function formatDataAge(value) {
   return `${day} 天前`;
 }
 
+function setPreviewModeState(mode) {
+  if (!refs.previewModeStrip || !refs.previewModeTitle || !refs.previewModeDetail) {
+    return;
+  }
+
+  const states = {
+    file: [
+      "file",
+      "静态预览，只读",
+      "样式和结构已加载；后端数据、刷新和发布操作需要用 HTTP 服务地址打开。",
+    ],
+    http: [
+      "pending",
+      "HTTP 服务视图，等待后端数据",
+      "正在尝试读取 /admin/operations；如果服务未启动，控件会保留但状态不会变为已连接。",
+    ],
+    connected: [
+      "connected",
+      "已连接后端服务",
+      "运行状态来自当前服务实例，可以继续执行刷新、选稿、编辑和发布检查。",
+    ],
+  };
+  const [className, title, detail] = states[mode] || states.http;
+  refs.previewModeStrip.className = `preview-mode-strip ${className}`;
+  refs.previewModeTitle.textContent = title;
+  refs.previewModeDetail.textContent = detail;
+}
+
 function setFileModeReadOnly() {
+  setPreviewModeState("file");
   refs.jobOutput.textContent = FILE_MODE_MESSAGE;
 
   if (refs.refreshAllButton) {
@@ -359,6 +392,7 @@ function describeDataWindow(value) {
 }
 
 function updateHeroOperationStatus(payload) {
+  setPreviewModeState("connected");
   const health = payload.health || {};
   const stats = payload.stats || {};
   const metrics = payload.metrics || {};

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -78,6 +78,22 @@
       .hero-status-rail {
         grid-template-columns: repeat(4, minmax(0, 1fr));
       }
+      .preview-mode-strip {
+        display: grid;
+        gap: 6px;
+        margin-top: 10px;
+        padding: 10px 12px;
+        border: 1px solid rgba(23, 23, 23, 0.14);
+        border-left: 4px solid rgba(184, 140, 50, 0.78);
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.58);
+      }
+      .preview-mode-kicker {
+        color: var(--muted);
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
     </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -205,6 +221,11 @@
             <span id="heroDataAge">数据时效：--</span>
             <span id="heroAutoRefreshCountdown">自动刷新：--</span>
             <span id="heroLastSync">上次同步：--</span>
+          </div>
+          <div id="previewModeStrip" class="preview-mode-strip pending" aria-live="polite">
+            <span class="preview-mode-kicker">Preview mode</span>
+            <strong id="previewModeTitle">正在确认连接方式</strong>
+            <span id="previewModeDetail">HTTP 服务视图会显示实时状态；file 模式只作为静态预览。</span>
           </div>
           <div id="heroVersionPulse" class="hero-version-pulse" aria-live="polite">
             <p class="version-kicker">版本脉搏</p>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -296,6 +296,49 @@ button {
   opacity: 1;
 }
 
+.preview-mode-strip {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 6px 10px;
+  align-items: center;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(23, 23, 23, 0.14);
+  border-left: 4px solid rgba(184, 140, 50, 0.78);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.preview-mode-strip.connected {
+  border-left-color: rgba(46, 110, 61, 0.72);
+  background: rgba(58, 132, 77, 0.08);
+}
+
+.preview-mode-strip.file {
+  border-left-color: rgba(219, 61, 27, 0.78);
+  background: rgba(219, 61, 27, 0.08);
+}
+
+.preview-mode-kicker {
+  grid-row: span 2;
+  color: var(--accent-deep);
+  font: 800 10px/1.2 "JetBrains Mono", monospace;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.preview-mode-strip strong {
+  min-width: 0;
+  font: 800 13px/1.25 "JetBrains Mono", monospace;
+}
+
+.preview-mode-strip span:last-child {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .status-chip.good {
   background: rgba(58, 132, 77, 0.16);
   color: #1f6b34;
@@ -887,6 +930,14 @@ textarea:focus-visible {
 
   .operations-status-strip {
     grid-template-columns: 1fr;
+  }
+
+  .preview-mode-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-mode-kicker {
+    grid-row: auto;
   }
 
   .hero-status-rail {

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -41,6 +41,11 @@ class WebConsoleTestCase(unittest.TestCase):
         styles = _read_text("src/ainews/web/styles.css")
 
         for expected in (
+            'id="previewModeStrip"',
+            'id="previewModeTitle"',
+            'id="previewModeDetail"',
+            "Preview mode",
+            "正在确认连接方式",
             'id="heroStatusRail"',
             'id="heroRailHealthCard"',
             'id="heroRailSchemaCard"',
@@ -88,6 +93,13 @@ class WebConsoleTestCase(unittest.TestCase):
             "refs.heroLastSync",
             "refs.heroReleaseVersion",
             "refs.heroDataWindow",
+            "refs.previewModeStrip",
+            "refs.previewModeTitle",
+            "refs.previewModeDetail",
+            "setPreviewModeState",
+            "静态预览，只读",
+            "HTTP 服务视图，等待后端数据",
+            "已连接后端服务",
             "heroReleaseVersion",
             "heroDataWindow",
             "updateLastSyncStatus",
@@ -114,6 +126,10 @@ class WebConsoleTestCase(unittest.TestCase):
         for expected in (
             ".hero-status-rail",
             ".status-rail-item",
+            ".preview-mode-strip",
+            ".preview-mode-strip.connected",
+            ".preview-mode-strip.file",
+            ".preview-mode-kicker",
             ".status-rail-item p",
             ".status-rail-item h3",
             ".status-rail-item.status-good",
@@ -209,6 +225,8 @@ class WebConsoleTestCase(unittest.TestCase):
         for expected in (
             '<style id="consoleFallbackStyles">',
             ".hero-status-rail",
+            ".preview-mode-strip",
+            ".preview-mode-kicker",
             ".toolbar-row",
             ".publication-list",
             "background:",


### PR DESCRIPTION
## Summary
- add a compact preview-mode status strip to the web console hero
- distinguish static file preview, HTTP pending, and connected backend states
- add inline fallback styling so the strip remains readable when external CSS is unavailable
- cover the new markup, state text, CSS, and fallback contract in web console tests

Closes #224.

## Verification
- ./.venv-dev/bin/python -m unittest tests/test_web_console.py -q
- make check PYTHON=./.venv-dev/bin/python

## Notes
- In-app browser inspection of the current file:// page was blocked by browser security policy, so verification relied on local tests and static fallback checks.