### PR TITLE
test: cover packaged web console assets

### DIFF
--- a/tests/test_package_assets.py
+++ b/tests/test_package_assets.py
@@ -1,5 +1,6 @@
 import unittest
 from fnmatch import fnmatch
+from importlib import resources
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +27,29 @@ class PackageAssetsTestCase(unittest.TestCase):
                 any(fnmatch(asset, pattern) for pattern in expected_patterns),
                 f"{asset} is not covered by package-data patterns",
             )
+
+    def test_web_console_assets_are_readable_package_resources(self) -> None:
+        package_root = resources.files("ainews")
+        assets = {
+            name: package_root.joinpath("web", name).read_text(encoding="utf-8")
+            for name in ("index.html", "styles.css", "app.js")
+        }
+
+        self.assertIn("<title>AI News Open Console</title>", assets["index.html"])
+        self.assertIn('<style id="consoleFallbackStyles">', assets["index.html"])
+        self.assertIn(".preview-mode-strip", assets["index.html"])
+        self.assertIn(".preview-mode-strip", assets["styles.css"])
+        self.assertIn("function setPreviewModeState", assets["app.js"])
+
+        for expected_path in (
+            "/assets/styles.css",
+            "assets/styles.css",
+            "styles.css",
+            "/assets/app.js",
+            "assets/app.js",
+            "app.js",
+        ):
+            self.assertIn(expected_path, assets["index.html"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add package-resource smoke coverage for the web console assets
- verify index.html, styles.css, and app.js are readable through importlib.resources
- assert the console bootstrap keeps file-mode and served asset path candidates covered

Closes #230.

## Verification
- ./.venv-dev/bin/python -m unittest tests/test_package_assets.py -q
- make check PYTHON=./.venv-dev/bin/python