### PR TITLE
web: polish console first-screen loading states

### DIFF
--- a/src/ainews/web/app.js
+++ b/src/ainews/web/app.js
@@ -117,6 +117,50 @@ window.addEventListener("ainews-console-asset-status", (event) => {
   updatePreviewAssetStatus(event.detail);
 });
 
+function firstScreenLoadingContainers() {
+  return [
+    refs.statsGrid,
+    refs.operationsSummary,
+    refs.operationsHealth,
+    refs.operationsMetrics,
+    refs.operationsPipelineRuns,
+    refs.operationsSources,
+    refs.operationsAlerts,
+    refs.operationsPublicationFailures,
+  ].filter(Boolean);
+}
+
+function markFirstScreenSectionLoaded(element) {
+  if (!element) {
+    return;
+  }
+  element.classList.remove("first-screen-loading", "first-screen-loading-block");
+}
+
+function settleFirstScreenLoading() {
+  firstScreenLoadingContainers().forEach(markFirstScreenSectionLoaded);
+  document.querySelectorAll(".status-rail-item.is-loading").forEach((element) => {
+    element.classList.remove("is-loading");
+  });
+  if (refs.operationsStatusStrip) {
+    refs.operationsStatusStrip.classList.remove("loading", "waiting");
+  }
+}
+
+function markFirstScreenWaiting() {
+  firstScreenLoadingContainers().forEach(markFirstScreenSectionLoaded);
+  document.querySelectorAll(".status-rail-item.is-loading").forEach((element) => {
+    element.classList.remove("is-loading");
+  });
+  document.querySelectorAll("[data-loading-placeholder]").forEach((element) => {
+    element.classList.add("loading-paused");
+  });
+  if (refs.operationsStatusStrip) {
+    refs.operationsStatusStrip.classList.remove("loading", "loaded");
+    refs.operationsStatusStrip.classList.add("waiting");
+  }
+}
+
 function adminHeaders() {
   const headers = { "Content-Type": "application/json" };
   if (state.token) {
@@ -174,6 +218,7 @@ function getDigestEditorMeta() {
 }
 
 function renderStats(stats) {
+  markFirstScreenSectionLoaded(refs.statsGrid);
   const cards = [
     ["文章总数", stats.total_articles || 0],
     ["可见文章", stats.visible_articles || 0],
@@ -323,6 +368,7 @@ function updatePreviewAssetStatus(status = {}) {
 }
 
 function setFileModeReadOnly() {
+  markFirstScreenWaiting();
   setPreviewModeState("file");
   refs.jobOutput.textContent = FILE_MODE_MESSAGE;
 
@@ -437,6 +483,7 @@ function describeDataWindow(value) {
 }
 
 function updateHeroOperationStatus(payload) {
+  settleFirstScreenLoading();
   setPreviewModeState("connected");
   const health = payload.health || {};
   const stats = payload.stats || {};
@@ -520,6 +567,7 @@ function updateHeroOperationStatus(payload) {
     refs.heroRailAgeHint.textContent = ageHint;
   }
   if (refs.operationsStatusStrip) {
+    refs.operationsStatusStrip.classList.remove("loading", "waiting");
     refs.operationsStatusStrip.classList.add("loaded");
   }
 }
@@ -534,6 +582,7 @@ function summarizePairs(payload) {
 }
 
 function renderOperationsSummary(payload) {
+  markFirstScreenSectionLoaded(refs.operationsSummary);
   const health = payload.health || {};
   const stats = payload.stats || {};
   const metrics = payload.metrics || {};
@@ -558,6 +607,8 @@ function renderOperationsSummary(payload) {
 }
 
 function renderOperationsHealth(payload) {
+  markFirstScreenSectionLoaded(refs.operationsHealth);
+  markFirstScreenSectionLoaded(refs.operationsMetrics);
   const health = payload.health || {};
   const checks = Object.entries(health.checks || {})
     .map(
@@ -605,6 +656,7 @@ function renderOperationsHealth(payload) {
 }
 
 function renderOperationsPipelineRuns(runs) {
+  markFirstScreenSectionLoaded(refs.operationsPipelineRuns);
   refs.operationsPipelineRuns.innerHTML = runs.length
     ? runs
         .map(
@@ -640,6 +692,7 @@ function renderOperationsPipelineRuns(runs) {
 }
 
 function renderOperationsSources(sources) {
+  markFirstScreenSectionLoaded(refs.operationsSources);
   refs.operationsSources.innerHTML = sources.length
     ? sources
         .map(
@@ -690,6 +743,7 @@ function renderOperationsSources(sources) {
 }
 
 function renderOperationsAlerts(sourceAlerts) {
+  markFirstScreenSectionLoaded(refs.operationsAlerts);
   refs.operationsAlerts.innerHTML = sourceAlerts.length
     ? sourceAlerts
         .map(
@@ -715,6 +769,7 @@ function renderOperationsAlerts(sourceAlerts) {
 }
 
 function renderOperationsPublicationFailures(failures, pending) {
+  markFirstScreenSectionLoaded(refs.operationsPublicationFailures);
   const cards = [];
   if (failures.length) {
     cards.push(
@@ -1894,6 +1949,7 @@ async function refreshAll() {
     ]);
   } catch (error) {
     logJob("refresh failed", { error: error.message });
+    markFirstScreenWaiting();
     success = false;
   } finally {
     if (success) {

--- a/src/ainews/web/index.html
+++ b/src/ainews/web/index.html
@@ -78,6 +78,31 @@
       .hero-status-rail {
         grid-template-columns: repeat(4, minmax(0, 1fr));
       }
+      .first-screen-loading-block {
+        display: grid;
+        gap: 10px;
+      }
+      .loading-card {
+        border: 1px solid rgba(23, 23, 23, 0.1);
+        border-radius: 18px;
+        padding: 14px;
+        background: rgba(255, 255, 255, 0.52);
+      }
+      .loading-heading,
+      .loading-line {
+        display: block;
+        border-radius: 999px;
+        background: rgba(23, 23, 23, 0.08);
+      }
+      .loading-heading {
+        width: 52%;
+        height: 18px;
+      }
+      .loading-line {
+        width: 78%;
+        height: 10px;
+        margin-top: 10px;
+      }
       .preview-mode-strip {
         display: grid;
         gap: 6px;
@@ -237,7 +262,7 @@
             <button id="saveTokenButton" class="button ghost">保存</button>
           </div>
           <p class="muted">所有管理操作都会自动带上 `X-Admin-Token`。</p>
-          <div id="operationsStatusStrip" class="operations-status-strip" aria-live="polite">
+          <div id="operationsStatusStrip" class="operations-status-strip loading" aria-live="polite">
             <span id="heroHealthBadge" class="chip status-chip">系统状态：加载中</span>
             <span id="heroSchemaVersion">schema：未同步</span>
             <span id="heroBuildVersion">build：未同步</span>
@@ -266,22 +291,22 @@
             </div>
           </div>
           <div id="heroStatusRail" class="hero-status-rail" role="list" aria-label="运营状态速览" aria-live="polite">
-            <article id="heroRailHealthCard" class="status-rail-item" role="listitem" aria-describedby="heroRailHealthHint">
+            <article id="heroRailHealthCard" class="status-rail-item is-loading" role="listitem" aria-describedby="heroRailHealthHint">
               <p>运行健康</p>
               <h3 id="heroRailHealth">未采样</h3>
               <p id="heroRailHealthHint" class="sr-only">运行健康状态用于快速判断，异常时先看 Operations 面板里的健康检查列表。</p>
             </article>
-            <article id="heroRailSchemaCard" class="status-rail-item" role="listitem" aria-describedby="heroRailSchemaHint">
+            <article id="heroRailSchemaCard" class="status-rail-item is-loading" role="listitem" aria-describedby="heroRailSchemaHint">
               <p>Schema</p>
               <h3 id="heroRailSchema">--</h3>
               <p id="heroRailSchemaHint" class="sr-only">Schema 用于确认后台与前端约定未发生版本漂移。</p>
             </article>
-            <article id="heroRailBuildCard" class="status-rail-item" role="listitem" aria-describedby="heroRailBuildHint">
+            <article id="heroRailBuildCard" class="status-rail-item is-loading" role="listitem" aria-describedby="heroRailBuildHint">
               <p>构建版本</p>
               <h3 id="heroRailBuild">--</h3>
               <p id="heroRailBuildHint" class="sr-only">构建版本用于核对发布件与服务实例是否匹配。</p>
             </article>
-            <article id="heroRailAgeCard" class="status-rail-item" role="listitem" aria-describedby="heroRailAgeHint">
+            <article id="heroRailAgeCard" class="status-rail-item is-loading" role="listitem" aria-describedby="heroRailAgeHint">
               <p>数据时效</p>
               <h3 id="heroRailAge">--</h3>
               <p id="heroRailAgeHint" class="sr-only">数据时效超过 1 小时通常表示运维层采集或 pipeline 刷新异常。</p>
@@ -327,7 +352,23 @@
         </div>
       </section>
 
-      <section class="stats-grid" id="statsGrid"></section>
+      <section class="stats-grid first-screen-loading" id="statsGrid" aria-label="首屏统计正在加载">
+        <article class="panel stat-card loading-card" data-loading-placeholder="stats">
+          <p class="loading-kicker">Loading</p>
+          <span class="loading-heading"></span>
+          <span class="loading-line"></span>
+        </article>
+        <article class="panel stat-card loading-card" data-loading-placeholder="stats">
+          <p class="loading-kicker">Loading</p>
+          <span class="loading-heading"></span>
+          <span class="loading-line short"></span>
+        </article>
+        <article class="panel stat-card loading-card" data-loading-placeholder="stats">
+          <p class="loading-kicker">Loading</p>
+          <span class="loading-heading"></span>
+          <span class="loading-line"></span>
+        </article>
+      </section>
 
       <section class="panel operations-panel">
         <div class="section-head">
@@ -346,7 +387,23 @@
         <p class="muted">
           把 `/health`、最近 pipeline、冷却来源、来源告警和发布失败收成一屏。细节操作仍保留在下方来源与抽取面板里。
         </p>
-        <div id="operationsSummary" class="operations-summary-grid"></div>
+        <div id="operationsSummary" class="operations-summary-grid first-screen-loading" aria-label="运维摘要正在加载">
+          <article class="stat-card operations-stat-card loading-card" data-loading-placeholder="operations-summary">
+            <p class="loading-kicker">Health</p>
+            <span class="loading-heading"></span>
+            <span class="loading-line"></span>
+          </article>
+          <article class="stat-card operations-stat-card loading-card" data-loading-placeholder="operations-summary">
+            <p class="loading-kicker">Runtime</p>
+            <span class="loading-heading"></span>
+            <span class="loading-line short"></span>
+          </article>
+          <article class="stat-card operations-stat-card loading-card" data-loading-placeholder="operations-summary">
+            <p class="loading-kicker">Publish</p>
+            <span class="loading-heading"></span>
+            <span class="loading-line"></span>
+          </article>
+        </div>
         <div class="operations-grid">
           <article class="operations-slab">
             <div class="section-head">
@@ -355,8 +412,17 @@
                 <h3>系统状态</h3>
               </div>
             </div>
-            <div id="operationsHealth"></div>
-            <div id="operationsMetrics" class="chip-row"></div>
+            <div id="operationsHealth" class="first-screen-loading-block">
+              <article class="publication-card loading-card" data-loading-placeholder="operations-health">
+                <p class="loading-kicker">Waiting for /health</p>
+                <span class="loading-heading"></span>
+                <span class="loading-line"></span>
+                <span class="loading-line short"></span>
+              </article>
+            </div>
+            <div id="operationsMetrics" class="chip-row first-screen-loading-block">
+              <span class="chip pending">metrics: 等待采样</span>
+            </div>
           </article>
 
           <article class="operations-slab">
@@ -366,7 +432,13 @@
                 <h3>最近运行</h3>
               </div>
             </div>
-            <div id="operationsPipelineRuns" class="publication-list compact-list"></div>
+            <div id="operationsPipelineRuns" class="publication-list compact-list first-screen-loading-block">
+              <article class="publication-card operations-card loading-card" data-loading-placeholder="pipeline-runs">
+                <p class="loading-kicker">Recent run</p>
+                <span class="loading-heading"></span>
+                <span class="loading-line"></span>
+              </article>
+            </div>
           </article>
 
           <article class="operations-slab">
@@ -376,7 +448,13 @@
                 <h3>热点来源</h3>
               </div>
             </div>
-            <div id="operationsSources" class="publication-list compact-list"></div>
+            <div id="operationsSources" class="publication-list compact-list first-screen-loading-block">
+              <article class="publication-card operations-card loading-card" data-loading-placeholder="runtime-sources">
+                <p class="loading-kicker">Source health</p>
+                <span class="loading-heading"></span>
+                <span class="loading-line"></span>
+              </article>
+            </div>
           </article>
 
           <article class="operations-slab">
@@ -386,8 +464,20 @@
                 <h3>告警与发布失败</h3>
               </div>
             </div>
-            <div id="operationsAlerts" class="publication-list compact-list"></div>
-            <div id="operationsPublicationFailures" class="publication-list compact-list"></div>
+            <div id="operationsAlerts" class="publication-list compact-list first-screen-loading-block">
+              <article class="publication-card operations-card loading-card" data-loading-placeholder="source-alerts">
+                <p class="loading-kicker">Incidents</p>
+                <span class="loading-heading"></span>
+                <span class="loading-line short"></span>
+              </article>
+            </div>
+            <div id="operationsPublicationFailures" class="publication-list compact-list first-screen-loading-block">
+              <article class="publication-card operations-card loading-card" data-loading-placeholder="publication-failures">
+                <p class="loading-kicker">Publish queue</p>
+                <span class="loading-heading"></span>
+                <span class="loading-line"></span>
+              </article>
+            </div>
           </article>
         </div>
       </section>

--- a/src/ainews/web/styles.css
+++ b/src/ainews/web/styles.css
@@ -8,6 +8,9 @@
   --accent-deep: #8e1f0a;
   --gold: #b88c32;
   --panel-shadow: 0 24px 70px rgba(81, 51, 17, 0.08);
+  --loading-base: rgba(255, 255, 255, 0.56);
+  --loading-line: rgba(23, 23, 23, 0.08);
+  --loading-sheen: rgba(219, 61, 27, 0.12);
 }
 
 * {
@@ -246,6 +249,30 @@ button {
   font-weight: 700;
 }
 
+.operations-status-strip.loading {
+  position: relative;
+  overflow: hidden;
+  border-style: solid;
+  background:
+    linear-gradient(110deg, rgba(255, 255, 255, 0.72), rgba(255, 247, 232, 0.62)),
+    radial-gradient(circle at 12% 30%, rgba(184, 140, 50, 0.18), transparent 32%);
+}
+
+.operations-status-strip.loading::after,
+.status-rail-item.is-loading::after,
+.loading-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 0%, var(--loading-sheen) 42%, transparent 72%);
+  animation: loading-sweep 1.8s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.operations-status-strip.loading span {
+  position: relative;
+}
+
 .hero-version-pulse {
   margin-top: 14px;
   display: grid;
@@ -294,6 +321,16 @@ button {
 
 .operations-status-strip.loaded {
   opacity: 1;
+}
+
+.operations-status-strip.loaded,
+.operations-status-strip.waiting {
+  overflow: visible;
+}
+
+.operations-status-strip.loaded::after,
+.operations-status-strip.waiting::after {
+  display: none;
 }
 
 .preview-mode-strip {
@@ -357,6 +394,84 @@ button {
 .status-chip.warn {
   background: rgba(219, 61, 27, 0.16);
   color: var(--accent-deep);
+}
+
+.status-rail-item.is-loading,
+.loading-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.status-rail-item.is-loading {
+  border-left: 4px solid rgba(184, 140, 50, 0.58);
+  background:
+    linear-gradient(135deg, var(--loading-base), rgba(255, 248, 238, 0.62)),
+    radial-gradient(circle at 100% 0%, rgba(219, 61, 27, 0.1), transparent 34%);
+}
+
+.status-rail-item.is-loading h3 {
+  color: rgba(23, 23, 23, 0.56);
+}
+
+.first-screen-loading-block {
+  display: grid;
+  gap: 10px;
+}
+
+.loading-card {
+  min-height: 112px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(255, 248, 238, 0.54)),
+    radial-gradient(circle at top right, rgba(184, 140, 50, 0.11), transparent 34%);
+}
+
+.loading-card.loading-paused {
+  opacity: 0.86;
+}
+
+.loading-card.loading-paused::after {
+  display: none;
+}
+
+.loading-kicker {
+  margin: 0 0 12px;
+  color: var(--accent-deep);
+  font: 800 10px/1 "JetBrains Mono", monospace;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.loading-heading,
+.loading-line {
+  display: block;
+  border-radius: 999px;
+  background: var(--loading-line);
+}
+
+.loading-heading {
+  width: min(180px, 58%);
+  height: 22px;
+}
+
+.loading-line {
+  width: 82%;
+  height: 10px;
+  margin-top: 12px;
+}
+
+.loading-line.short {
+  width: 48%;
+}
+
+@keyframes loading-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  55%,
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .token-box,
@@ -982,5 +1097,11 @@ textarea:focus-visible {
 
   .button:hover {
     transform: none;
+  }
+
+  .operations-status-strip.loading::after,
+  .status-rail-item.is-loading::after,
+  .loading-card::after {
+    display: none;
   }
 }

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -238,6 +238,65 @@ class WebConsoleTestCase(unittest.TestCase):
         for expected in expected_app_snippets:
             self.assertIn(expected, app)
 
+    def test_console_first_screen_loading_states_are_visible_and_settled(self) -> None:
+        index = _read_text("src/ainews/web/index.html")
+        app = _read_text("src/ainews/web/app.js")
+        styles = _read_text("src/ainews/web/styles.css")
+
+        for expected in (
+            'class="operations-status-strip loading"',
+            'class="status-rail-item is-loading"',
+            'class="stats-grid first-screen-loading"',
+            'class="operations-summary-grid first-screen-loading"',
+            'class="first-screen-loading-block"',
+            'data-loading-placeholder="stats"',
+            'data-loading-placeholder="operations-summary"',
+            'data-loading-placeholder="operations-health"',
+            'data-loading-placeholder="pipeline-runs"',
+            'data-loading-placeholder="runtime-sources"',
+            'data-loading-placeholder="source-alerts"',
+            'data-loading-placeholder="publication-failures"',
+            "首屏统计正在加载",
+            "运维摘要正在加载",
+            "metrics: 等待采样",
+        ):
+            self.assertIn(expected, index)
+
+        for expected in (
+            "function firstScreenLoadingContainers",
+            "function markFirstScreenSectionLoaded",
+            "function settleFirstScreenLoading",
+            "function markFirstScreenWaiting",
+            'classList.remove("first-screen-loading", "first-screen-loading-block")',
+            'document.querySelectorAll(".status-rail-item.is-loading")',
+            'document.querySelectorAll("[data-loading-placeholder]")',
+            'element.classList.add("loading-paused")',
+            'refs.operationsStatusStrip.classList.remove("loading", "waiting")',
+            'refs.operationsStatusStrip.classList.add("waiting")',
+            "markFirstScreenSectionLoaded(refs.statsGrid)",
+            "markFirstScreenSectionLoaded(refs.operationsSummary)",
+            "markFirstScreenSectionLoaded(refs.operationsHealth)",
+            "markFirstScreenSectionLoaded(refs.operationsPipelineRuns)",
+            "markFirstScreenWaiting();",
+            "settleFirstScreenLoading();",
+        ):
+            self.assertIn(expected, app)
+
+        for expected in (
+            ".operations-status-strip.loading",
+            ".status-rail-item.is-loading",
+            ".first-screen-loading-block",
+            ".loading-card",
+            ".loading-card.loading-paused",
+            ".loading-kicker",
+            ".loading-heading",
+            ".loading-line.short",
+            "@keyframes loading-sweep",
+            "@media (prefers-reduced-motion: reduce)",
+            ".loading-card::after",
+        ):
+            self.assertIn(expected, styles)
+
     def test_console_includes_inline_fallback_styles_for_static_views(self) -> None:
         index = _read_text("src/ainews/web/index.html")
 
@@ -247,6 +306,10 @@ class WebConsoleTestCase(unittest.TestCase):
             ".preview-mode-strip",
             ".preview-mode-kicker",
             ".preview-asset-detail",
+            ".first-screen-loading-block",
+            ".loading-card",
+            ".loading-heading",
+            ".loading-line",
             ".toolbar-row",
             ".publication-list",
             "background:",


### PR DESCRIPTION
## Summary
- add first-screen skeleton placeholders for stats and operations panels
- add warm pending/loading styles with reduced-motion fallback
- settle loading classes once backend data arrives or when file-mode preview is waiting for a backend
- cover the new loading classes and state cleanup hooks in web console tests

## Verification
- node --check src/ainews/web/app.js
- ./.venv-dev/bin/python -m unittest tests/test_web_console.py -q
- make check PYTHON=./.venv-dev/bin/python

Closes #238